### PR TITLE
chore: generalise database management

### DIFF
--- a/cmd/notary/main_test.go
+++ b/cmd/notary/main_test.go
@@ -96,7 +96,7 @@ pebble_notices: false`
 goodbye: "world"`
 	invalidDBConfig = `key_path:  "./key_test.pem"
 cert_path: "./cert_test.pem"
-db_path: "/etc/hosts"
+db_path: "./certs.db"
 port: 8000
 pebble_notices: false`
 )

--- a/cmd/notary/main_test.go
+++ b/cmd/notary/main_test.go
@@ -111,8 +111,8 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("couldn't create temp directory")
 	}
-	writeCertErr := os.WriteFile(testfolder+"/cert_test.pem", []byte(validCert), 0644)
-	writeKeyErr := os.WriteFile(testfolder+"/key_test.pem", []byte(validPK), 0644)
+	writeCertErr := os.WriteFile(testfolder+"/cert_test.pem", []byte(validCert), 0o644)
+	writeKeyErr := os.WriteFile(testfolder+"/key_test.pem", []byte(validPK), 0o644)
 	if writeCertErr != nil || writeKeyErr != nil {
 		log.Fatalf("couldn't create temp testing file")
 	}
@@ -145,7 +145,7 @@ func TestNotaryFail(t *testing.T) {
 		{"database not connectable", []string{"-config", "config.yaml"}, invalidDBConfig, "Couldn't connect to database:"},
 	}
 	for _, tc := range cases {
-		writeConfigErr := os.WriteFile("config.yaml", []byte(tc.ConfigYAML), 0644)
+		writeConfigErr := os.WriteFile("config.yaml", []byte(tc.ConfigYAML), 0o644)
 		if writeConfigErr != nil {
 			t.Errorf("Failed writing config file")
 		}

--- a/cmd/notary/main_test.go
+++ b/cmd/notary/main_test.go
@@ -89,14 +89,14 @@ D7DC34n8CH9+avz9sCRwxpjxKnYW/BeyK0c4n9uZpjI8N4sOVqy6yWBUseww
 -----END RSA PRIVATE KEY-----`
 	validConfig = `key_path:  "./key_test.pem"
 cert_path: "./cert_test.pem"
-db)path: "./certs.db"
+db_path: "./certs.db"
 port: 8000
 pebble_notices: false`
 	invalidConfig = `hello: "world"
 goodbye: "world"`
 	invalidDBConfig = `key_path:  "./key_test.pem"
 cert_path: "./cert_test.pem"
