### PR TITLE
chore: set TLS minimum version to v1.2

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -63,6 +63,7 @@ func New(port int, cert []byte, key []byte, dbPath string, pebbleNotificationsEn
 		Handler:        router,
 		MaxHeaderBytes: 1 << 20,
 		TLSConfig: &tls.Config{
+			MinVersion:   tls.VersionTLS12,
 			Certificates: []tls.Certificate{serverCerts},
 		},
 	}


### PR DESCRIPTION
# Description

We used to allow any TLS version in our HTTPs server. Here we only allow requests using TLS v1.2 and higher.

This addresses a HIGH severity warning from `gosec`

```shell
[/home/guillaume/code/notary/internal/server/server.go:65-67] - G402 (CWE-295): TLS MinVersion too low. (Confidence: HIGH, Severity: HIGH)
    64:                 MaxHeaderBytes: 1 << 20,
  > 65:                 TLSConfig: &tls.Config{
  > 66:                         Certificates: []tls.Certificate{serverCerts},
  > 67:                 },
    68:         }
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
