### PR TITLE
docs: fix non-consecutive header levels

### DIFF
--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -2,7 +2,7 @@
 
 In this tutorial, you will learn how to install Notary on a Linux machine and access the Notary UI.
 
-### Prerequisites:
+## Prerequisites:
 
 - A Linux machine that supports snaps
 


### PR DESCRIPTION
# Description

Fix non-consecutive header levels that prevents the docs from building.

Our documentation should build and be published after this PR is merged.

## Logs

```
python -m sphinx -T -W --keep-going -b dirhtml -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html  
Running Sphinx v8.[1](https://app.readthedocs.com/projects/canonical-notary/builds/2805088/#32069125--1).3
loading translations [en]... done
matplotlib is not installed, social cards will not be generated
making output directory... done
myst v4.0.1: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions={'linkify', 'substitution', 'deflist'}, disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=3, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=[2](https://app.readthedocs.com/projects/canonical-notary/builds/2805088/#32069125--2)00, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
building [mo]: targets for 0 po files that are out of date
writing output... 
building [dirhtml]: targets for 16 source files that are out of date
updating environment: [new config] 16 added, 0 changed, 0 removed
reading sources... [  6%] explanation/index
reading sources... [ 12%] how-to/deploy
reading sources... [ 19%] how-to/index
reading sources... [ 25%] index
reading sources... [ [3](https://app.readthedocs.com/projects/canonical-notary/builds/2805088/#32069125--3)1%] reference/api/accounts
reading sources... [ 38%] reference/api/certificate_requests
reading sources... [ [4](https://app.readthedocs.com/projects/canonical-notary/builds/2805088/#32069125--4)4%] reference/api/index
reading sources... [ [5](https://app.readthedocs.com/projects/canonical-notary/builds/2805088/#32069125--5)0%] reference/api/login
reading sources... [ 56%] reference/api/metrics
reading sources... [ 62%] reference/api/status
reading sources... [ 69%] reference/config_file
reading sources... [ 75%] reference/index
reading sources... [ 81%] reference/metrics
reading sources... [ 88%] reference/tls
reading sources... [ 94%] tutorials/getting_started
reading sources... [100%] tutorials/index
/home/docs/checkouts/readthedocs.org/user_builds/canonical-notary/checkouts/latest/docs/tutorials/getting_started.md.rst:5: WARNING: Non-consecutive header level increase; H1 to H3 [myst.header]
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... 
copying static files... 
Writing evaluated template result to /home/docs/checkouts/readthedocs.org/user_builds/canonical-notary/checkouts/latest/_readthedocs/html/_static/basic.css
Writing evaluated template result to /home/docs/checkouts/readthedocs.org/user_builds/canonical-notary/checkouts/latest/_readthedocs/html/_static/language_data.js
Writing evaluated template result to /home/docs/checkouts/readthedocs.org/user_builds/canonical-notary/checkouts/latest/_readthedocs/html/_static/documentation_options.js
Writing evaluated template result to /home/docs/checkouts/readthedocs.org/user_builds/canonical-notary/checkouts/latest/_readthedocs/html/_static/copybutton.js
copying static files: done
copying extra files... 
copying extra files: done
copying assets: done
writing output... [  [6](https://app.readthedocs.com/projects/canonical-notary/builds/2805088/#32069125--6)%] explanation/index
writing output... [ 12%] how-to/deploy
writing output... [ 19%] how-to/index
writing output... [ 25%] index
writing output... [ 31%] reference/api/accounts
writing output... [ 38%] reference/api/certificate_requests
writing output... [ 44%] reference/api/index
writing output... [ 50%] reference/api/login
writing output... [ 56%] reference/api/metrics
writing output... [ 62%] reference/api/status
writing output... [ 69%] reference/config_file
writing output... [ [7](https://app.readthedocs.com/projects/canonical-notary/builds/2805088/#32069125--7)5%] reference/index
writing output... [ [8](https://app.readthedocs.com/projects/canonical-notary/builds/2805088/#32069125--8)1%] reference/metrics
writing output... [ 88%] reference/tls
writing output... [ [9](https://app.readthedocs.com/projects/canonical-notary/builds/2805088/#32069125--9)4%] tutorials/getting_started
writing output... [100%] tutorials/index
generating indices... genindex done
writing additional pages... search done
copying images... [ 50%] images/initialize.png
copying images... [[10](https://app.readthedocs.com/projects/canonical-notary/builds/2805088/#32069125--10)0%] images/certificate_requests.png
dumping search index in English (code: en)... done
dumping object inventory... done
build finished with problems, 1 warning (with warnings treated as errors).
```

## Screenshot

![image](https://github.com/user-attachments/assets/6819f539-9dc6-4fe9-8723-b545337aa6aa)


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
