### PR TITLE
chore: update go version to 1.24

### DIFF
--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -13,6 +13,6 @@ jobs:
           go-version-file: "go.mod"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v6.4.0
         with:
-          version: v1.63
+          version: v1.64.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/notary
 
-go 1.22.1
+go 1.24.0
 
 require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible

--- a/internal/db/db_certificates.go
+++ b/internal/db/db_certificates.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/canonical/sqlair"
 )
@@ -139,10 +140,10 @@ func (db *Database) AddCertificateChainToCertificateRequest(csrFilter CSRFilter,
 		parentID = int(childID)
 	} else {
 		// Otherwise, go through the certificate chain in reverse and add certs as their parents
-		for i := len(certBundle) - 1; i >= 0; i-- {
+		for _, v := range slices.Backward(certBundle) {
 			certRow := Certificate{
 				IssuerID:       parentID,
-				CertificatePEM: certBundle[i],
+				CertificatePEM: v,
 			}
 			stmt, err := sqlair.Prepare(fmt.Sprintf(getCertificateStmt, db.certificatesTable), Certificate{})
 			if err != nil {

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -22,7 +22,7 @@ parts:
     source: .
     source-type: local
     build-snaps:
-      - go/1.22/stable
+      - go/1.24/stable
       - node/20/stable
     override-build: |
       npm install --prefix ui

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,7 +36,7 @@ parts:
     source: .
     source-type: local
     build-snaps:
-      - go/1.22/stable
+      - go/1.24/stable
       - node/20/stable
     override-build: |
       npm install --prefix ui


### PR DESCRIPTION
# Description

Notary is still stuck in Go 1.22. Version 1.24 came out 3 days ago, so this PR updates Notary to that. It also includes a tiny change using a feature that was introduced in 1.23.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
