### PR TITLE
feat: create cli commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ You can build and run the program by following these steps:
 4. Build the frontend: `npm i --prefix ui && npm run build --prefix ui`
 5. Install the project: `go install ./...`
 6. Create a `config.yaml` file as described in README.md
-7. Run the project: `notary -config config.yaml`
+7. Run the project: `notary start -config config.yaml`
 
 Commands assume you're running them from the top level git repo directory
 

--- a/README.md
+++ b/README.md
@@ -79,5 +79,5 @@ You will need to build the frontend first, and then install notary with Go.
 
 ```bash
 npm install --prefix ui && npm run build --prefix ui && go install ./...
-notary -config ./config.yaml
+notary start -config ./config.yaml
 ```

--- a/cmd/notary/main.go
+++ b/cmd/notary/main.go
@@ -1,31 +1,15 @@
 package main
 
 import (
-	"flag"
-	"log"
+	"fmt"
 	"os"
 
-	server "github.com/canonical/notary/internal/api"
-	"github.com/canonical/notary/internal/config"
+	"github.com/canonical/notary/internal/cli"
 )
 
 func main() {
-	log.SetOutput(os.Stdout)
-	configFilePtr := flag.String("config", "", "The config file to be provided to the server")
-	flag.Parse()
-	if *configFilePtr == "" {
-		log.Fatalf("Providing a config file is required.")
-	}
-	conf, err := config.Validate(*configFilePtr)
-	if err != nil {
-		log.Fatalf("Couldn't validate config file: %s", err)
-	}
-	srv, err := server.NewServer(conf.Port, conf.Cert, conf.Key, conf.DBPath, conf.PebbleNotificationsEnabled)
-	if err != nil {
-		log.Fatalf("Couldn't create server: %s", err)
-	}
-	log.Printf("Starting server at %s", srv.Addr)
-	if err := srv.ListenAndServeTLS("", ""); err != nil {
-		log.Fatalf("Server ran into error: %s", err)
+	if err := cli.Run(os.Args[1:]); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
 }

--- a/cmd/notary/main_test.go
+++ b/cmd/notary/main_test.go
@@ -140,9 +140,9 @@ func TestNotaryFail(t *testing.T) {
 		ConfigYAML     string
 		ExpectedOutput string
 	}{
-		{"flags not set", []string{}, validConfig, "Providing a config file is required."},
-		{"config file not valid", []string{"-config", "config.yaml"}, invalidConfig, "config file validation failed:"},
-		{"database not connectable", []string{"-config", "config.yaml"}, invalidDBConfig, "Couldn't connect to database:"},
+		{"flags not set", []string{"start"}, validConfig, "Providing a config file is required."},
+		{"config file not valid", []string{"start -config", "config.yaml"}, invalidConfig, "config file validation failed:"},
+		{"database not connectable", []string{"start -config", "config.yaml"}, invalidDBConfig, "Couldn't connect to database:"},
 	}
 	for _, tc := range cases {
 		writeConfigErr := os.WriteFile("config.yaml", []byte(tc.ConfigYAML), 0644)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 	"os"
 )
@@ -12,23 +11,32 @@ type Runner interface {
 	Name() string
 }
 
+func getSupportedCommands() []Runner {
+	return []Runner{
+		NewStartCommand(),
+	}
+}
+
+func getSupportedCommandNames() []string {
+	allowedSubcommands := []string{}
+	for _, cmd := range getSupportedCommands() {
+		allowedSubcommands = append(allowedSubcommands, cmd.Name())
+	}
+	return allowedSubcommands
+}
+
 func Run(args []string) error {
 	if len(args) < 1 {
-		return errors.New("you must pass a subcommand")
-	}
-
-	cmds := []Runner{
-		NewStartCommand(),
+		return fmt.Errorf("you must pass a subcommand. Allowed commands: %v", getSupportedCommandNames())
 	}
 
 	subcommand := os.Args[1]
 
-	for _, cmd := range cmds {
+	for _, cmd := range getSupportedCommands() {
 		if cmd.Name() == subcommand {
 			cmd.Init(os.Args[2:])
 			return cmd.Run()
 		}
 	}
-
-	return fmt.Errorf("unknown subcommand: %s", subcommand)
+	return fmt.Errorf("unknown subcommand: %s. Allowed commands: %v", subcommand, getSupportedCommandNames())
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+type Runner interface {
+	Init([]string) error
+	Run() error
+	Name() string
+}
+
+func Run(args []string) error {
+	if len(args) < 1 {
+		return errors.New("you must pass a subcommand")
+	}
+
+	cmds := []Runner{
+		NewStartCommand(),
+	}
+
+	subcommand := os.Args[1]
+
+	for _, cmd := range cmds {
+		if cmd.Name() == subcommand {
+			cmd.Init(os.Args[2:])
+			return cmd.Run()
+		}
+	}
+
+	return fmt.Errorf("unknown subcommand: %s", subcommand)
+}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	server "github.com/canonical/notary/internal/api"
+	"github.com/canonical/notary/internal/config"
+)
+
+type StartCommand struct {
+	fs         *flag.FlagSet
+	configPath string
+}
+
+func (startCommand *StartCommand) Name() string {
+	return startCommand.fs.Name()
+}
+
+func (startCommand *StartCommand) Init(args []string) error {
+	return startCommand.fs.Parse(args)
+}
+
+func (startCommand *StartCommand) Run() error {
+	if startCommand.configPath == "" {
+		return fmt.Errorf("providing a config file is required")
+	}
+	conf, err := config.Validate(startCommand.configPath)
+	if err != nil {
+		return fmt.Errorf("couldn't validate config file: %s", err)
+	}
+	srv, err := server.NewServer(conf.Port, conf.Cert, conf.Key, conf.DBPath, conf.PebbleNotificationsEnabled)
+	if err != nil {
+		return fmt.Errorf("couldn't create server: %s", err)
+	}
+	log.Printf("Starting server at %s", srv.Addr)
+	if err := srv.ListenAndServeTLS("", ""); err != nil {
+		return fmt.Errorf("server ran into error: %s", err)
+	}
+	return nil
+}
+
+func NewStartCommand() *StartCommand {
+	command := &StartCommand{
+		fs: flag.NewFlagSet("start", flag.ContinueOnError),
+	}
+
+	command.fs.StringVar(&command.configPath, "config", "", "The config file to be provided to the server")
+
+	return command
+}

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"flag"
@@ -131,7 +131,7 @@ func TestMain(m *testing.M) {
 	os.Exit(exitval)
 }
 
-func TestNotaryFail(t *testing.T) {
+func TestStartFail(t *testing.T) {
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 	cases := []struct {
@@ -140,9 +140,9 @@ func TestNotaryFail(t *testing.T) {
 		ConfigYAML     string
 		ExpectedOutput string
 	}{
-		{"flags not set", []string{"start"}, validConfig, "Providing a config file is required."},
-		{"config file not valid", []string{"start -config", "config.yaml"}, invalidConfig, "config file validation failed:"},
-		{"database not connectable", []string{"start -config", "config.yaml"}, invalidDBConfig, "Couldn't connect to database:"},
+		{"flags not set", []string{"start"}, validConfig, "providing a config file is required."},
+		{"config file not valid", []string{"start", "-config", "config.yaml"}, invalidConfig, "config file validation failed:"},
+		{"database not connectable", []string{"start", "-config", "config.yaml"}, invalidDBConfig, "Couldn't connect to database:"},
 	}
 	for _, tc := range cases {
 		writeConfigErr := os.WriteFile("config.yaml", []byte(tc.ConfigYAML), 0644)

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -12,7 +12,7 @@ platforms:
 
 services:
   notary:
-    command: notary [ -config /etc/notary/config/config.yaml ]
+    command: notary start [ -config /etc/notary/config/config.yaml ]
     override: replace
     startup: enabled
 

--- a/service/bin/notaryd-start
+++ b/service/bin/notaryd-start
@@ -2,4 +2,4 @@
 
 set -ex
 
-"$SNAP"/bin/notary -config "$SNAP_COMMON"/notary.yaml
+"$SNAP"/bin/notary start -config "$SNAP_COMMON"/notary.yaml


### PR DESCRIPTION
# Description

As we add more features to gocert, we add the option to have multiple commands. For now we only implement one command: `start` with the same usage as the initial root command:

```shell
notary start -config config.yaml
``` 

## Rationale

We will soon add a `version` command which should be handled differently from starting the server. Here we will want to run

```shell
notary version
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
