### PR TITLE
fix: use version from version file in rock-scan workflow

### DIFF
--- a/.github/workflows/rock-scan.yaml
+++ b/.github/workflows/rock-scan.yaml
@@ -26,7 +26,7 @@ jobs:
         run: |
           image_name="$(yq '.name' rockcraft.yaml)"
           echo "image_name=${image_name}" >> $GITHUB_ENV
-          version="$(yq '.version' rockcraft.yaml)"
+          version="$(cat version/VERSION)"
           echo "version=${version}" >> $GITHUB_ENV
           rock_file=$(ls *.rock | tail -n 1)
           sudo rockcraft.skopeo \


### PR DESCRIPTION
# Description

Use version from version file in rock-scan workflow as this is where the project version is now defined (instead of directly in rockcraft.yaml).

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
