### PR TITLE
fix: take version from version file

### DIFF
--- a/.github/workflows/rock-publish.yaml
+++ b/.github/workflows/rock-publish.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Import and push to github package
         run: |
           image_name="$(yq '.name' rockcraft.yaml)"
-          version="$(yq '.version' rockcraft.yaml)"
+          version="$(cat version/VERSION)"
           rock_file=$(ls *.rock | tail -n 1)
           sudo rockcraft.skopeo \
             --insecure-policy \


### PR DESCRIPTION
# Description

Fixes an issue with rock publishing where the version used to be taken from the `version` key in rockcraft.yaml. We now take the version fro the VERSION file. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
