### PR TITLE
chore: include err value in test errors

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -40,24 +40,27 @@ yaml.here`
 func TestMain(m *testing.M) {
 	testfolder, err := os.MkdirTemp("./", "configtest-")
 	if err != nil {
-		log.Fatalf("couldn't create temp directory")
+		log.Fatalf("couldn't create temp directory: %s", err)
 	}
-	writeCertErr := os.WriteFile(testfolder+"/cert_test.pem", []byte(validCert), 0o644)
-	writeKeyErr := os.WriteFile(testfolder+"/key_test.pem", []byte(validPK), 0o644)
-	if writeCertErr != nil || writeKeyErr != nil {
-		log.Fatalf("couldn't create temp testing file")
+	err = os.WriteFile(testfolder+"/cert_test.pem", []byte(validCert), 0o644)
+	if err != nil {
+		log.Fatalf("couldn't create temp testing file: %s", err)
+	}
+	err = os.WriteFile(testfolder+"/key_test.pem", []byte(validPK), 0o644)
+	if err != nil {
+		log.Fatalf("couldn't create temp testing file: %s", err)
 	}
 	if err := os.Chdir(testfolder); err != nil {
-		log.Fatalf("couldn't enter testing directory")
+		log.Fatalf("couldn't enter testing directory: %s", err)
 	}
 
 	exitval := m.Run()
 
 	if err := os.Chdir("../"); err != nil {
-		log.Fatalf("couldn't change back to parent directory")
+		log.Fatalf("couldn't change back to parent directory: %s", err)
 	}
 	if err := os.RemoveAll(testfolder); err != nil {
-		log.Fatalf("couldn't remove temp testing directory")
+		log.Fatalf("couldn't remove temp testing directory: %s", err)
 	}
 	os.Exit(exitval)
 }
@@ -104,11 +107,11 @@ func TestBadConfigFail(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		writeConfigErr := os.WriteFile("config.yaml", []byte(tc.ConfigYAML), 0o644)
-		if writeConfigErr != nil {
-			t.Errorf("Failed writing config file")
+		err := os.WriteFile("config.yaml", []byte(tc.ConfigYAML), 0o644)
+		if err != nil {
+			t.Errorf("Failed writing config file: %v", err)
 		}
-		_, err := config.Validate("config.yaml")
+		_, err = config.Validate("config.yaml")
 		if err == nil {
 			t.Errorf("Expected error, got nil")
 		}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -90,24 +90,27 @@ D7DC34n8CH9+avz9sCRwxpjxKnYW/BeyK0c4n9uZpjI8N4sOVqy6yWBUseww
 func TestMain(m *testing.M) {
 	testfolder, err := os.MkdirTemp("./", "configtest-")
 	if err != nil {
-		log.Fatalf("couldn't create temp directory")
+		log.Fatalf("couldn't create temp directory: %s", err)
 	}
-	writeCertErr := os.WriteFile(testfolder+"/cert_test.pem", []byte(validCert), 0o644)
-	writeKeyErr := os.WriteFile(testfolder+"/key_test.pem", []byte(validPK), 0o644)
-	if writeCertErr != nil || writeKeyErr != nil {
-		log.Fatalf("couldn't create temp testing file")
+	err = os.WriteFile(testfolder+"/cert_test.pem", []byte(validCert), 0o644)
+	if err != nil {
+		log.Fatalf("couldn't create temp testing file: %s", err)
+	}
+	err = os.WriteFile(testfolder+"/key_test.pem", []byte(validPK), 0o644)
+	if err != nil {
+		log.Fatalf("couldn't create temp testing file: %s", err)
 	}
 	if err := os.Chdir(testfolder); err != nil {
-		log.Fatalf("couldn't enter testing directory")
+		log.Fatalf("couldn't enter testing directory: %s", err)
 	}
 
 	exitval := m.Run()
 
 	if err := os.Chdir("../"); err != nil {
-		log.Fatalf("couldn't change back to parent directory")
+		log.Fatalf("couldn't change back to parent directory: %s", err)
 	}
 	if err := os.RemoveAll(testfolder); err != nil {
-		log.Fatalf("couldn't remove temp testing directory")
+		log.Fatalf("couldn't remove temp testing directory: %s", err)
 	}
 	os.Exit(exitval)
 }


### PR DESCRIPTION
# Description

Include `err` value in test errors.

Here we address one of the major concerns from Ben review's (#84 ).

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
