### PR TITLE
fix: inherit secrets in publish-snap workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,3 +43,4 @@ jobs:
     if: github.ref_name == 'main'
     needs: [snap-build]
     uses: ./.github/workflows/publish-snap.yaml
+    secrets: inherit

--- a/.github/workflows/publish-snap.yaml
+++ b/.github/workflows/publish-snap.yaml
@@ -2,6 +2,9 @@ name: Publish Snap
 
 on:
   workflow_call:
+    secrets:
+      SNAPCRAFT_STORE_CREDENTIALS:
+        required: true
 
 jobs:
   publish-snap:


### PR DESCRIPTION
# Description

Publishing to the snap store fails right now and this PR "should" fix this issue.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
