### PR TITLE
chore: use int64 instead of int for DB ID fields

### DIFF
--- a/internal/db/db_certificate_authorities.go
+++ b/internal/db/db_certificate_authorities.go
@@ -30,9 +30,9 @@ type CertificateAuthority struct {
 
 	Status CAStatus `db:"status"`
 
-	PrivateKeyID  int `db:"private_key_id"`
-	CertificateID int `db:"certificate_id"`
-	CSRID         int `db:"csr_id"`
+	PrivateKeyID  int   `db:"private_key_id"`
+	CertificateID int64 `db:"certificate_id"`
+	CSRID         int   `db:"csr_id"`
 }
 type CertificateAuthorityDenormalized struct {
 	CertificateAuthorityID int      `db:"certificate_authority_id"`

--- a/internal/db/db_certificate_authorities.go
+++ b/internal/db/db_certificate_authorities.go
@@ -26,16 +26,16 @@ const (
 )
 
 type CertificateAuthority struct {
-	CertificateAuthorityID int `db:"certificate_authority_id"`
+	CertificateAuthorityID int64 `db:"certificate_authority_id"`
 
 	Status CAStatus `db:"status"`
 
-	PrivateKeyID  int   `db:"private_key_id"`
+	PrivateKeyID  int64 `db:"private_key_id"`
 	CertificateID int64 `db:"certificate_id"`
-	CSRID         int   `db:"csr_id"`
+	CSRID         int64 `db:"csr_id"`
 }
 type CertificateAuthorityDenormalized struct {
-	CertificateAuthorityID int      `db:"certificate_authority_id"`
+	CertificateAuthorityID int64    `db:"certificate_authority_id"`
 	Status                 CAStatus `db:"status"`
 	PrivateKeyPEM          string   `db:"private_key"`
 	CertificatePEM         string   `db:"certificate"`

--- a/internal/db/db_certificates.go
+++ b/internal/db/db_certificates.go
@@ -107,7 +107,7 @@ func (db *Database) AddCertificateChainToCertificateRequest(csrFilter CSRFilter,
 	if err != nil {
 		return errors.New("cert validation failed: " + err.Error())
 	}
-	parentID := int64(0)
+	var parentID int64 = 0
 	if isSelfSigned(certBundle) {
 		certRow := Certificate{
 			IssuerID:       0,

--- a/internal/db/db_csrs.go
+++ b/internal/db/db_csrs.go
@@ -13,7 +13,7 @@ type CertificateRequest struct {
 
 	CSR           string `db:"csr"`
 	Status        string `db:"status"`
-	CertificateID int    `db:"certificate_id"`
+	CertificateID int64  `db:"certificate_id"`
 }
 
 type CertificateRequestWithChain struct {

--- a/internal/db/db_csrs.go
+++ b/internal/db/db_csrs.go
@@ -9,7 +9,7 @@ import (
 )
 
 type CertificateRequest struct {
-	CSR_ID int `db:"csr_id"`
+	CSR_ID int64 `db:"csr_id"`
 
 	CSR           string `db:"csr"`
 	Status        string `db:"status"`
@@ -17,7 +17,7 @@ type CertificateRequest struct {
 }
 
 type CertificateRequestWithChain struct {
-	CSR_ID int `db:"csr_id"`
+	CSR_ID int64 `db:"csr_id"`
 
 	CSR              string `db:"csr"`
 	Status           string `db:"status"`

--- a/internal/db/db_private_keys.go
+++ b/internal/db/db_private_keys.go
@@ -9,7 +9,7 @@ import (
 )
 
 type PrivateKey struct {
-	PrivateKeyID int `db:"private_key_id"`
+	PrivateKeyID int64 `db:"private_key_id"`
 
 	PrivateKeyPEM string `db:"private_key"`
 }

--- a/internal/db/db_users.go
+++ b/internal/db/db_users.go
@@ -8,7 +8,7 @@ import (
 )
 
 type User struct {
-	ID int `db:"id"`
+	ID int64 `db:"id"`
 
 	Username       string `db:"username"`
 	HashedPassword string `db:"hashed_password"`

--- a/internal/db/filter.go
+++ b/internal/db/filter.go
@@ -16,11 +16,11 @@ func ByCertificatePEM(pem string) CertificateFilter {
 }
 
 type CSRFilter struct {
-	ID  *int
+	ID  *int64
 	PEM *string
 }
 
-func ByCSRID(id int) CSRFilter {
+func ByCSRID(id int64) CSRFilter {
 	return CSRFilter{ID: &id}
 }
 
@@ -29,11 +29,11 @@ func ByCSRPEM(pem string) CSRFilter {
 }
 
 type UserFilter struct {
-	ID       *int
+	ID       *int64
 	Username *string
 }
 
-func ByUserID(id int) UserFilter {
+func ByUserID(id int64) UserFilter {
 	return UserFilter{ID: &id}
 }
 
@@ -42,11 +42,11 @@ func ByUsername(username string) UserFilter {
 }
 
 type PrivateKeyFilter struct {
-	ID  *int
+	ID  *int64
 	PEM *string
 }
 
-func ByPrivateKeyID(id int) PrivateKeyFilter {
+func ByPrivateKeyID(id int64) PrivateKeyFilter {
 	return PrivateKeyFilter{ID: &id}
 }
 
@@ -55,16 +55,16 @@ func ByPrivateKeyPEM(pem string) PrivateKeyFilter {
 }
 
 type CertificateAuthorityFilter struct {
-	ID     *int
-	CSRID  *int
+	ID     *int64
+	CSRID  *int64
 	CSRPEM *string
 }
 
-func ByCertificateAuthorityID(id int) CertificateAuthorityFilter {
+func ByCertificateAuthorityID(id int64) CertificateAuthorityFilter {
 	return CertificateAuthorityFilter{ID: &id}
 }
 
-func ByCertificateAuthorityCSRID(id int) CertificateAuthorityFilter {
+func ByCertificateAuthorityCSRID(id int64) CertificateAuthorityFilter {
 	return CertificateAuthorityFilter{CSRID: &id}
 }
 

--- a/internal/db/filter.go
+++ b/internal/db/filter.go
@@ -3,11 +3,11 @@ package db
 import "fmt"
 
 type CertificateFilter struct {
-	ID  *int
+	ID  *int64
 	PEM *string
 }
 
-func ByCertificateID(id int) CertificateFilter {
+func ByCertificateID(id int64) CertificateFilter {
 	return CertificateFilter{ID: &id}
 }
 

--- a/internal/server/handlers_accounts.go
+++ b/internal/server/handlers_accounts.go
@@ -23,7 +23,7 @@ type ChangeAccountParams struct {
 }
 
 type GetAccountResponse struct {
-	ID          int    `json:"id"`
+	ID          int64  `json:"id"`
 	Username    string `json:"username"`
 	Permissions int    `json:"permissions"`
 }
@@ -84,8 +84,8 @@ func GetAccount(env *HandlerConfig) http.HandlerFunc {
 			}
 			account, err = env.DB.GetUser(db.ByUsername(claims.Username))
 		} else {
-			var idNum int
-			idNum, err = strconv.Atoi(id)
+			var idNum int64
+			idNum, err = strconv.ParseInt(id, 10, 64)
 			if err != nil {
 				writeError(w, http.StatusInternalServerError, "Internal Error")
 				return
@@ -171,7 +171,7 @@ func CreateAccount(env *HandlerConfig) http.HandlerFunc {
 func DeleteAccount(env *HandlerConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("id")
-		idInt, err := strconv.Atoi(id)
+		idInt, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
 			log.Println(err)
 			writeError(w, http.StatusInternalServerError, "Internal Error")
@@ -213,7 +213,7 @@ func DeleteAccount(env *HandlerConfig) http.HandlerFunc {
 func ChangeAccountPassword(env *HandlerConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("id")
-		var idNum int
+		var idNum int64
 		if id == "me" {
 			claims, err := getClaimsFromAuthorizationHeader(r.Header.Get("Authorization"), env.JWTSecret)
 			if err != nil {
@@ -229,7 +229,7 @@ func ChangeAccountPassword(env *HandlerConfig) http.HandlerFunc {
 			}
 			idNum = account.ID
 		} else {
-			idInt, err := strconv.Atoi(id)
+			idInt, err := strconv.ParseInt(id, 10, 64)
 			if err != nil {
 				log.Println(err)
 				writeError(w, http.StatusInternalServerError, "Internal Error")

--- a/internal/server/handlers_certificate_authorities.go
+++ b/internal/server/handlers_certificate_authorities.go
@@ -20,7 +20,7 @@ import (
 )
 
 type CertificateAuthority struct {
-	CertificateAuthorityID int         `json:"certificate_authority_id"`
+	CertificateAuthorityID int64       `json:"certificate_authority_id"`
 	Status                 db.CAStatus `json:"status"`
 	PrivateKeyPEM          string      `json:"private_key,omitempty"`
 	CertificatePEM         string      `json:"certificate"`
@@ -213,7 +213,7 @@ func CreateCertificateAuthority(env *HandlerConfig) http.HandlerFunc {
 func GetCertificateAuthority(env *HandlerConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("id")
-		idNum, err := strconv.Atoi(id)
+		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "Internal Error")
 			return
@@ -251,7 +251,7 @@ func GetCertificateAuthority(env *HandlerConfig) http.HandlerFunc {
 func UpdateCertificateAuthority(env *HandlerConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("id")
-		idNum, err := strconv.Atoi(id)
+		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "Internal Error")
 			return
@@ -288,7 +288,7 @@ func UpdateCertificateAuthority(env *HandlerConfig) http.HandlerFunc {
 func DeleteCertificateAuthority(env *HandlerConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("id")
-		idNum, err := strconv.Atoi(id)
+		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "Internal Error")
 			return
@@ -312,7 +312,7 @@ func DeleteCertificateAuthority(env *HandlerConfig) http.HandlerFunc {
 func PostCertificateAuthorityCertificate(env *HandlerConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("id")
-		idNum, err := strconv.Atoi(id)
+		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "Internal Error")
 			return

--- a/internal/server/handlers_certificate_requests.go
+++ b/internal/server/handlers_certificate_requests.go
@@ -21,7 +21,7 @@ type CreateCertificateParams struct {
 }
 
 type CertificateRequest struct {
-	ID               int    `json:"id"`
+	ID               int64  `json:"id"`
 	CSR              string `json:"csr"`
 	CertificateChain string `json:"certificate_chain"`
 	Status           string `json:"status"`
@@ -94,7 +94,7 @@ func CreateCertificateRequest(env *HandlerConfig) http.HandlerFunc {
 func GetCertificateRequest(env *HandlerConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("id")
-		idNum, err := strconv.Atoi(id)
+		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "Internal Error")
 			return
@@ -128,7 +128,7 @@ func GetCertificateRequest(env *HandlerConfig) http.HandlerFunc {
 func DeleteCertificateRequest(env *HandlerConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("id")
-		idNum, err := strconv.Atoi(id)
+		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "Internal Error")
 			return
@@ -166,7 +166,7 @@ func CreateCertificate(env *HandlerConfig) http.HandlerFunc {
 			return
 		}
 		id := r.PathValue("id")
-		idNum, err := strconv.Atoi(id)
+		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, "id is not a number")
 			return
@@ -203,7 +203,7 @@ func CreateCertificate(env *HandlerConfig) http.HandlerFunc {
 func RejectCertificateRequest(env *HandlerConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("id")
-		idNum, err := strconv.Atoi(id)
+		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, "id is not a number")
 			return
@@ -238,7 +238,7 @@ func RejectCertificateRequest(env *HandlerConfig) http.HandlerFunc {
 func DeleteCertificate(env *HandlerConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("id")
-		idNum, err := strconv.Atoi(id)
+		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "Internal Error")
 			return
@@ -274,7 +274,7 @@ func DeleteCertificate(env *HandlerConfig) http.HandlerFunc {
 func RevokeCertificate(env *HandlerConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("id")
-		idNum, err := strconv.Atoi(id)
+		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "Internal Error")
 			return

--- a/internal/server/handlers_login.go
+++ b/internal/server/handlers_login.go
@@ -18,7 +18,7 @@ func expireAfter() int64 {
 }
 
 type jwtNotaryClaims struct {
-	ID          int    `json:"id"`
+	ID          int64  `json:"id"`
 	Username    string `json:"username"`
 	Permissions int    `json:"permissions"`
 	jwt.StandardClaims
@@ -34,7 +34,7 @@ type LoginResponse struct {
 }
 
 // Helper function to generate a JWT
-func generateJWT(id int, username string, jwtSecret []byte, permissions int) (string, error) {
+func generateJWT(id int64, username string, jwtSecret []byte, permissions int) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwtNotaryClaims{
 		ID:          id,
 		Username:    username,

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -124,7 +124,7 @@ func adminOrMe(jwtSecret []byte, handler func(http.ResponseWriter, *http.Request
 		}
 
 		if claims.Permissions != AdminPermission {
-			if r.PathValue("id") != "me" && strconv.Itoa(claims.ID) != r.PathValue("id") {
+			if r.PathValue("id") != "me" && strconv.FormatInt(claims.ID, 10) != r.PathValue("id") {
 				writeError(w, http.StatusForbidden, "forbidden: admin access required")
 				return
 			}
@@ -211,7 +211,7 @@ func AllowRequest(claims *jwtNotaryClaims, method, path string) (bool, error) {
 		if !pr.SelfAuthorizedAllowed {
 			return false, nil
 		}
-		matchedID, err := strconv.Atoi(matches[1])
+		matchedID, err := strconv.ParseInt(matches[1], 10, 64)
 		if err != nil {
 			return true, fmt.Errorf("error converting url id to string: %s", err)
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,7 +31,7 @@ func (key NotificationKey) String() (string, error) {
 	return "", fmt.Errorf("unknown notification key: %d", key)
 }
 
-func SendPebbleNotification(key NotificationKey, request_id int) error {
+func SendPebbleNotification(key NotificationKey, request_id int64) error {
 	keyStr, err := key.String()
 	if err != nil {
 		return fmt.Errorf("couldn't get a string representation of the notification key: %w", err)


### PR DESCRIPTION
# Description

This was a mistake from a while ago where I didn't know that all database connectors in go use int64 for ID fields. This change reflects that in our data structs.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
