### PR TITLE
chore: use static table names

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -3,7 +3,6 @@ package db
 
 import (
 	"database/sql"
-	"fmt"
 
 	"github.com/canonical/sqlair"
 	_ "github.com/mattn/go-sqlite3"
@@ -11,21 +10,8 @@ import (
 
 // Database is the object used to communicate with the established repository.
 type Database struct {
-	certificateRequestsTable    string
-	certificatesTable           string
-	usersTable                  string
-	privateKeysTable            string
-	certificateAuthoritiesTable string
-	conn                        *sqlair.DB
+	conn *sqlair.DB
 }
-
-const (
-	certificateRequestsTableName    = "certificate_requests"
-	certificatesTableName           = "certificates"
-	usersTableName                  = "users"
-	privateKeysTableName            = "private_keys"
-	certificateAuthoritiesTableName = "certificate_authorities"
-)
 
 // Close closes the connection to the repository cleanly.
 func (db *Database) Close() error {
@@ -47,27 +33,22 @@ func NewDatabase(databasePath string) (*Database, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, err := sqlConnection.Exec(fmt.Sprintf(queryCreateCertificateRequestsTable, certificateRequestsTableName)); err != nil {
+	if _, err := sqlConnection.Exec(queryCreateCertificateRequestsTable); err != nil {
 		return nil, err
 	}
-	if _, err := sqlConnection.Exec(fmt.Sprintf(queryCreateCertificatesTable, certificatesTableName)); err != nil {
+	if _, err := sqlConnection.Exec(queryCreateCertificatesTable); err != nil {
 		return nil, err
 	}
-	if _, err := sqlConnection.Exec(fmt.Sprintf(queryCreateUsersTable, usersTableName)); err != nil {
+	if _, err := sqlConnection.Exec(queryCreateUsersTable); err != nil {
 		return nil, err
 	}
-	if _, err := sqlConnection.Exec(fmt.Sprintf(queryCreatePrivateKeysTable, privateKeysTableName)); err != nil {
+	if _, err := sqlConnection.Exec(queryCreatePrivateKeysTable); err != nil {
 		return nil, err
 	}
-	if _, err := sqlConnection.Exec(fmt.Sprintf(queryCreateCertificateAuthoritiesTable, certificateAuthoritiesTableName)); err != nil {
+	if _, err := sqlConnection.Exec(queryCreateCertificateAuthoritiesTable); err != nil {
 		return nil, err
 	}
 	db := new(Database)
 	db.conn = sqlair.NewDB(sqlConnection)
-	db.certificateRequestsTable = certificateRequestsTableName
-	db.certificatesTable = certificatesTableName
-	db.usersTable = usersTableName
-	db.privateKeysTable = privateKeysTableName
-	db.certificateAuthoritiesTable = certificateAuthoritiesTableName
 	return db, nil
 }

--- a/internal/db/db_private_keys.go
+++ b/internal/db/db_private_keys.go
@@ -15,7 +15,7 @@ type PrivateKey struct {
 }
 
 const queryCreatePrivateKeysTable = `
-	CREATE TABLE IF NOT EXISTS %s (
+	CREATE TABLE IF NOT EXISTS private_keys (
 	    private_key_id INTEGER PRIMARY KEY AUTOINCREMENT,
 
 		private_key TEXT NOT NULL UNIQUE
@@ -23,15 +23,15 @@ const queryCreatePrivateKeysTable = `
 `
 
 const (
-	listPrivateKeysStmt  = "SELECT &PrivateKey.* FROM %s"
-	getPrivateKeyStmt    = "SELECT &PrivateKey.* FROM %s WHERE private_key_id==$PrivateKey.private_key_id or private_key==$PrivateKey.private_key"
-	createPrivateKeyStmt = "INSERT INTO %s (private_key) VALUES ($PrivateKey.private_key)"
-	deletePrivateKeyStmt = "DELETE FROM %s WHERE private_key_id==$PrivateKey.private_key_id or private_key==$PrivateKey.private_key"
+	listPrivateKeysStmt  = "SELECT &PrivateKey.* FROM private_keys"
+	getPrivateKeyStmt    = "SELECT &PrivateKey.* FROM private_keys WHERE private_key_id==$PrivateKey.private_key_id or private_key==$PrivateKey.private_key"
+	createPrivateKeyStmt = "INSERT INTO private_keys (private_key) VALUES ($PrivateKey.private_key)"
+	deletePrivateKeyStmt = "DELETE FROM private_keys WHERE private_key_id==$PrivateKey.private_key_id or private_key==$PrivateKey.private_key"
 )
 
 // ListPrivateKeys gets every PrivateKey entry in the table.
 func (db *Database) ListPrivateKeys() ([]PrivateKey, error) {
-	stmt, err := sqlair.Prepare(fmt.Sprintf(listPrivateKeysStmt, db.privateKeysTable), PrivateKey{})
+	stmt, err := sqlair.Prepare(listPrivateKeysStmt, PrivateKey{})
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (db *Database) GetPrivateKey(filter PrivateKeyFilter) (*PrivateKey, error) 
 		return nil, fmt.Errorf("invalid filter identifier: both ID and PEM are nil")
 	}
 
-	stmt, err := sqlair.Prepare(fmt.Sprintf(getPrivateKeyStmt, db.privateKeysTable), PrivateKey{})
+	stmt, err := sqlair.Prepare(getPrivateKeyStmt, PrivateKey{})
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (db *Database) CreatePrivateKey(pk string) error {
 	if err := ValidatePrivateKey(pk); err != nil {
 		return errors.New("private key validation failed: " + err.Error())
 	}
-	stmt, err := sqlair.Prepare(fmt.Sprintf(createPrivateKeyStmt, db.privateKeysTable), PrivateKey{})
+	stmt, err := sqlair.Prepare(createPrivateKeyStmt, PrivateKey{})
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func (db *Database) DeletePrivateKey(filter PrivateKeyFilter) error {
 		return fmt.Errorf("invalid filter identifier: both ID and PEM are nil")
 	}
 
-	stmt, err := sqlair.Prepare(fmt.Sprintf(deletePrivateKeyStmt, db.privateKeysTable), PrivateKey{})
+	stmt, err := sqlair.Prepare(deletePrivateKeyStmt, PrivateKey{})
 	if err != nil {
 		return err
 	}

--- a/internal/db/db_users.go
+++ b/internal/db/db_users.go
@@ -16,7 +16,7 @@ type User struct {
 }
 
 const queryCreateUsersTable = `
-	CREATE TABLE IF NOT EXISTS %s (
+	CREATE TABLE IF NOT EXISTS users (
  		id INTEGER PRIMARY KEY AUTOINCREMENT,
 
 		username TEXT NOT NULL UNIQUE 
@@ -27,17 +27,17 @@ const queryCreateUsersTable = `
 )`
 
 const (
-	listUsersStmt   = "SELECT &User.* from %s"
-	getUserStmt     = "SELECT &User.* from %s WHERE id==$User.id or username==$User.username"
-	createUserStmt  = "INSERT INTO %s (username, hashed_password, permissions) VALUES ($User.username, $User.hashed_password, $User.permissions)"
-	updateUserStmt  = "UPDATE %s SET hashed_password=$User.hashed_password WHERE id==$User.id or username==$User.username"
-	deleteUserStmt  = "DELETE FROM %s WHERE id==$User.id"
-	getNumUsersStmt = "SELECT COUNT(*) AS &NumUsers.count FROM %s"
+	listUsersStmt   = "SELECT &User.* from users"
+	getUserStmt     = "SELECT &User.* from users WHERE id==$User.id or username==$User.username"
+	createUserStmt  = "INSERT INTO users (username, hashed_password, permissions) VALUES ($User.username, $User.hashed_password, $User.permissions)"
+	updateUserStmt  = "UPDATE users SET hashed_password=$User.hashed_password WHERE id==$User.id or username==$User.username"
+	deleteUserStmt  = "DELETE FROM users WHERE id==$User.id"
+	getNumUsersStmt = "SELECT COUNT(*) AS &NumUsers.count FROM users"
 )
 
 // ListUsers returns all of the users and their fields available in the database.
 func (db *Database) ListUsers() ([]User, error) {
-	stmt, err := sqlair.Prepare(fmt.Sprintf(listUsersStmt, db.usersTable), User{})
+	stmt, err := sqlair.Prepare(listUsersStmt, User{})
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (db *Database) GetUser(filter UserFilter) (*User, error) {
 		return nil, fmt.Errorf("invalid filter: both ID and Username are nil")
 	}
 
-	stmt, err := sqlair.Prepare(fmt.Sprintf(getUserStmt, db.usersTable), User{})
+	stmt, err := sqlair.Prepare(getUserStmt, User{})
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (db *Database) CreateUser(username string, password string, permission int)
 	if err != nil {
 		return err
 	}
-	stmt, err := sqlair.Prepare(fmt.Sprintf(createUserStmt, db.usersTable), User{})
+	stmt, err := sqlair.Prepare(createUserStmt, User{})
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (db *Database) UpdateUserPassword(filter UserFilter, password string) error
 	if err != nil {
 		return err
 	}
-	stmt, err := sqlair.Prepare(fmt.Sprintf(updateUserStmt, db.usersTable), User{})
+	stmt, err := sqlair.Prepare(updateUserStmt, User{})
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func (db *Database) DeleteUser(filter UserFilter) error {
 	if err != nil {
 		return err
 	}
-	stmt, err := sqlair.Prepare(fmt.Sprintf(deleteUserStmt, db.usersTable), User{})
+	stmt, err := sqlair.Prepare(deleteUserStmt, User{})
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ type NumUsers struct {
 
 // NumUsers returns the number of users in the database.
 func (db *Database) NumUsers() (int, error) {
-	stmt, err := sqlair.Prepare(fmt.Sprintf(getNumUsersStmt, db.usersTable), NumUsers{})
+	stmt, err := sqlair.Prepare(getNumUsersStmt, NumUsers{})
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
# Description

This PR removes the ability to dynamically set table names. As more and more complex SQL queries are required, the amount of `Sprintf` magic required increases exponentially. Since we don't expect users to clone and change the table names or interact with the table directly at all, we should prioritise developer experience and get rid of these so we can write complex SQL queries easier.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
