### PR TITLE
feat: add headers before writing headers

### DIFF
--- a/internal/server/handlers_accounts.go
+++ b/internal/server/handlers_accounts.go
@@ -62,8 +62,7 @@ func ListAccounts(env *HandlerConfig) http.HandlerFunc {
 				Permissions: account.Permissions,
 			}
 		}
-		w.WriteHeader(http.StatusOK)
-		err = writeJSON(w, accountsResponse)
+		err = writeResponse(w, accountsResponse, http.StatusOK)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
@@ -107,8 +106,7 @@ func GetAccount(env *HandlerConfig) http.HandlerFunc {
 			Username:    account.Username,
 			Permissions: account.Permissions,
 		}
-		w.WriteHeader(http.StatusOK)
-		err = writeJSON(w, accountResponse)
+		err = writeResponse(w, accountResponse, http.StatusOK)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
@@ -160,8 +158,7 @@ func CreateAccount(env *HandlerConfig) http.HandlerFunc {
 			return
 		}
 		successResponse := SuccessResponse{Message: "success"}
-		w.WriteHeader(http.StatusCreated)
-		err = writeJSON(w, successResponse)
+		err = writeResponse(w, successResponse, http.StatusCreated)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
@@ -205,8 +202,7 @@ func DeleteAccount(env *HandlerConfig) http.HandlerFunc {
 			return
 		}
 		successResponse := SuccessResponse{Message: "success"}
-		w.WriteHeader(http.StatusAccepted)
-		err = writeJSON(w, successResponse)
+		err = writeResponse(w, successResponse, http.StatusAccepted)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
@@ -269,8 +265,7 @@ func ChangeAccountPassword(env *HandlerConfig) http.HandlerFunc {
 			return
 		}
 		successResponse := SuccessResponse{Message: "success"}
-		w.WriteHeader(http.StatusCreated)
-		err = writeJSON(w, successResponse)
+		err = writeResponse(w, successResponse, http.StatusCreated)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return

--- a/internal/server/handlers_certificate_requests.go
+++ b/internal/server/handlers_certificate_requests.go
@@ -44,8 +44,7 @@ func ListCertificateRequests(env *HandlerConfig) http.HandlerFunc {
 				Status:           csr.Status,
 			}
 		}
-		w.WriteHeader(http.StatusOK)
-		err = writeJSON(w, certificateRequestsResponse)
+		err = writeResponse(w, certificateRequestsResponse, http.StatusOK)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
@@ -81,8 +80,7 @@ func CreateCertificateRequest(env *HandlerConfig) http.HandlerFunc {
 			return
 		}
 		successResponse := SuccessResponse{Message: "success"}
-		w.WriteHeader(http.StatusCreated)
-		err = writeJSON(w, successResponse)
+		err = writeResponse(w, successResponse, http.StatusCreated)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
@@ -116,8 +114,7 @@ func GetCertificateRequest(env *HandlerConfig) http.HandlerFunc {
 			CertificateChain: csr.CertificateChain,
 			Status:           csr.Status,
 		}
-		w.WriteHeader(http.StatusOK)
-		err = writeJSON(w, certificateRequestResponse)
+		err = writeResponse(w, certificateRequestResponse, http.StatusOK)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
@@ -146,8 +143,7 @@ func DeleteCertificateRequest(env *HandlerConfig) http.HandlerFunc {
 			return
 		}
 		successResponse := SuccessResponse{Message: "success"}
-		w.WriteHeader(http.StatusAccepted)
-		err = writeJSON(w, successResponse)
+		err = writeResponse(w, successResponse, http.StatusAccepted)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
@@ -193,8 +189,7 @@ func CreateCertificate(env *HandlerConfig) http.HandlerFunc {
 			}
 		}
 		successResponse := SuccessResponse{Message: "success"}
-		w.WriteHeader(http.StatusCreated)
-		err = writeJSON(w, successResponse)
+		err = writeResponse(w, successResponse, http.StatusCreated)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
@@ -227,8 +222,7 @@ func RejectCertificate(env *HandlerConfig) http.HandlerFunc {
 			}
 		}
 		successResponse := SuccessResponse{Message: "success"}
-		w.WriteHeader(http.StatusAccepted)
-		err = writeJSON(w, successResponse)
+		err = writeResponse(w, successResponse, http.StatusAccepted)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
@@ -263,8 +257,7 @@ func DeleteCertificate(env *HandlerConfig) http.HandlerFunc {
 			}
 		}
 		successResponse := SuccessResponse{Message: "success"}
-		w.WriteHeader(http.StatusOK)
-		err = writeJSON(w, successResponse)
+		err = writeResponse(w, successResponse, http.StatusOK)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return

--- a/internal/server/handlers_login.go
+++ b/internal/server/handlers_login.go
@@ -85,11 +85,10 @@ func Login(env *HandlerConfig) http.HandlerFunc {
 			writeError(w, http.StatusInternalServerError, "Internal Error")
 			return
 		}
-		w.WriteHeader(http.StatusOK)
 		loginResponse := LoginResponse{
 			Token: jwt,
 		}
-		err = writeJSON(w, loginResponse)
+		err = writeResponse(w, loginResponse, http.StatusOK)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return

--- a/internal/server/handlers_status.go
+++ b/internal/server/handlers_status.go
@@ -24,8 +24,7 @@ func GetStatus(env *HandlerConfig) http.HandlerFunc {
 			Initialized: numUsers > 0,
 			Version:     version.GetVersion(),
 		}
-		w.WriteHeader(http.StatusOK)
-		err = writeJSON(w, statusResponse)
+		err = writeResponse(w, statusResponse, http.StatusOK)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return

--- a/internal/server/response.go
+++ b/internal/server/response.go
@@ -10,8 +10,8 @@ type SuccessResponse struct {
 	Message string `json:"message"`
 }
 
-// writeJSON is a helper function that writes a JSON response to the http.ResponseWriter
-func writeJSON(w http.ResponseWriter, v any) error {
+// writeResponse is a helper function that writes a JSON response to the http.ResponseWriter
+func writeResponse(w http.ResponseWriter, v any, status int) error {
 	type response struct {
 		Result any `json:"result,omitempty"`
 	}
@@ -21,6 +21,7 @@ func writeJSON(w http.ResponseWriter, v any) error {
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
 	if _, err := w.Write(respBytes); err != nil {
 		return err
 	}
@@ -40,6 +41,7 @@ func writeError(w http.ResponseWriter, status int, message string) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_, err = w.Write(respBytes)
 	if err != nil {


### PR DESCRIPTION
# Description

When using the writeHeader() function, go's net/http discards any other header that is set after this function call. This PR moves this function to the end of all of the handlers so we get the expected headers in our responses. To validate that this change works, we can use curl to look at the response headers.

Before the change:
```
< HTTP/2 401 
< content-type: text/plain; charset=utf-8
< content-length: 24
< date: Fri, 29 Nov 2024 20:02:31 GMT
```
The content type is text/plain because that is the default header attached to all handlers unless specified.


After the change:
```
< HTTP/2 401 
< content-type: application/json
< content-length: 24
< date: Fri, 29 Nov 2024 20:03:48 GMT
```
The correct content-type is set.


# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
