### PR TITLE
fix: require certificate when creating certificates

### DIFF
--- a/.github/workflows/rock-build.yaml
+++ b/.github/workflows/rock-build.yaml
@@ -65,7 +65,7 @@ jobs:
           curl -k --location 'https://localhost:3000/api/v1/certificate_requests/1/certificate' \
             --header "Authorization: Bearer $ADMIN_TOKEN" \
             --header 'Content-Type: application/json' \
-            --data "{\"certificate\":\"${COMBINED_CERTIFICATE}\"}"
+            --data "{\"certificate\":\"${CERTIFICATE}\"}"
           
           docker exec notary /usr/bin/pebble notices
           docker exec notary /usr/bin/pebble notices | grep canonical\\.com

--- a/internal/server/handlers_certificate_requests.go
+++ b/internal/server/handlers_certificate_requests.go
@@ -175,6 +175,10 @@ func CreateCertificate(env *HandlerConfig) http.HandlerFunc {
 			writeError(w, http.StatusBadRequest, "Invalid JSON format")
 			return
 		}
+		if createCertificateParams.Certificate == "" {
+			writeError(w, http.StatusBadRequest, "Bad Request: certificate is empty")
+			return
+		}
 		id := r.PathValue("id")
 		insertId, err := env.DB.UpdateCSR(id, createCertificateParams.Certificate)
 		if err != nil {

--- a/internal/server/handlers_certificate_requests.go
+++ b/internal/server/handlers_certificate_requests.go
@@ -83,6 +83,10 @@ func CreateCertificateRequest(env *HandlerConfig) http.HandlerFunc {
 			writeError(w, http.StatusBadRequest, "Invalid JSON format")
 			return
 		}
+		if createCertificateRequestParams.CSR == "" {
+			writeError(w, http.StatusBadRequest, "csr is empty")
+			return
+		}
 		id, err := env.DB.CreateCSR(createCertificateRequestParams.CSR)
 		if err != nil {
 			if strings.Contains(err.Error(), "UNIQUE constraint failed") {
@@ -176,7 +180,7 @@ func CreateCertificate(env *HandlerConfig) http.HandlerFunc {
 			return
 		}
 		if createCertificateParams.Certificate == "" {
-			writeError(w, http.StatusBadRequest, "Bad Request: certificate is empty")
+			writeError(w, http.StatusBadRequest, "certificate is empty")
 			return
 		}
 		id := r.PathValue("id")

--- a/internal/server/handlers_certificate_requests.go
+++ b/internal/server/handlers_certificate_requests.go
@@ -84,7 +84,7 @@ func CreateCertificateRequest(env *HandlerConfig) http.HandlerFunc {
 			return
 		}
 		if createCertificateRequestParams.CSR == "" {
-			writeError(w, http.StatusBadRequest, "csr is empty")
+			writeError(w, http.StatusBadRequest, "csr is missing")
 			return
 		}
 		id, err := env.DB.CreateCSR(createCertificateRequestParams.CSR)
@@ -180,7 +180,7 @@ func CreateCertificate(env *HandlerConfig) http.HandlerFunc {
 			return
 		}
 		if createCertificateParams.Certificate == "" {
-			writeError(w, http.StatusBadRequest, "certificate is empty")
+			writeError(w, http.StatusBadRequest, "certificate is missing")
 			return
 		}
 		id := r.PathValue("id")

--- a/internal/server/handlers_certificate_requests_test.go
+++ b/internal/server/handlers_certificate_requests_test.go
@@ -189,7 +189,21 @@ func TestCertificateRequestsEndToEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("2. Create certificate request", func(t *testing.T) {
+	t.Run("2. Create certificate request - Bad Request (csr is missing)", func(t *testing.T) {
+		createCertificateRequestRequest := CreateCertificateRequestParams{}
+		statusCode, createCertResponse, err := createCertificateRequest(ts.URL, client, adminToken, createCertificateRequestRequest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if statusCode != http.StatusBadRequest {
+			t.Fatalf("expected status %d, got %d", http.StatusBadRequest, statusCode)
+		}
+		if createCertResponse.Error != "csr is missing" {
+			t.Fatalf("expected error, got %s", createCertResponse.Error)
+		}
+	})
+
+	t.Run("3. Create certificate request", func(t *testing.T) {
 		csr1Path := filepath.Join("testdata", "csr1.pem")
 		csr1, err := os.ReadFile(csr1Path)
 		if err != nil {
@@ -210,7 +224,7 @@ func TestCertificateRequestsEndToEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("3. List certificate requests - 1 Certificate", func(t *testing.T) {
+	t.Run("4. List certificate requests - 1 Certificate", func(t *testing.T) {
 		statusCode, listCertRequestsResponse, err := listCertificateRequests(ts.URL, client, adminToken)
 		if err != nil {
 			t.Fatal(err)
@@ -226,7 +240,7 @@ func TestCertificateRequestsEndToEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("4. Get certificate request", func(t *testing.T) {
+	t.Run("5. Get certificate request", func(t *testing.T) {
 		statusCode, getCertRequestResponse, err := getCertificateRequest(ts.URL, client, adminToken, 1)
 		if err != nil {
 			t.Fatal(err)
@@ -248,7 +262,7 @@ func TestCertificateRequestsEndToEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("5. Create identical certificate request", func(t *testing.T) {
+	t.Run("6. Create identical certificate request", func(t *testing.T) {
 		csr1Path := filepath.Join("testdata", "csr1.pem")
 		csr1, err := os.ReadFile(csr1Path)
 		if err != nil {
@@ -269,7 +283,7 @@ func TestCertificateRequestsEndToEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("6. List certificate requests - 1 Certificate", func(t *testing.T) {
+	t.Run("7. List certificate requests - 1 Certificate", func(t *testing.T) {
 		statusCode, listCertRequestsResponse, err := listCertificateRequests(ts.URL, client, adminToken)
 		if err != nil {
 			t.Fatal(err)
@@ -285,7 +299,7 @@ func TestCertificateRequestsEndToEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("7. Create another certificate request", func(t *testing.T) {
+	t.Run("8. Create another certificate request", func(t *testing.T) {
 		csr2Path := filepath.Join("testdata", "csr2.pem")
 		csr2, err := os.ReadFile(csr2Path)
 		if err != nil {
@@ -306,7 +320,7 @@ func TestCertificateRequestsEndToEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("8. List certificate requests - 2 Certificates", func(t *testing.T) {
+	t.Run("9. List certificate requests - 2 Certificates", func(t *testing.T) {
 		statusCode, listCertRequestsResponse, err := listCertificateRequests(ts.URL, client, adminToken)
 		if err != nil {
 			t.Fatal(err)
@@ -322,7 +336,7 @@ func TestCertificateRequestsEndToEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("9. Get certificate request 2", func(t *testing.T) {
+	t.Run("10. Get certificate request 2", func(t *testing.T) {
 		statusCode, getCertRequestResponse, err := getCertificateRequest(ts.URL, client, adminToken, 2)
 		if err != nil {
 			t.Fatal(err)
@@ -344,7 +358,7 @@ func TestCertificateRequestsEndToEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("10. Delete certificate request 1", func(t *testing.T) {
+	t.Run("11. Delete certificate request 1", func(t *testing.T) {
 		statusCode, err := deleteCertificateRequest(ts.URL, client, adminToken, 1)
 		if err != nil {
 			t.Fatal(err)
@@ -354,7 +368,7 @@ func TestCertificateRequestsEndToEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("11. List certificate requests - 1 Certificate", func(t *testing.T) {
+	t.Run("12. List certificate requests - 1 Certificate", func(t *testing.T) {
 		statusCode, listCertRequestsResponse, err := listCertificateRequests(ts.URL, client, adminToken)
 		if err != nil {
 			t.Fatal(err)
@@ -370,7 +384,7 @@ func TestCertificateRequestsEndToEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("12. Delete certificate request 2", func(t *testing.T) {
+	t.Run("13. Delete certificate request 2", func(t *testing.T) {
 		statusCode, err := deleteCertificateRequest(ts.URL, client, adminToken, 2)
 		if err != nil {
 			t.Fatal(err)
@@ -416,7 +430,21 @@ func TestCertificatesEndToEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("2. Create Certificate", func(t *testing.T) {
+	t.Run("2. Create Certificate - Bad Request (certificate is missing)", func(t *testing.T) {
+		createCertificateRequest := CreateCertificateParams{}
+		statusCode, createCertResponse, err := createCertificate(ts.URL, client, adminToken, createCertificateRequest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if statusCode != http.StatusBadRequest {
+			t.Fatalf("expected status %d, got %d", http.StatusBadRequest, statusCode)
+		}
+		if createCertResponse.Error != "certificate is missing" {
+			t.Fatalf("expected error, got %s", createCertResponse.Error)
+		}
+	})
+
+	t.Run("3. Create Certificate", func(t *testing.T) {
 		certPath := filepath.Join("testdata", "csr2_cert.pem")
 		cert, err := os.ReadFile(certPath)
 		if err != nil {
@@ -442,7 +470,7 @@ func TestCertificatesEndToEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("3. Get Certificate", func(t *testing.T) {
+	t.Run("4. Get Certificate", func(t *testing.T) {
 		statusCode, getCertResponse, err := getCertificateRequest(ts.URL, client, adminToken, 1)
 		if err != nil {
 			t.Fatal(err)
@@ -458,7 +486,7 @@ func TestCertificatesEndToEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("4. Reject Certificate", func(t *testing.T) {
+	t.Run("5. Reject Certificate", func(t *testing.T) {
 		statusCode, err := rejectCertificate(ts.URL, client, adminToken, 1)
 		if err != nil {
 			t.Fatal(err)
@@ -468,7 +496,7 @@ func TestCertificatesEndToEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("5. Get Certificate", func(t *testing.T) {
+	t.Run("6. Get Certificate", func(t *testing.T) {
 		statusCode, getCertResponse, err := getCertificateRequest(ts.URL, client, adminToken, 1)
 		if err != nil {
 			t.Fatal(err)
@@ -484,7 +512,7 @@ func TestCertificatesEndToEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("6. Delete Certificate", func(t *testing.T) {
+	t.Run("7. Delete Certificate", func(t *testing.T) {
 		statusCode, err := deleteCertificateRequest(ts.URL, client, adminToken, 1)
 		if err != nil {
 			t.Fatal(err)
@@ -494,7 +522,7 @@ func TestCertificatesEndToEnd(t *testing.T) {
 		}
 	})
 
-	t.Run("7. Get Certificate", func(t *testing.T) {
+	t.Run("8. Get Certificate", func(t *testing.T) {
 		statusCode, getCertResponse, err := getCertificateRequest(ts.URL, client, adminToken, 1)
 		if err != nil {
 			t.Fatal(err)

--- a/ui/src/app/queries.ts
+++ b/ui/src/app/queries.ts
@@ -55,7 +55,7 @@ export async function postCertToID(params: RequiredCSRParams) {
         throw new Error('Certificate not provided')
     }
     const reqParams = {
-        "cert": params.cert.trim()
+        "certificate": params.cert.trim()
     }
     const response = await fetch("/api/v1/certificate_requests/" + params.id + "/certificate", {
         method: 'post',


### PR DESCRIPTION
# Description

Here we address 2 related issues.
1. The UI uses `certificate` instead of `cert` when creating certificates. This change was made in the Go webserver in a previous PR but we forgot to adapt the frontend.
2. The Go webserver now returns a "bad request" error when trying to create a certificate without the `certificate` parameter. It used to not check for required parameter and return a 201 created. 
3. The integration test in the github workflow uses the correct variable

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
