### PR TITLE
chore: prevent remote code execution in pebble calls

### DIFF
--- a/internal/server/handlers_certificate_requests.go
+++ b/internal/server/handlers_certificate_requests.go
@@ -168,7 +168,7 @@ func CreateCertificate(env *HandlerConfig) http.HandlerFunc {
 		id := r.PathValue("id")
 		idNum, err := strconv.Atoi(id)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "id is not a number")
+			writeError(w, http.StatusBadRequest, "id is not a number")
 			return
 		}
 		err = env.DB.AddCertificateChainToCertificateRequest(db.ByCSRID(idNum), createCertificateParams.CertificateChain)
@@ -203,7 +203,7 @@ func RejectCertificate(env *HandlerConfig) http.HandlerFunc {
 		id := r.PathValue("id")
 		idNum, err := strconv.Atoi(id)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "Internal Error")
+			writeError(w, http.StatusBadRequest, "id is not a number")
 			return
 		}
 		err = env.DB.RejectCertificateRequest(db.ByCSRID(idNum))

--- a/internal/server/handlers_certificate_requests.go
+++ b/internal/server/handlers_certificate_requests.go
@@ -184,7 +184,7 @@ func CreateCertificate(env *HandlerConfig) http.HandlerFunc {
 			return
 		}
 		if env.SendPebbleNotifications {
-			err := SendPebbleNotification("canonical.com/notary/certificate/update", id)
+			err := SendPebbleNotification(CertificateUpdate, idNum)
 			if err != nil {
 				log.Printf("pebble notify failed: %s. continuing silently.", err.Error())
 			}
@@ -217,7 +217,7 @@ func RejectCertificate(env *HandlerConfig) http.HandlerFunc {
 			return
 		}
 		if env.SendPebbleNotifications {
-			err := SendPebbleNotification("canonical.com/notary/certificate/update", id)
+			err := SendPebbleNotification(CertificateUpdate, idNum)
 			if err != nil {
 				log.Printf("pebble notify failed: %s. continuing silently.", err.Error())
 			}
@@ -252,7 +252,7 @@ func DeleteCertificate(env *HandlerConfig) http.HandlerFunc {
 			return
 		}
 		if env.SendPebbleNotifications {
-			err := SendPebbleNotification("canonical.com/notary/certificate/update", id)
+			err := SendPebbleNotification(CertificateUpdate, idNum)
 			if err != nil {
 				log.Printf("pebble notify failed: %s. continuing silently.", err.Error())
 			}

--- a/internal/server/handlers_certificate_requests.go
+++ b/internal/server/handlers_certificate_requests.go
@@ -168,7 +168,7 @@ func CreateCertificate(env *HandlerConfig) http.HandlerFunc {
 		id := r.PathValue("id")
 		idNum, err := strconv.Atoi(id)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "Internal Error")
+			writeError(w, http.StatusInternalServerError, "id is not a number")
 			return
 		}
 		err = env.DB.AddCertificateChainToCertificateRequest(db.ByCSRID(idNum), createCertificateParams.CertificateChain)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -28,7 +28,7 @@ func (key NotificationKey) String() (string, error) {
 	if key == CertificateUpdate {
 		return "canonical.com/notary/certificate/update", nil
 	}
-	return "", fmt.Errorf("unknown notification key")
+	return "", fmt.Errorf("unknown notification key: %d", key)
 }
 
 func SendPebbleNotification(key NotificationKey, request_id int) error {
@@ -37,7 +37,8 @@ func SendPebbleNotification(key NotificationKey, request_id int) error {
 		return fmt.Errorf("couldn't get a string representation of the notification key: %w", err)
 	}
 	cmd := exec.Command("pebble", "notify", keyStr, fmt.Sprintf("request_id=%v", request_id))
-	if err := cmd.Run(); err != nil {
+	err = cmd.Run()
+	if err != nil {
 		return fmt.Errorf("couldn't execute a pebble notify: %w", err)
 	}
 	return nil

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,8 +18,25 @@ type HandlerConfig struct {
 	JWTSecret               []byte
 }
 
-func SendPebbleNotification(key, request_id string) error {
-	cmd := exec.Command("pebble", "notify", key, fmt.Sprintf("request_id=%s", request_id))
+type NotificationKey int
+
+const (
+	CertificateUpdate NotificationKey = 1
+)
+
+func (key NotificationKey) String() (string, error) {
+	if key == CertificateUpdate {
+		return "canonical.com/notary/certificate/update", nil
+	}
+	return "", fmt.Errorf("unknown notification key")
+}
+
+func SendPebbleNotification(key NotificationKey, request_id int) error {
+	keyStr, err := key.String()
+	if err != nil {
+		return fmt.Errorf("couldn't get a string representation of the notification key: %w", err)
+	}
+	cmd := exec.Command("pebble", "notify", keyStr, fmt.Sprintf("request_id=%v", request_id))
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("couldn't execute a pebble notify: %w", err)
 	}


### PR DESCRIPTION
# Description

It was possible to call `SendPebbleNotification` with values that would trigger unwanted code execution. Example calling it with `key="abc" and request_id="1 && rm -rf /"`

```shell
pebble notify abc 1 && rm -rf /
```

While this was a risk at the local function level, I didn't see an obvious way to achieve it with our current API's since API handlers would make sure that the ID they received were ints. That being said, it's more secure to have the validation much closer to the actual exec call, which is what this PR does.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
