### PR TITLE
chore: use new repo for snap publish action

### DIFF
--- a/.github/workflows/snap-publish.yaml
+++ b/.github/workflows/snap-publish.yaml
@@ -26,7 +26,7 @@ jobs:
           echo "snap_file=${SNAP_FILE}" >>$GITHUB_OUTPUT
 
       - name: Publish snap
-        uses: snapcore/action-publish@v1.2.0
+        uses: canonical/action-publish@v1.2.0
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         if: ${{ github.ref_name == 'main' }}


### PR DESCRIPTION
# Description

Use new repo for snap publish action.

## Rationale

Our CI is failing at the `snap-publish` step because the repo was moved from `snapcore` to `canonical` and the git tags were removed from the old one.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
