### PR TITLE
feat: add API input validation and return appropriate HTTP status code

### DIFF
--- a/internal/db/db_certificate_authorities_test.go
+++ b/internal/db/db_certificate_authorities_test.go
@@ -270,7 +270,6 @@ func TestRootCertificateAuthorityEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't delete certificate authority: %s", err)
 	}
-
 }
 
 func TestIntermediateCertificateAuthorityEndToEnd(t *testing.T) {

--- a/internal/server/handlers_accounts.go
+++ b/internal/server/handlers_accounts.go
@@ -87,7 +87,7 @@ func GetAccount(env *HandlerConfig) http.HandlerFunc {
 			var idNum int64
 			idNum, err = strconv.ParseInt(id, 10, 64)
 			if err != nil {
-				writeError(w, http.StatusInternalServerError, "Internal Error")
+				writeError(w, http.StatusBadRequest, "Invalid ID")
 				return
 			}
 			account, err = env.DB.GetUser(db.ByUserID(idNum))
@@ -174,7 +174,7 @@ func DeleteAccount(env *HandlerConfig) http.HandlerFunc {
 		idInt, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
 			log.Println(err)
-			writeError(w, http.StatusInternalServerError, "Internal Error")
+			writeError(w, http.StatusBadRequest, "Invalid ID")
 			return
 		}
 		account, err := env.DB.GetUser(db.ByUserID(idInt))
@@ -232,7 +232,7 @@ func ChangeAccountPassword(env *HandlerConfig) http.HandlerFunc {
 			idInt, err := strconv.ParseInt(id, 10, 64)
 			if err != nil {
 				log.Println(err)
-				writeError(w, http.StatusInternalServerError, "Internal Error")
+				writeError(w, http.StatusBadRequest, "Invalid ID")
 				return
 			}
 			idNum = idInt

--- a/internal/server/handlers_certificate_authorities.go
+++ b/internal/server/handlers_certificate_authorities.go
@@ -74,7 +74,7 @@ func (updateCAParams *UpdateCertificateAuthorityParams) IsValid() (bool, error) 
 		return false, errors.New("status is required")
 	}
 	if updateCAParams.Status != db.CAActive && updateCAParams.Status != db.CAExpired && updateCAParams.Status != db.CAPending && updateCAParams.Status != db.CALegacy {
-		return false, fmt.Errorf("Invalid status. Status must be one of %s, %s, %s, %s", db.CAActive, db.CAExpired, db.CAPending, db.CALegacy)
+		return false, fmt.Errorf("invalid status: status must be one of %s, %s, %s, %s", db.CAActive, db.CAExpired, db.CAPending, db.CALegacy)
 	}
 	return true, nil
 }

--- a/internal/server/handlers_certificate_authorities.go
+++ b/internal/server/handlers_certificate_authorities.go
@@ -80,25 +80,21 @@ func (updateCAParams *UpdateCertificateAuthorityParams) IsValid() (bool, error) 
 }
 
 func (params *UploadCertificateToCertificateAuthorityParams) IsValid() (bool, error) {
-	// Certificate chain must not be empty.
 	if strings.TrimSpace(params.CertificateChain) == "" {
 		return false, errors.New("certificate_chain is required")
 	}
 
-	// Parse the PEM blocks from the certificate chain.
 	rest := []byte(params.CertificateChain)
 	var found bool
 	for {
 		var block *pem.Block
 		block, rest = pem.Decode(rest)
 		if block == nil {
-			break // no more PEM blocks
+			break
 		}
-		// Ensure that this is a certificate PEM block.
 		if block.Type != "CERTIFICATE" {
 			return false, fmt.Errorf("unexpected PEM block type: %s, expected CERTIFICATE", block.Type)
 		}
-		// Attempt to parse the certificate to validate its correctness.
 		_, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {
 			return false, fmt.Errorf("failed to parse certificate: %v", err)

--- a/internal/server/handlers_certificate_authorities.go
+++ b/internal/server/handlers_certificate_authorities.go
@@ -215,7 +215,7 @@ func GetCertificateAuthority(env *HandlerConfig) http.HandlerFunc {
 		id := r.PathValue("id")
 		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "Internal Error")
+			writeError(w, http.StatusBadRequest, "Invalid ID")
 			return
 		}
 
@@ -253,7 +253,7 @@ func UpdateCertificateAuthority(env *HandlerConfig) http.HandlerFunc {
 		id := r.PathValue("id")
 		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "Internal Error")
+			writeError(w, http.StatusBadRequest, "Invalid ID")
 			return
 		}
 
@@ -290,7 +290,7 @@ func DeleteCertificateAuthority(env *HandlerConfig) http.HandlerFunc {
 		id := r.PathValue("id")
 		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "Internal Error")
+			writeError(w, http.StatusBadRequest, "Invalid ID")
 			return
 		}
 
