### PR TITLE
fix: infinite certificate loop

### DIFF
--- a/internal/db/db_certificate_authorities_test.go
+++ b/internal/db/db_certificate_authorities_test.go
@@ -451,3 +451,35 @@ func TestCertificateAuthorityFails(t *testing.T) {
 		t.Fatalf("Should have failed to delete certificate authority")
 	}
 }
+
+func TestSelfSignedCertificateList(t *testing.T) {
+	tempDir := t.TempDir()
+	database, err := db.NewDatabase(filepath.Join(tempDir, "db.sqlite3"))
+	if err != nil {
+		t.Fatalf("Couldn't complete NewDatabase: %s", err)
+	}
+	defer database.Close()
+
+	err = database.CreateCertificateAuthority(selfSignedCACertificateRequest, selfSignedCACertificatePK, selfSignedCACertificate+"\n"+selfSignedCACertificate)
+	if err != nil {
+		t.Fatalf("Couldn't create certificate authority: %s", err)
+	}
+	cas, err := database.ListCertificateAuthorities()
+	if err != nil {
+		t.Fatalf("Couldn't list certificate authorities: %s", err)
+	}
+	if len(cas) != 1 {
+		t.Fatalf("%d CA's found when only 1 should be available", len(cas))
+	}
+
+	csrs, err := database.ListCertificateRequestWithCertificates()
+	if err != nil {
+		t.Fatalf("Couldn't list certificates: %s", err)
+	}
+	if len(csrs) != 1 {
+		t.Fatalf("%d certificates found when only 1 should be available", len(csrs))
+	}
+	if csrs[0].CertificateChain == "" {
+		t.Fatalf("certificate should be available for CSR")
+	}
+}

--- a/internal/db/db_certificates.go
+++ b/internal/db/db_certificates.go
@@ -128,16 +128,6 @@ func (db *Database) AddCertificateChainToCertificateRequest(csrFilter CSRFilter,
 		if err != nil {
 			return err
 		}
-		// Update the certificate to refer to itself
-		certRow.IssuerID = childID
-		stmt, err = sqlair.Prepare(updateCertificateStmt, Certificate{})
-		if err != nil {
-			return err
-		}
-		err = db.conn.Query(context.Background(), stmt, certRow).Run()
-		if err != nil {
-			return err
-		}
 		parentID = childID
 	} else {
 		// Otherwise, go through the certificate chain in reverse and add certs as their parents


### PR DESCRIPTION
# Description

The reason fixes #176 happens is because we have an infinite loop where a certificate refers to itself if it is self signed. We usually store self signed certificates in the database so that they refer to no certificate instead of their own ID in the database in order to avoid this issue, since we can infer that all certificates without parents are self signed.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
