### PR TITLE
chore: split rock build and test steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,9 @@ jobs:
   rock-build:
     needs: [go-build, go-unit-test, go-vet, go-lint]
     uses: ./.github/workflows/rock-build.yaml
+  rock-test:
+    needs: [rock-build]
+    uses: ./.github/workflows/rock-build.yaml
   rock-scan:
     if: github.ref_name == 'main'
     needs: [rock-build]

--- a/.github/workflows/rock-build.yaml
+++ b/.github/workflows/rock-build.yaml
@@ -13,7 +13,6 @@ jobs:
         id: rockcraft
         with:
           rockcraft-channel: edge
-      
       - name: Install pre-requisites
         run: |
           sudo apt-get update
@@ -21,59 +20,8 @@ jobs:
       - name: Import the image to Docker registry
         run: |
           sudo rockcraft.skopeo --insecure-policy copy oci-archive:${{ steps.rockcraft.outputs.rock }} docker-daemon:notary:latest
-
-      - name: Create files required by Notary
-        run: |
-          printf 'key_path:  "/etc/notary/config/key.pem"\ncert_path: "/etc/notary/config/cert.pem"\ndb_path: "/var/lib/notary/database/certs.db"\nport: 3000\npebble_notifications: true\n' > config.yaml
-          openssl req -newkey rsa:2048 -nodes -keyout key.pem -x509 -days 1 -out cert.pem -subj "/CN=githubaction.example"
-
-      - name: Run the image
-        run: |
-          docker run -d -p 3000:3000 --name notary notary:latest
-      - name: Load config
-        run: |
-          docker exec notary /usr/bin/pebble mkdir -p /etc/notary/config
-          docker exec notary /usr/bin/pebble mkdir -p /var/lib/notary/database
-          docker cp key.pem notary:/etc/notary/config/key.pem
-          docker cp cert.pem notary:/etc/notary/config/cert.pem
-          docker cp config.yaml notary:/etc/notary/config/config.yaml
-          docker restart notary
-      - name: Check if Notary frontend is loaded
-        run: |
-          sleep 30
-          docker logs notary
-          curl -k https://localhost:3000/certificate_requests.html 2>&1 | grep "Certificate Requests"
-
-      - name: Test if pebble notify fires correctly
-        id: test_notify
-        run : |
-          openssl genpkey -algorithm RSA -out private_key.pem -pkeyopt rsa_keygen_bits:2048
-          openssl req -new -key private_key.pem -out request.csr -subj "/C=CA/ST=Quebec/L=Montreal/O=Test Company/OU=IT Department/CN=test.example.com"
-          openssl req -x509 -new -nodes -key private_key.pem -sha256 -days 365 -out ca_certificate.pem -subj "/C=CA/ST=Quebec/L=Montreal/O=Test CA/OU=CA Department/CN=Test CA"
-          openssl x509 -req -in request.csr -CA ca_certificate.pem -CAkey private_key.pem -CAcreateserial -out certificate.pem -days 365 -sha256
-          CSR=$(cat request.csr | awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}')
-          CERTIFICATE=$(cat certificate.pem ca_certificate.pem | awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}')
-
-          curl -XPOST -k -d '{"username":"admin", "password": "Admin1234"}' https://localhost:3000/api/v1/accounts
-          export ADMIN_TOKEN=$(curl -XPOST -k -d '{"username":"admin", "password": "Admin1234"}' https://localhost:3000/login | jq -r .result.token )
-
-          curl -k --location 'https://localhost:3000/api/v1/certificate_requests' \
-            --header "Authorization: Bearer $ADMIN_TOKEN" \
-            --header 'Content-Type: application/json' \
-            --data "{\"csr\":\"${CSR}\"}"
-
-          curl -k --location 'https://localhost:3000/api/v1/certificate_requests/1/certificate' \
-            --header "Authorization: Bearer $ADMIN_TOKEN" \
-            --header 'Content-Type: application/json' \
-            --data "{\"certificate\":\"${CERTIFICATE}\"}"
-          
-          docker exec notary /usr/bin/pebble notices
-          docker exec notary /usr/bin/pebble notices | grep canonical\\.com
-          docker exec notary /usr/bin/pebble notice 3
-        
       - uses: actions/upload-artifact@v4
         if: steps.test_notify.outcome == 'success'
         with:
-
           name: rock
           path: ${{ steps.rockcraft.outputs.rock }}

--- a/.github/workflows/rock-test.yaml
+++ b/.github/workflows/rock-test.yaml
@@ -1,0 +1,60 @@
+name: Rock Test
+
+on:
+  workflow_call:
+
+jobs:
+  test-rock:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: rock
+      - name: Create files required by Notary
+        run: |
+          printf 'key_path:  "/etc/notary/config/key.pem"\ncert_path: "/etc/notary/config/cert.pem"\ndb_path: "/var/lib/notary/database/certs.db"\nport: 3000\npebble_notifications: true\n' > config.yaml
+          openssl req -newkey rsa:2048 -nodes -keyout key.pem -x509 -days 1 -out cert.pem -subj "/CN=githubaction.example"
+      - name: Run the image
+        run: |
+          docker run -d -p 3000:3000 --name notary notary:latest
+      - name: Load config
+        run: |
+          docker exec notary /usr/bin/pebble mkdir -p /etc/notary/config
+          docker exec notary /usr/bin/pebble mkdir -p /var/lib/notary/database
+          docker cp key.pem notary:/etc/notary/config/key.pem
+          docker cp cert.pem notary:/etc/notary/config/cert.pem
+          docker cp config.yaml notary:/etc/notary/config/config.yaml
+          docker restart notary
+      - name: Check if Notary frontend is loaded
+        run: |
+          sleep 30
+          docker logs notary
+          curl -k https://localhost:3000/certificate_requests.html 2>&1 | grep "Certificate Requests"
+      - name: Test if pebble notify fires correctly
+        id: test_notify
+        run : |
+          openssl genpkey -algorithm RSA -out private_key.pem -pkeyopt rsa_keygen_bits:2048
+          openssl req -new -key private_key.pem -out request.csr -subj "/C=CA/ST=Quebec/L=Montreal/O=Test Company/OU=IT Department/CN=test.example.com"
+          openssl req -x509 -new -nodes -key private_key.pem -sha256 -days 365 -out ca_certificate.pem -subj "/C=CA/ST=Quebec/L=Montreal/O=Test CA/OU=CA Department/CN=Test CA"
+          openssl x509 -req -in request.csr -CA ca_certificate.pem -CAkey private_key.pem -CAcreateserial -out certificate.pem -days 365 -sha256
+          CSR=$(cat request.csr | awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}')
+          CERTIFICATE=$(cat certificate.pem ca_certificate.pem | awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}')
+
+          curl -XPOST -k -d '{"username":"admin", "password": "Admin1234"}' https://localhost:3000/api/v1/accounts
+          export ADMIN_TOKEN=$(curl -XPOST -k -d '{"username":"admin", "password": "Admin1234"}' https://localhost:3000/login | jq -r .result.token )
+
+          curl -k --location 'https://localhost:3000/api/v1/certificate_requests' \
+            --header "Authorization: Bearer $ADMIN_TOKEN" \
+            --header 'Content-Type: application/json' \
+            --data "{\"csr\":\"${CSR}\"}"
+
+          curl -k --location 'https://localhost:3000/api/v1/certificate_requests/1/certificate' \
+            --header "Authorization: Bearer $ADMIN_TOKEN" \
+            --header 'Content-Type: application/json' \
+            --data "{\"certificate\":\"${CERTIFICATE}\"}"
+          
+          docker exec notary /usr/bin/pebble notices
+          docker exec notary /usr/bin/pebble notices | grep canonical\\.com
+          docker exec notary /usr/bin/pebble notice 3


### PR DESCRIPTION
# Description

This change splits the steps that build and test the rock, which allows the workflow to upload the failed rock for debugging purposes.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