@@ -304,6 +304,12 @@ func DeleteCertificateAuthority(env *HandlerConfig) http.HandlerFunc {
 			writeError(w, http.StatusInternalServerError, "Internal Error")
 			return
 		}
+		successResponse := SuccessResponse{Message: "success"}
+		err = writeResponse(w, successResponse, http.StatusOK)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal error")
+			return
+		}
 	}
 }
 
@@ -314,7 +320,7 @@ func PostCertificateAuthorityCertificate(env *HandlerConfig) http.HandlerFunc {
 		id := r.PathValue("id")
 		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "Internal Error")
+			writeError(w, http.StatusBadRequest, "Invalid ID")
 			return
 		}
 		var UploadCertificateToCertificateAuthorityParams UploadCertificateToCertificateAuthorityParams

--- a/internal/server/handlers_certificate_authorities.go
+++ b/internal/server/handlers_certificate_authorities.go
@@ -93,7 +93,7 @@ func (params *UploadCertificateToCertificateAuthorityParams) IsValid() (bool, er
 			break
 		}
 		if block.Type != "CERTIFICATE" {
-			return false, fmt.Errorf("unexpected PEM block type: %s, expected CERTIFICATE", block.Type)
+			return false, fmt.Errorf("unexpected PEM block type: expected CERTIFICATE")
 		}
 		_, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {

--- a/internal/server/handlers_certificate_authorities_test.go
+++ b/internal/server/handlers_certificate_authorities_test.go
@@ -761,7 +761,7 @@ func TestUploadCertificateToCertificateAuthorityInvalidInputs(t *testing.T) {
 			certificateChain: `-----BEGIN PRIVATE KEY-----
 MIIBVwIBADANBgkqhkiG9w0BAQEFAASCAT8wggE7AgEAAkEAuQ==
 -----END PRIVATE KEY-----`,
-			expectedError: "Invalid request: unexpected PEM block type: PRIVATE KEY, expected CERTIFICATE",
+			expectedError: "Invalid request: unexpected PEM block type: expected CERTIFICATE",
 		},
 		{
 			testName: "Invalid certificate PEM content",

--- a/internal/server/handlers_certificate_authorities_test.go
+++ b/internal/server/handlers_certificate_authorities_test.go
@@ -105,12 +105,29 @@ nCSo5Rj3yTrtNYFLnu+iLCvMb5PcJXE55Pu5OYGktHnvMgc=
 -----END CERTIFICATE-----`
 )
 
+type CreateCertificateAuthorityParams struct {
+	SelfSigned bool `json:"self_signed"`
+
+	CommonName          string `json:"common_name"`
+	SANsDNS             string `json:"sans_dns"`
+	CountryName         string `json:"country_name"`
+	StateOrProvinceName string `json:"state_or_province_name"`
+	LocalityName        string `json:"locality_name"`
+	OrganizationName    string `json:"organization_name"`
+	OrganizationalUnit  string `json:"organizational_unit_name"`
+	NotValidAfter       string `json:"not_valid_after"`
+}
+
+type UpdateCertificateAuthorityParams struct {
+	Status string `json:"status,omitempty"`
+}
+
 type CreateCertificateAuthorityResponse struct {
 	Result SuccessResponse `json:"result"`
 	Error  string          `json:"error,omitempty"`
 }
 
-func createCertificateAuthority(url string, client *http.Client, adminToken string, ca server.CreateCertificateAuthorityParams) (int, *CreateCertificateAuthorityResponse, error) {
+func createCertificateAuthority(url string, client *http.Client, adminToken string, ca CreateCertificateAuthorityParams) (int, *CreateCertificateAuthorityResponse, error) {
 	reqData, err := json.Marshal(ca)
 	if err != nil {
 		return 0, nil, err
@@ -181,7 +198,7 @@ type UpdateCertificateAuthorityResponse struct {
 	Error  string          `json:"error,omitempty"`
 }
 
-func updateCertificateAuthority(url string, client *http.Client, adminToken string, id int, status server.UpdateCertificateAuthorityParams) (int, *UpdateCertificateAuthorityResponse, error) {
+func updateCertificateAuthority(url string, client *http.Client, adminToken string, id int, status UpdateCertificateAuthorityParams) (int, *UpdateCertificateAuthorityResponse, error) {
 	reqData, err := json.Marshal(status)
 	if err != nil {
 		return 0, nil, err
@@ -275,7 +292,7 @@ func TestSelfSignedCertificateAuthorityEndToEnd(t *testing.T) {
 	})
 
 	t.Run("2. Create self signed certificate authority", func(t *testing.T) {
-		createCertificatAuthorityParams := server.CreateCertificateAuthorityParams{
+		createCertificatAuthorityParams := CreateCertificateAuthorityParams{
 			SelfSigned: true,
 
 			CommonName:          "Self Signed CA",
@@ -322,7 +339,7 @@ func TestSelfSignedCertificateAuthorityEndToEnd(t *testing.T) {
 	})
 
 	t.Run("4. Make a new Intermediate CA", func(t *testing.T) {
-		createCertificatAuthorityParams := server.CreateCertificateAuthorityParams{
+		createCertificatAuthorityParams := CreateCertificateAuthorityParams{
 			SelfSigned: false,
 
 			CommonName:          "Not Self Signed CA",
@@ -429,7 +446,7 @@ func TestSelfSignedCertificateAuthorityEndToEnd(t *testing.T) {
 		}
 	})
 	t.Run("9. Make first CA legacy", func(t *testing.T) {
-		statusCode, makeLegacyResponse, err := updateCertificateAuthority(ts.URL, client, adminToken, 1, server.UpdateCertificateAuthorityParams{Status: "legacy"})
+		statusCode, makeLegacyResponse, err := updateCertificateAuthority(ts.URL, client, adminToken, 1, UpdateCertificateAuthorityParams{Status: "legacy"})
 		if err != nil {
 			t.Fatal("expected no error, got: ", err)
 		}
@@ -522,4 +539,173 @@ func signCSR(csr string) string {
 	})
 
 	return certPEM.String()
+}
+
+func TestCreateCertificateAuthorityInvalidInputs(t *testing.T) {
+	tempDir := t.TempDir()
+	db_path := filepath.Join(tempDir, "db.sqlite3")
+	ts, _, err := setupServer(db_path)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer ts.Close()
+	client := ts.Client()
+
+	var adminToken string
+	var nonAdminToken string
+	t.Run("prepare user accounts and tokens", prepareAccounts(ts.URL, client, &adminToken, &nonAdminToken))
+
+	tests := []struct {
+		testName            string
+		selfSigned          bool
+		commonName          string
+		sansDNS             string
+		countryName         string
+		stateOrProvinceName string
+		localityName        string
+		organizationName    string
+		organizationalUnit  string
+		notValidAfter       string
+		error               string
+	}{
+		{
+			testName:            "Invalid Country Name - too long",
+			selfSigned:          true,
+			commonName:          "canonical.com",
+			sansDNS:             "ubuntu.com",
+			countryName:         "Canada",
+			stateOrProvinceName: "Quebec",
+			localityName:        "Montreal",
+			organizationName:    "Canonical",
+			organizationalUnit:  "Identity",
+			notValidAfter:       "2030-01-01T00:00:00Z",
+
+			error: "Invalid request: country_name must be a 2-letter ISO code",
+		},
+		{
+			testName:            "Invalid notValidAfter format - Not RFC3339",
+			selfSigned:          true,
+			commonName:          "canonical.com",
+			sansDNS:             "ubuntu.com",
+			countryName:         "CA",
+			stateOrProvinceName: "Quebec",
+			localityName:        "Montreal",
+			organizationName:    "Canonical",
+			organizationalUnit:  "Identity",
+			notValidAfter:       "2010-01-01 00:00:00Z",
+
+			error: "Invalid request: not_valid_after must be a valid RFC3339 timestamp",
+		},
+		{
+			testName:            "Invalid notValidAfter format - Past time",
+			selfSigned:          true,
+			commonName:          "canonical.com",
+			sansDNS:             "ubuntu.com",
+			countryName:         "CA",
+			stateOrProvinceName: "Quebec",
+			localityName:        "Montreal",
+			organizationName:    "Canonical",
+			organizationalUnit:  "Identity",
+			notValidAfter:       "2010-01-01T00:00:00Z",
+
+			error: "Invalid request: not_valid_after must be a future time",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			createCertificateAuthorityRequest := CreateCertificateAuthorityParams{
+				SelfSigned:          test.selfSigned,
+				CommonName:          test.commonName,
+				SANsDNS:             test.sansDNS,
+				CountryName:         test.countryName,
+				StateOrProvinceName: test.stateOrProvinceName,
+				LocalityName:        test.localityName,
+				OrganizationName:    test.organizationName,
+				OrganizationalUnit:  test.organizationalUnit,
+				NotValidAfter:       test.notValidAfter,
+			}
+			statusCode, createCertResponse, err := createCertificateAuthority(ts.URL, client, adminToken, createCertificateAuthorityRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if statusCode != http.StatusBadRequest {
+				t.Fatalf("expected status %d, got %d", http.StatusBadRequest, statusCode)
+			}
+			if createCertResponse.Error != test.error {
+				t.Fatalf("expected error %s, got %s", test.error, createCertResponse.Error)
+			}
+		})
+	}
+
+}
+
+func TestUpdateCertificateAuthorityParamsInvalidInputs(t *testing.T) {
+	tempDir := t.TempDir()
+	db_path := filepath.Join(tempDir, "db.sqlite3")
+	ts, _, err := setupServer(db_path)
+	if err != nil {
+		t.Fatalf("couldn't create test server: %s", err)
+	}
+	defer ts.Close()
+	client := ts.Client()
+
+	var adminToken string
+	var nonAdminToken string
+	t.Run("prepare user accounts and tokens", prepareAccounts(ts.URL, client, &adminToken, &nonAdminToken))
+
+	// create a self signed CA
+	createCertificatAuthorityParams := CreateCertificateAuthorityParams{
+		SelfSigned: true,
+		CommonName: "Self Signed CA",
+		SANsDNS:    "example.com",
+	}
+
+	statusCode, createCAResponse, err := createCertificateAuthority(ts.URL, client, adminToken, createCertificatAuthorityParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if statusCode != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d", http.StatusCreated, statusCode)
+	}
+
+	if createCAResponse.Error != "" {
+		t.Fatalf("expected success, got %s", createCAResponse.Error)
+	}
+
+	tests := []struct {
+		testName string
+		status   string
+		error    string
+	}{
+		{
+			testName: "Invalid Status - not supported",
+			status:   "pizza",
+			error:    "Invalid request: Invalid status. Status must be one of active, expired, pending, legacy",
+		},
+		{
+			testName: "Invalid Status - no status",
+			status:   "",
+			error:    "Invalid request: status is required",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			updateCertificateAuthorityRequest := UpdateCertificateAuthorityParams{
+				Status: test.status,
+			}
+			statusCode, createCertResponse, err := updateCertificateAuthority(ts.URL, client, adminToken, 1, updateCertificateAuthorityRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if statusCode != http.StatusBadRequest {
+				t.Fatalf("expected status %d, got %d", http.StatusBadRequest, statusCode)
+			}
+			if createCertResponse.Error != test.error {
+				t.Fatalf("expected error %s, got %s", test.error, createCertResponse.Error)
+			}
+		})
+	}
 }

--- a/internal/server/handlers_certificate_authorities_test.go
+++ b/internal/server/handlers_certificate_authorities_test.go
@@ -681,7 +681,7 @@ func TestUpdateCertificateAuthorityParamsInvalidInputs(t *testing.T) {
 		{
 			testName: "Invalid Status - not supported",
 			status:   "pizza",
-			error:    "Invalid request: Invalid status. Status must be one of active, expired, pending, legacy",
+			error:    "Invalid request: invalid status: status must be one of active, expired, pending, legacy",
 		},
 		{
 			testName: "Invalid Status - no status",

--- a/internal/server/handlers_certificate_requests.go
+++ b/internal/server/handlers_certificate_requests.go
@@ -96,7 +96,7 @@ func GetCertificateRequest(env *HandlerConfig) http.HandlerFunc {
 		id := r.PathValue("id")
 		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "Internal Error")
+			writeError(w, http.StatusBadRequest, "Invalid ID")
 			return
 		}
 		csr, err := env.DB.GetCertificateRequestAndChain(db.ByCSRID(idNum))
@@ -168,7 +168,7 @@ func CreateCertificate(env *HandlerConfig) http.HandlerFunc {
 		id := r.PathValue("id")
 		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "id is not a number")
+			writeError(w, http.StatusBadRequest, "Invalid ID")
 			return
 		}
 		err = env.DB.AddCertificateChainToCertificateRequest(db.ByCSRID(idNum), createCertificateParams.CertificateChain)
@@ -205,7 +205,7 @@ func RejectCertificateRequest(env *HandlerConfig) http.HandlerFunc {
 		id := r.PathValue("id")
 		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "id is not a number")
+			writeError(w, http.StatusBadRequest, "Invalid ID")
 			return
 		}
 		err = env.DB.RejectCertificateRequest(db.ByCSRID(idNum))
@@ -240,7 +240,7 @@ func DeleteCertificate(env *HandlerConfig) http.HandlerFunc {
 		id := r.PathValue("id")
 		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "Internal Error")
+			writeError(w, http.StatusBadRequest, "Invalid ID")
 			return
 		}
 		err = env.DB.DeleteCertificateRequest(db.ByCSRID(idNum))
@@ -276,7 +276,7 @@ func RevokeCertificate(env *HandlerConfig) http.HandlerFunc {
 		id := r.PathValue("id")
 		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "Internal Error")
+			writeError(w, http.StatusBadRequest, "Invalid ID")
 			return
 		}
 		err = env.DB.RevokeCertificate(db.ByCSRID(idNum))

--- a/internal/server/handlers_certificate_requests_test.go
+++ b/internal/server/handlers_certificate_requests_test.go
@@ -158,7 +158,6 @@ func rejectCertificate(url string, client *http.Client, adminToken string, id in
 // The order of the tests is important, as some tests depend on the
 // state of the server after previous tests.
 func TestCertificateRequestsEndToEnd(t *testing.T) {
-
 	tempDir := t.TempDir()
 	db_path := filepath.Join(tempDir, "db.sqlite3")
 	ts, _, err := setupServer(db_path)


### PR DESCRIPTION
# Description

We shouldn't return a 500 error code when the issue comes from the user input. The 400 Bad Request status code is more appropriate and informative in that context. Here, we add proper HTTP API input validation and return a relevant and informative status code when the input is invalid. For now, the changes have only been made for the CA endpoints. Once this PR is approved and merged, I will apply the same approach for all of our endpoints. 

Fixes #170 
Fixes #172 

## Before and after

Here we have the before and after returns when making a PUT call to change the status of a Certificate Authority. 

**Before**

```
Status: 500 Internal error
Response:
{
    "error": "Internal Error"
}
```

**After**

```
Status: 400 Bad Request
Response:
{
    "error": "Invalid request: invalid status: status must be one of active, expired, pending, legacy"
}
```
# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