-db_path: "./certs.db"
+db_path: "/etc/hosts"
 port: 8000
 pebble_notices: false`
 )

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	server "github.com/canonical/notary/internal/api"
-	"github.com/canonical/notary/internal/certdb"
+	"github.com/canonical/notary/internal/db"
 	"github.com/golang-jwt/jwt"
 )
 
@@ -153,7 +153,7 @@ const (
 )
 
 func TestNotaryCertificatesHandlers(t *testing.T) {
-	testdb, err := certdb.NewCertificateRequestsRepository(":memory:", "CertificateRequests")
+	testdb, err := db.NewDatabase(":memory:")
 	if err != nil {
 		log.Fatalf("couldn't create test sqlite db: %s", err)
 	}
@@ -406,11 +406,10 @@ func TestNotaryCertificatesHandlers(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestNotaryUsersHandlers(t *testing.T) {
-	testdb, err := certdb.NewCertificateRequestsRepository(":memory:", "CertificateRequests")
+	testdb, err := db.NewDatabase(":memory:")
 	if err != nil {
 		log.Fatalf("couldn't create test sqlite db: %s", err)
 	}
@@ -573,7 +572,7 @@ func TestNotaryUsersHandlers(t *testing.T) {
 }
 
 func TestLogin(t *testing.T) {
-	testdb, err := certdb.NewCertificateRequestsRepository(":memory:", "CertificateRequests")
+	testdb, err := db.NewDatabase(":memory:")
 	if err != nil {
 		log.Fatalf("couldn't create test sqlite db: %s", err)
 	}
@@ -687,7 +686,7 @@ func TestLogin(t *testing.T) {
 }
 
 func TestAuthorization(t *testing.T) {
-	testdb, err := certdb.NewCertificateRequestsRepository(":memory:", "CertificateRequests")
+	testdb, err := db.NewDatabase(":memory:")
 	if err != nil {
 		log.Fatalf("couldn't create test sqlite db: %s", err)
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -11,11 +11,11 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/canonical/notary/internal/certdb"
+	"github.com/canonical/notary/internal/db"
 )
 
 type Environment struct {
-	DB                      *certdb.CertificateRequestsRepository
+	DB                      *db.Database
 	SendPebbleNotifications bool
 	JWTSecret               []byte
 }
@@ -42,7 +42,7 @@ func NewServer(port int, cert []byte, key []byte, dbPath string, pebbleNotificat
 	if err != nil {
 		return nil, err
 	}
-	db, err := certdb.NewCertificateRequestsRepository(dbPath, "CertificateRequests")
+	db, err := db.NewDatabase(dbPath)
 	if err != nil {
 		log.Fatalf("Couldn't connect to database: %s", err)
 	}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -92,8 +92,8 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("couldn't create temp directory")
 	}
-	writeCertErr := os.WriteFile(testfolder+"/cert_test.pem", []byte(validCert), 0644)
-	writeKeyErr := os.WriteFile(testfolder+"/key_test.pem", []byte(validPK), 0644)
+	writeCertErr := os.WriteFile(testfolder+"/cert_test.pem", []byte(validCert), 0o644)
+	writeKeyErr := os.WriteFile(testfolder+"/key_test.pem", []byte(validPK), 0o644)
 	if writeCertErr != nil || writeKeyErr != nil {
 		log.Fatalf("couldn't create temp testing file")
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,7 +52,7 @@ func Validate(filePath string) (Config, error) {
 	if c.DBPath == "" {
 		return config, errors.Join(validationErr, errors.New("`db_path` is empty"))
 	}
-	dbfile, err := os.OpenFile(c.DBPath, os.O_CREATE|os.O_RDONLY, 0644)
+	dbfile, err := os.OpenFile(c.DBPath, os.O_CREATE|os.O_RDONLY, 0o644)
 	if err != nil {
 		return config, errors.Join(validationErr, err)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,8 +42,8 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("couldn't create temp directory")
 	}
-	writeCertErr := os.WriteFile(testfolder+"/cert_test.pem", []byte(validCert), 0644)
-	writeKeyErr := os.WriteFile(testfolder+"/key_test.pem", []byte(validPK), 0644)
+	writeCertErr := os.WriteFile(testfolder+"/cert_test.pem", []byte(validCert), 0o644)
+	writeKeyErr := os.WriteFile(testfolder+"/key_test.pem", []byte(validPK), 0o644)
 	if writeCertErr != nil || writeKeyErr != nil {
 		log.Fatalf("couldn't create temp testing file")
 	}
@@ -63,7 +63,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestGoodConfigSuccess(t *testing.T) {
-	writeConfigErr := os.WriteFile("config.yaml", []byte(validConfig), 0644)
+	writeConfigErr := os.WriteFile("config.yaml", []byte(validConfig), 0o644)
 	if writeConfigErr != nil {
 		t.Fatalf("Error writing config file")
 	}
@@ -87,7 +87,6 @@ func TestGoodConfigSuccess(t *testing.T) {
 	if conf.Port != 8000 {
 		t.Fatalf("Port was not configured correctly")
 	}
-
 }
 
 func TestBadConfigFail(t *testing.T) {
@@ -105,7 +104,7 @@ func TestBadConfigFail(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		writeConfigErr := os.WriteFile("config.yaml", []byte(tc.ConfigYAML), 0644)
+		writeConfigErr := os.WriteFile("config.yaml", []byte(tc.ConfigYAML), 0o644)
 		if writeConfigErr != nil {
 			t.Errorf("Failed writing config file")
 		}
@@ -117,6 +116,5 @@ func TestBadConfigFail(t *testing.T) {
 		if !strings.Contains(err.Error(), tc.ExpectedError) {
 			t.Errorf("Expected error not found: %s", err)
 		}
-
 	}
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,5 +1,5 @@
-// Package certdb provides a simplistic ORM to communicate with an SQL database for storage
-package certdb
+// Package db provides a simplistic ORM to communicate with an SQL database for storage
+package db
 
 import (
 	"database/sql"
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-const queryCreateCSRsTable = `CREATE TABLE IF NOT EXISTS %s (
+const queryCreateCSRsTable = `CREATE TABLE IF NOT EXISTS CertificateRequests (
 	csr TEXT PRIMARY KEY UNIQUE NOT NULL, 
 	certificate TEXT DEFAULT ''
 )`
@@ -29,6 +29,7 @@ const queryCreateUsersTable = `CREATE TABLE IF NOT EXISTS users (
 	password TEXT NOT NULL,
 	permissions INTEGER
 )`
+
 const (
 	queryGetAllUsers       = "SELECT * FROM users"
 	queryGetUser           = "SELECT * FROM users WHERE user_id=?"
@@ -39,7 +40,7 @@ const (
 )
 
 // CertificateRequestRepository is the object used to communicate with the established repository.
-type CertificateRequestsRepository struct {
+type Database struct {
 	certificateTable string
 	conn             *sql.DB
 }
@@ -61,7 +62,7 @@ type User struct {
 var ErrIdNotFound = errors.New("id not found")
 
 // RetrieveAllCSRs gets every CertificateRequest entry in the table.
-func (db *CertificateRequestsRepository) RetrieveAllCSRs() ([]CertificateRequest, error) {
+func (db *Database) RetrieveAllCSRs() ([]CertificateRequest, error) {
 	rows, err := db.conn.Query(fmt.Sprintf(queryGetAllCSRs, db.certificateTable))
 	if err != nil {
 		return nil, err
@@ -81,7 +82,7 @@ func (db *CertificateRequestsRepository) RetrieveAllCSRs() ([]CertificateRequest
 
 // RetrieveCSR gets a given CSR from the repository.
 // It returns the row id and matching certificate alongside the CSR in a CertificateRequest object.
-func (db *CertificateRequestsRepository) RetrieveCSR(id string) (CertificateRequest, error) {
+func (db *Database) RetrieveCSR(id string) (CertificateRequest, error) {
 	var newCSR CertificateRequest
 	row := db.conn.QueryRow(fmt.Sprintf(queryGetCSR, db.certificateTable), id)
 	if err := row.Scan(&newCSR.ID, &newCSR.CSR, &newCSR.Certificate); err != nil {
@@ -95,7 +96,7 @@ func (db *CertificateRequestsRepository) RetrieveCSR(id string) (CertificateRequ
 
 // CreateCSR creates a new entry in the repository.
 // The given CSR must be valid and unique
-func (db *CertificateRequestsRepository) CreateCSR(csr string) (int64, error) {
+func (db *Database) CreateCSR(csr string) (int64, error) {
 	if err := ValidateCertificateRequest(csr); err != nil {
 		return 0, errors.New("csr validation failed: " + err.Error())
 	}
@@ -112,7 +113,7 @@ func (db *CertificateRequestsRepository) CreateCSR(csr string) (int64, error) {
 
 // UpdateCSR adds a new cert to the given CSR in the repository.
 // The given certificate must share the public key of the CSR and must be valid.
-func (db *CertificateRequestsRepository) UpdateCSR(id string, cert string) (int64, error) {
+func (db *Database) UpdateCSR(id string, cert string) (int64, error) {
 	csr, err := db.RetrieveCSR(id)
 	if err != nil {
 		return 0, err
@@ -140,7 +141,7 @@ func (db *CertificateRequestsRepository) UpdateCSR(id string, cert string) (int6
 }
 
 // DeleteCSR removes a CSR from the database alongside the certificate that may have been generated for it.
-func (db *CertificateRequestsRepository) DeleteCSR(id string) (int64, error) {
+func (db *Database) DeleteCSR(id string) (int64, error) {
 	result, err := db.conn.Exec(fmt.Sprintf(queryDeleteCSR, db.certificateTable), id)
 	if err != nil {
 		return 0, err
@@ -156,7 +157,7 @@ func (db *CertificateRequestsRepository) DeleteCSR(id string) (int64, error) {
 }
 
 // RetrieveAllUsers returns all of the users and their fields available in the database.
-func (db *CertificateRequestsRepository) RetrieveAllUsers() ([]User, error) {
+func (db *Database) RetrieveAllUsers() ([]User, error) {
 	rows, err := db.conn.Query(queryGetAllUsers)
 	if err != nil {
 		return nil, err
@@ -175,7 +176,7 @@ func (db *CertificateRequestsRepository) RetrieveAllUsers() ([]User, error) {
 }
 
 // RetrieveUser retrieves the name, password and the permission level of a user.
-func (db *CertificateRequestsRepository) RetrieveUser(id string) (User, error) {
+func (db *Database) RetrieveUser(id string) (User, error) {
 	var newUser User
 	row := db.conn.QueryRow(queryGetUser, id)
 	if err := row.Scan(&newUser.ID, &newUser.Username, &newUser.Password, &newUser.Permissions); err != nil {
@@ -188,7 +189,7 @@ func (db *CertificateRequestsRepository) RetrieveUser(id string) (User, error) {
 }
 
 // RetrieveUser retrieves the id, password and the permission level of a user.
-func (db *CertificateRequestsRepository) RetrieveUserByUsername(name string) (User, error) {
+func (db *Database) RetrieveUserByUsername(name string) (User, error) {
 	var newUser User
 	row := db.conn.QueryRow(queryGetUserByUsername, name)
 	if err := row.Scan(&newUser.ID, &newUser.Username, &newUser.Password, &newUser.Permissions); err != nil {
@@ -203,7 +204,7 @@ func (db *CertificateRequestsRepository) RetrieveUserByUsername(name string) (Us
 // CreateUser creates a new user from a given username, password and permission level.
 // The permission level 1 represents an admin, and a 0 represents a regular user.
 // The password passed in should be in plaintext. This function handles hashing and salting the password before storing it in the database.
-func (db *CertificateRequestsRepository) CreateUser(username, password, permissions string) (int64, error) {
+func (db *Database) CreateUser(username, password, permissions string) (int64, error) {
 	pw, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return 0, err
@@ -221,7 +222,7 @@ func (db *CertificateRequestsRepository) CreateUser(username, password, permissi
 
 // UpdateUser updates the password of the given user.
 // Just like with CreateUser, this function handles hashing and salting the password before storage.
-func (db *CertificateRequestsRepository) UpdateUser(id, password string) (int64, error) {
+func (db *Database) UpdateUser(id, password string) (int64, error) {
 	user, err := db.RetrieveUser(id)
 	if err != nil {
 		return 0, err
@@ -242,7 +243,7 @@ func (db *CertificateRequestsRepository) UpdateUser(id, password string) (int64,
 }
 
 // DeleteUser removes a user from the table.
-func (db *CertificateRequestsRepository) DeleteUser(id string) (int64, error) {
+func (db *Database) DeleteUser(id string) (int64, error) {
 	result, err := db.conn.Exec(queryDeleteUser, id)
 	if err != nil {
 		return 0, err
@@ -258,7 +259,7 @@ func (db *CertificateRequestsRepository) DeleteUser(id string) (int64, error) {
 }
 
 // Close closes the connection to the repository cleanly.
-func (db *CertificateRequestsRepository) Close() error {
+func (db *Database) Close() error {
 	if db.conn == nil {
 		return nil
 	}
@@ -268,23 +269,22 @@ func (db *CertificateRequestsRepository) Close() error {
 	return nil
 }
 
-// NewCertificateRequestsRepository connects to a given table in a given database,
+// NewDatabase connects to a given table in a given database,
 // stores the connection information and returns an object containing the information.
 // The database path must be a valid file path or ":memory:".
 // The table will be created if it doesn't exist in the format expected by the package.
-func NewCertificateRequestsRepository(databasePath string, tableName string) (*CertificateRequestsRepository, error) {
+func NewDatabase(databasePath string) (*Database, error) {
 	conn, err := sql.Open("sqlite3", databasePath)
 	if err != nil {
 		return nil, err
 	}
-	if _, err := conn.Exec(fmt.Sprintf(queryCreateCSRsTable, tableName)); err != nil {
+	if _, err := conn.Exec(queryCreateCSRsTable); err != nil {
 		return nil, err
 	}
 	if _, err := conn.Exec(queryCreateUsersTable); err != nil {
 		return nil, err
 	}
-	db := new(CertificateRequestsRepository)
+	db := new(Database)
 	db.conn = conn
-	db.certificateTable = tableName
 	return db, nil
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -125,7 +125,7 @@ func TestRetrieve(t *testing.T) {
 }
 
 func TestUsersEndToEnd(t *testing.T) {
-	db, err := db.NewDatabase(":memory:") //nolint:errcheck
+	db, err := db.NewDatabase(":memory:")
 	if err != nil {
 		t.Fatalf("Couldn't complete NewDatabase: %s", err)
 	}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,4 +1,4 @@
-package certdb_test
+package db_test
 
 import (
 	"fmt"
@@ -7,12 +7,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/canonical/notary/internal/certdb"
+	"github.com/canonical/notary/internal/db"
 	"golang.org/x/crypto/bcrypt"
 )
 
 func TestConnect(t *testing.T) {
-	db, err := certdb.NewCertificateRequestsRepository(":memory:", "CertificateReqs")
+	db, err := db.NewDatabase(":memory:")
 	if err != nil {
 		t.Fatalf("Can't connect to SQLite: %s", err)
 	}
@@ -20,9 +20,9 @@ func TestConnect(t *testing.T) {
 }
 
 func TestCSRsEndToEnd(t *testing.T) {
-	db, err := certdb.NewCertificateRequestsRepository(":memory:", "CertificateRequests") //nolint:errcheck
+	db, err := db.NewDatabase(":memory:")
 	if err != nil {
-		t.Fatalf("Couldn't complete NewCertificateRequestsRepository: %s", err)
+		t.Fatalf("Couldn't complete NewDatabase: %s", err)
 	}
 	defer db.Close()
 
@@ -61,7 +61,7 @@ func TestCSRsEndToEnd(t *testing.T) {
 	if len(res) != 2 {
 		t.Fatalf("CSR's weren't deleted from the DB properly")
 	}
-	var BananaCertBundle = strings.TrimSpace(fmt.Sprintf("%s%s", BananaCert, IssuerCert))
+	BananaCertBundle := strings.TrimSpace(fmt.Sprintf("%s%s", BananaCert, IssuerCert))
 	_, err = db.UpdateCSR(strconv.FormatInt(id2, 10), BananaCertBundle)
 	if err != nil {
 		t.Fatalf("Couldn't complete Update: %s", err)
@@ -85,7 +85,7 @@ func TestCSRsEndToEnd(t *testing.T) {
 }
 
 func TestCreateFails(t *testing.T) {
-	db, _ := certdb.NewCertificateRequestsRepository(":memory:", "CertificateReqs") //nolint:errcheck
+	db, _ := db.NewDatabase(":memory:")
 	defer db.Close()
 
 	InvalidCSR := strings.ReplaceAll(AppleCSR, "M", "i")
@@ -100,7 +100,7 @@ func TestCreateFails(t *testing.T) {
 }
 
 func TestUpdateFails(t *testing.T) {
-	db, _ := certdb.NewCertificateRequestsRepository(":memory:", "CertificateRequests") //nolint:errcheck
+	db, _ := db.NewDatabase(":memory:")
 	defer db.Close()
 
 	id1, _ := db.CreateCSR(AppleCSR)  //nolint:errcheck
@@ -115,20 +115,19 @@ func TestUpdateFails(t *testing.T) {
 }
 
 func TestRetrieve(t *testing.T) {
-	db, _ := certdb.NewCertificateRequestsRepository(":memory:", "CertificateRequests") //nolint:errcheck
+	db, _ := db.NewDatabase(":memory:") //nolint:errcheck
 	defer db.Close()
 
 	db.CreateCSR(AppleCSR) //nolint:errcheck
 	if _, err := db.RetrieveCSR("this is definitely not an id"); err == nil {
 		t.Fatalf("Expected failure looking for nonexistent CSR")
 	}
-
 }
 
 func TestUsersEndToEnd(t *testing.T) {
-	db, err := certdb.NewCertificateRequestsRepository(":memory:", "CertificateRequests") //nolint:errcheck
+	db, err := db.NewDatabase(":memory:") //nolint:errcheck
 	if err != nil {
-		t.Fatalf("Couldn't complete NewCertificateRequestsRepository: %s", err)
+		t.Fatalf("Couldn't complete NewDatabase: %s", err)
 	}
 	defer db.Close()
 
@@ -178,7 +177,7 @@ func TestUsersEndToEnd(t *testing.T) {
 }
 
 func Example() {
-	db, err := certdb.NewCertificateRequestsRepository("./certs.db", "CertificateReq")
+	db, err := db.NewDatabase("./certs.db")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/internal/db/validation.go
+++ b/internal/db/validation.go
@@ -1,4 +1,4 @@
-package certdb
+package db
 
 import (
 	"bytes"

--- a/internal/db/validation_test.go
+++ b/internal/db/validation_test.go
@@ -1,11 +1,11 @@
-package certdb_test
+package db_test
 
 import (
 	"fmt"
 	"strings"
 	"testing"
 
-	"github.com/canonical/notary/internal/certdb"
+	"github.com/canonical/notary/internal/db"
 )
 
 const (
@@ -215,7 +215,7 @@ func TestCSRValidationSuccess(t *testing.T) {
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("ValidCSR%d", i), func(t *testing.T) {
-			if err := certdb.ValidateCertificateRequest(c); err != nil {
+			if err := db.ValidateCertificateRequest(c); err != nil {
 				t.Errorf("Couldn't verify valid CSR: %s", err)
 			}
 		})
@@ -223,14 +223,14 @@ func TestCSRValidationSuccess(t *testing.T) {
 }
 
 func TestCSRValidationFail(t *testing.T) {
-	var wrongString = "this is a real csr!!!"
-	var wrongStringErr = "PEM Certificate Request string not found or malformed"
-	var ValidCSRWithoutWhitespace = strings.ReplaceAll(AppleCSR, "\n", "")
-	var ValidCSRWithoutWhitespaceErr = "PEM Certificate Request string not found or malformed"
-	var wrongPemType = strings.ReplaceAll(AppleCSR, "CERTIFICATE REQUEST", "SOME RANDOM PEM TYPE")
-	var wrongPemTypeErr = "given PEM string not a certificate request"
-	var InvalidCSR = strings.ReplaceAll(AppleCSR, "s", "p")
-	var InvalidCSRErr = "asn1: syntax error: data truncated"
+	wrongString := "this is a real csr!!!"
+	wrongStringErr := "PEM Certificate Request string not found or malformed"
+	ValidCSRWithoutWhitespace := strings.ReplaceAll(AppleCSR, "\n", "")
+	ValidCSRWithoutWhitespaceErr := "PEM Certificate Request string not found or malformed"
+	wrongPemType := strings.ReplaceAll(AppleCSR, "CERTIFICATE REQUEST", "SOME RANDOM PEM TYPE")
+	wrongPemTypeErr := "given PEM string not a certificate request"
+	InvalidCSR := strings.ReplaceAll(AppleCSR, "s", "p")
+	InvalidCSRErr := "asn1: syntax error: data truncated"
 
 	cases := []struct {
 		input       string
@@ -256,7 +256,7 @@ func TestCSRValidationFail(t *testing.T) {
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("InvalidCSR%d", i), func(t *testing.T) {
-			err := certdb.ValidateCertificateRequest(c.input)
+			err := db.ValidateCertificateRequest(c.input)
 			if err == nil {
 				t.Errorf("No error received. Expected: %s", c.expectedErr)
 				return
@@ -273,7 +273,7 @@ func TestCertValidationSuccess(t *testing.T) {
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("ValidCert%d", i), func(t *testing.T) {
-			if err := certdb.ValidateCertificate(c); err != nil {
+			if err := db.ValidateCertificate(c); err != nil {
 				t.Errorf("Couldn't verify valid Cert: %s", err)
 			}
 		})
@@ -281,20 +281,20 @@ func TestCertValidationSuccess(t *testing.T) {
 }
 
 func TestCertValidationFail(t *testing.T) {
-	var wrongCertString = "this is a real cert!!!"
-	var wrongCertStringErr = "less than 2 certificate PEM strings were found"
-	var wrongPemType = strings.ReplaceAll(BananaCert, "CERTIFICATE", "SOME RANDOM PEM TYPE")
-	var wrongPemTypeErr = "a given PEM string was not a certificate"
-	var InvalidCert = strings.ReplaceAll(BananaCert, "M", "i")
-	var InvalidCertErr = "x509: malformed certificate"
-	var singleCert = BananaCert
-	var singleCertErr = "less than 2 certificate PEM strings were found"
-	var issuerCertPKDoesNotMatch = fmt.Sprintf("%s\n%s", BananaCert, WrongPKIssuerCert)
-	var issuerCertPKDoesNotMatchErr = "invalid certificate chain: certificate 0, certificate 1: keys do not match"
-	var issuerCertSubjectDoesNotMatch = fmt.Sprintf("%s\n%s", BananaCert, WrongSubjectIssuerCert)
-	var issuerCertSubjectDoesNotMatchErr = "invalid certificate chain: certificate 0, certificate 1: subjects do not match"
-	var issuerCertNotCA = fmt.Sprintf("%s\n%s", BananaCert, StrawberryCert)
-	var issuerCertNotCaErr = "invalid certificate chain: certificate 1 is not a certificate authority"
+	wrongCertString := "this is a real cert!!!"
+	wrongCertStringErr := "less than 2 certificate PEM strings were found"
+	wrongPemType := strings.ReplaceAll(BananaCert, "CERTIFICATE", "SOME RANDOM PEM TYPE")
+	wrongPemTypeErr := "a given PEM string was not a certificate"
+	InvalidCert := strings.ReplaceAll(BananaCert, "M", "i")
+	InvalidCertErr := "x509: malformed certificate"
+	singleCert := BananaCert
+	singleCertErr := "less than 2 certificate PEM strings were found"
+	issuerCertPKDoesNotMatch := fmt.Sprintf("%s\n%s", BananaCert, WrongPKIssuerCert)
+	issuerCertPKDoesNotMatchErr := "invalid certificate chain: certificate 0, certificate 1: keys do not match"
+	issuerCertSubjectDoesNotMatch := fmt.Sprintf("%s\n%s", BananaCert, WrongSubjectIssuerCert)
+	issuerCertSubjectDoesNotMatchErr := "invalid certificate chain: certificate 0, certificate 1: subjects do not match"
+	issuerCertNotCA := fmt.Sprintf("%s\n%s", BananaCert, StrawberryCert)
+	issuerCertNotCaErr := "invalid certificate chain: certificate 1 is not a certificate authority"
 
 	cases := []struct {
 		inputCert   string
@@ -332,7 +332,7 @@ func TestCertValidationFail(t *testing.T) {
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("InvalidCert%d", i), func(t *testing.T) {
-			err := certdb.ValidateCertificate(c.inputCert)
+			err := db.ValidateCertificate(c.inputCert)
 			if err == nil {
 				t.Errorf("No error received. Expected: %s", c.expectedErr)
 				return
@@ -357,7 +357,7 @@ func TestCertificateMatchesCSRSuccess(t *testing.T) {
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("InvalidCert%d", i), func(t *testing.T) {
-			err := certdb.CertificateMatchesCSR(c.inputCert, c.inputCSR)
+			err := db.CertificateMatchesCSR(c.inputCert, c.inputCSR)
 			if err != nil {
 				t.Errorf("Certificate did not match when it should have")
 			}
@@ -366,7 +366,7 @@ func TestCertificateMatchesCSRSuccess(t *testing.T) {
 }
 
 func TestCertificateMatchesCSRFail(t *testing.T) {
-	var certificateDoesNotMatchErr = "certificate does not match CSR"
+	certificateDoesNotMatchErr := "certificate does not match CSR"
 
 	cases := []struct {
 		inputCSR    string
@@ -382,7 +382,7 @@ func TestCertificateMatchesCSRFail(t *testing.T) {
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("InvalidCert%d", i), func(t *testing.T) {
-			err := certdb.CertificateMatchesCSR(c.inputCert, c.inputCSR)
+			err := db.CertificateMatchesCSR(c.inputCert, c.inputCSR)
 			if err == nil {
 				t.Errorf("No error received. Expected: %s", c.expectedErr)
 				return

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/canonical/notary/internal/certdb"
+	"github.com/canonical/notary/internal/db"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -31,7 +31,7 @@ type PrometheusMetrics struct {
 }
 
 // NewMetricsSubsystem returns the metrics endpoint HTTP handler and the Prometheus metrics collectors for the server and middleware.
-func NewMetricsSubsystem(db *certdb.CertificateRequestsRepository) *PrometheusMetrics {
+func NewMetricsSubsystem(db *db.Database) *PrometheusMetrics {
 	metricsBackend := newPrometheusMetrics()
 	metricsBackend.Handler = promhttp.HandlerFor(metricsBackend.registry, promhttp.HandlerOpts{})
 	ticker := time.NewTicker(120 * time.Second)
@@ -85,7 +85,7 @@ func newPrometheusMetrics() *PrometheusMetrics {
 
 // GenerateMetrics receives the live list of csrs to calculate the most recent values for the metrics
 // defined for prometheus
-func (pm *PrometheusMetrics) GenerateMetrics(csrs []certdb.CertificateRequest) {
+func (pm *PrometheusMetrics) GenerateMetrics(csrs []db.CertificateRequest) {
 	var csrCount float64 = float64(len(csrs))
 	var outstandingCSRCount float64
 	var certCount float64
@@ -179,6 +179,7 @@ func certificatesExpiringIn7DaysMetric() prometheus.Gauge {
 	})
 	return metric
 }
+
 func certificatesExpiringIn30DaysMetric() prometheus.Gauge {
 	metric := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "certificates_expiring_in_30_days",

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -15,13 +15,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/canonical/notary/internal/certdb"
+	"github.com/canonical/notary/internal/db"
 	metrics "github.com/canonical/notary/internal/metrics"
 )
 
 // TestPrometheusHandler tests that the Prometheus metrics handler responds correctly to an HTTP request.
 func TestPrometheusHandler(t *testing.T) {
-	db, err := certdb.NewCertificateRequestsRepository(":memory:", "CertificateReq")
+	db, err := db.NewDatabase(":memory:")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func generateCertPair(daysRemaining int) (string, string, string) {
 	return csr, cert, ca
 }
 
-func initializeTestDB(t *testing.T, db *certdb.CertificateRequestsRepository) {
+func initializeTestDB(t *testing.T, db *db.Database) {
 	for i, v := range []int{5, 10, 32} {
 		csr, cert, ca := generateCertPair(v)
 		_, err := db.CreateCSR(csr)
@@ -117,7 +117,7 @@ func TestMetrics(t *testing.T) {
 	}
 	defer f.Close()
 	defer os.Remove(f.Name())
-	db, err := certdb.NewCertificateRequestsRepository(f.Name(), "CertificateReq")
+	db, err := db.NewDatabase(f.Name())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
# Description

This PR does a couple of things related to the database. Those are mainly because the database is no only used for certificate management anymore, it also stores users and soon Certificate Authority content.

- Rename the file from `certdb` to `db`
- Treat the certificateRequest and users table in the same way. Both are now un-parametrized and variables are used to referenced to both table names.
- Rename `CertificateRequestsRepository` to `Database` to reflect that the db contains varying types of data.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
