### PR TITLE
feat: return last inserted id for create type functions

### DIFF
--- a/docs/reference/api/accounts.md
+++ b/docs/reference/api/accounts.md
@@ -47,7 +47,7 @@ This path creates a new account. The first account can be created without authen
 {
     "result": {
         "message": "success",
-        "object_id": 1
+        "id": 1
     }
 }
 ```

--- a/docs/reference/api/accounts.md
+++ b/docs/reference/api/accounts.md
@@ -46,7 +46,8 @@ This path creates a new account. The first account can be created without authen
 ```json
 {
     "result": {
-        "message": "success"
+        "message": "success",
+        "object_id": 1
     }
 }
 ```

--- a/docs/reference/api/certificate_authorities.md
+++ b/docs/reference/api/certificate_authorities.md
@@ -52,7 +52,8 @@ This path creates a new certificate authority.
 ```json
 {
     "result": {
-        "message": "Certificate Authority created successfully"
+        "message": "Certificate Authority created successfully",
+        "object_id": 1
     }
 }
 ```

--- a/docs/reference/api/certificate_authorities.md
+++ b/docs/reference/api/certificate_authorities.md
@@ -53,7 +53,7 @@ This path creates a new certificate authority.
 {
     "result": {
         "message": "Certificate Authority created successfully",
-        "object_id": 1
+        "id": 1
     }
 }
 ```

--- a/docs/reference/api/certificate_requests.md
+++ b/docs/reference/api/certificate_requests.md
@@ -45,7 +45,7 @@ This path creates a new certificate request.
 {
     "result": {
         "message": "success",
-        "object_id": 1
+        "id": 1
     }
 }
 ```
@@ -116,7 +116,7 @@ This path creates a certificate for a certificate request.
 {
     "result": {
         "message": "success",
-        "object_id": 1
+        "id": 1
     }
 }
 ```

--- a/docs/reference/api/certificate_requests.md
+++ b/docs/reference/api/certificate_requests.md
@@ -44,7 +44,8 @@ This path creates a new certificate request.
 ```json
 {
     "result": {
-        "message": "success"
+        "message": "success",
+        "object_id": 1
     }
 }
 ```
@@ -114,7 +115,8 @@ This path creates a certificate for a certificate request.
 ```json
 {
     "result": {
-        "message": "success"
+        "message": "success",
+        "object_id": 1
     }
 }
 ```

--- a/internal/db/db_certificate_authorities_test.go
+++ b/internal/db/db_certificate_authorities_test.go
@@ -215,9 +215,12 @@ func TestRootCertificateAuthorityEndToEnd(t *testing.T) {
 		t.Fatalf("CA found when no CA's should be available")
 	}
 
-	err = database.CreateCertificateAuthority(selfSignedCACertificateRequest, selfSignedCACertificatePK, selfSignedCACertificate+"\n"+selfSignedCACertificate)
+	caID, err := database.CreateCertificateAuthority(selfSignedCACertificateRequest, selfSignedCACertificatePK, selfSignedCACertificate+"\n"+selfSignedCACertificate)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
+	}
+	if caID != 1 {
+		t.Fatalf("Error creating certificate authority: expected CA id to be 1 but it was %d", caID)
 	}
 	cas, err = database.ListCertificateAuthorities()
 	if err != nil {
@@ -288,9 +291,12 @@ func TestIntermediateCertificateAuthorityEndToEnd(t *testing.T) {
 		t.Fatalf("CA found when no CA's should be available")
 	}
 
-	err = database.CreateCertificateAuthority(selfSignedCACertificateRequest, selfSignedCACertificatePK, "")
+	caID, err := database.CreateCertificateAuthority(selfSignedCACertificateRequest, selfSignedCACertificatePK, "")
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
+	}
+	if caID != 1 {
+		t.Fatalf("Error creating certificate authority: expected CA id to be 1 but it was %d", caID)
 	}
 	cas, err = database.ListCertificateAuthorities()
 	if err != nil {
@@ -365,35 +371,35 @@ func TestCertificateAuthorityFails(t *testing.T) {
 	}
 	defer database.Close()
 
-	err = database.CreateCertificateAuthority("", "", "")
+	_, err = database.CreateCertificateAuthority("", "", "")
 	if err == nil {
 		t.Fatalf("Should have failed to create certificate authority")
 	}
-	err = database.CreateCertificateAuthority(selfSignedCACertificateRequest, "", "")
+	_, err = database.CreateCertificateAuthority(selfSignedCACertificateRequest, "", "")
 	if err == nil {
 		t.Fatalf("Should have failed to create certificate authority")
 	}
-	err = database.CreateCertificateAuthority(selfSignedCACertificateRequest, "nope", "")
+	_, err = database.CreateCertificateAuthority(selfSignedCACertificateRequest, "nope", "")
 	if err == nil {
 		t.Fatalf("Should have failed to create certificate authority")
 	}
-	err = database.CreateCertificateAuthority("nope", selfSignedCACertificatePK, "")
+	_, err = database.CreateCertificateAuthority("nope", selfSignedCACertificatePK, "")
 	if err == nil {
 		t.Fatalf("Should have failed to create certificate authority")
 	}
-	err = database.CreateCertificateAuthority("", selfSignedCACertificatePK, selfSignedCACertificate+"\n"+selfSignedCACertificate)
+	_, err = database.CreateCertificateAuthority("", selfSignedCACertificatePK, selfSignedCACertificate+"\n"+selfSignedCACertificate)
 	if err == nil {
 		t.Fatalf("Should have failed to create certificate authority")
 	}
-	err = database.CreateCertificateAuthority(selfSignedCACertificateRequest, "", selfSignedCACertificate+"\n"+selfSignedCACertificate)
+	_, err = database.CreateCertificateAuthority(selfSignedCACertificateRequest, "", selfSignedCACertificate+"\n"+selfSignedCACertificate)
 	if err == nil {
 		t.Fatalf("Should have failed to create certificate authority")
 	}
-	err = database.CreateCertificateAuthority("nope", selfSignedCACertificatePK, selfSignedCACertificate+"\n"+selfSignedCACertificate)
+	_, err = database.CreateCertificateAuthority("nope", selfSignedCACertificatePK, selfSignedCACertificate+"\n"+selfSignedCACertificate)
 	if err == nil {
 		t.Fatalf("Should have failed to create certificate authority")
 	}
-	err = database.CreateCertificateAuthority(selfSignedCACertificateRequest, "nope", selfSignedCACertificate+"\n"+selfSignedCACertificate)
+	_, err = database.CreateCertificateAuthority(selfSignedCACertificateRequest, "nope", selfSignedCACertificate+"\n"+selfSignedCACertificate)
 	if err == nil {
 		t.Fatalf("Should have failed to create certificate authority")
 	}
@@ -460,9 +466,12 @@ func TestSelfSignedCertificateList(t *testing.T) {
 	}
 	defer database.Close()
 
-	err = database.CreateCertificateAuthority(selfSignedCACertificateRequest, selfSignedCACertificatePK, selfSignedCACertificate+"\n"+selfSignedCACertificate)
+	caID, err := database.CreateCertificateAuthority(selfSignedCACertificateRequest, selfSignedCACertificatePK, selfSignedCACertificate+"\n"+selfSignedCACertificate)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
+	}
+	if caID != 1 {
+		t.Fatalf("Error creating certificate authority: expected CA id to be 1 but it was %d", caID)
 	}
 	cas, err := database.ListCertificateAuthorities()
 	if err != nil {

--- a/internal/db/db_certificates_test.go
+++ b/internal/db/db_certificates_test.go
@@ -16,19 +16,25 @@ func TestCertificatesEndToEnd(t *testing.T) {
 	}
 	defer database.Close()
 
-	err = database.CreateCertificateRequest(AppleCSR)
+	csrID, err := database.CreateCertificateRequest(AppleCSR)
 	if err != nil {
 		t.Fatalf("Couldn't complete Create: %s", err)
 	}
-	err = database.CreateCertificateRequest(BananaCSR)
+	if csrID != 1 {
+		t.Fatalf("Couldn't complete Create: wrong csr id. expected 1, got %d", csrID)
+	}
+	csrID, err = database.CreateCertificateRequest(BananaCSR)
 	if err != nil {
 		t.Fatalf("Couldn't complete Create: %s", err)
 	}
-	err = database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(AppleCSR), AppleCert+IntermediateCert+RootCert)
+	if csrID != 2 {
+		t.Fatalf("Couldn't complete Create: wrong csr id. expected 2, got %d", csrID)
+	}
+	_, err = database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(AppleCSR), AppleCert+IntermediateCert+RootCert)
 	if err != nil {
 		t.Fatalf("Couldn't complete Create: %s", err)
 	}
-	err = database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(BananaCSR), BananaCert+IntermediateCert+RootCert)
+	_, err = database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(BananaCSR), BananaCert+IntermediateCert+RootCert)
 	if err != nil {
 		t.Fatalf("Couldn't complete Create: %s", err)
 	}
@@ -62,7 +68,7 @@ func TestCertificatesEndToEnd(t *testing.T) {
 		t.Fatalf("The certificate chain from the database doesn't match the certificate chain that was given")
 	}
 
-	err = database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(BananaCSR), BananaCert+IntermediateCert+RootCert)
+	_, err = database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(BananaCSR), BananaCert+IntermediateCert+RootCert)
 	if err != nil {
 		t.Fatalf("Couldn't complete Update: %s", err)
 	}
@@ -161,38 +167,37 @@ func TestCertificateAddFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	err := database.CreateCertificateRequest(AppleCSR)
+	_, err := database.CreateCertificateRequest(AppleCSR)
 	if err != nil {
 		t.Fatalf("The certificate should have been uploaded successfully")
 	}
-	err = database.CreateCertificateRequest(BananaCSR)
+	_, err = database.CreateCertificateRequest(BananaCSR)
 	if err != nil {
 		t.Fatalf("The certificate should have been uploaded successfully")
 	}
 	InvalidCert := strings.ReplaceAll(BananaCert, "/", "+")
-	if err := database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(BananaCSR), InvalidCert); err == nil {
+	if _, err := database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(BananaCSR), InvalidCert); err == nil {
 		t.Fatalf("Expected adding certificate chain with invalid cert to fail")
 	}
-	if err := database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(AppleCSR), BananaCert); err == nil {
+	if _, err := database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(AppleCSR), BananaCert); err == nil {
 		t.Fatalf("Expected adding certificate chain with mismatched cert to fail")
 	}
-	if err := database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(AppleCSR), ""); err == nil {
+	if _, err := database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(AppleCSR), ""); err == nil {
 		t.Fatalf("Expected adding certificate chain with empty string to fail")
 	}
-	if err := database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(AppleCSR), "random string"); err == nil {
+	if _, err := database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(AppleCSR), "random string"); err == nil {
 		t.Fatalf("Expected adding certificate chain with random string to fail")
 	}
-
-	if err := database.AddCertificateChainToCertificateRequest(db.ByCSRID(1), InvalidCert); err == nil {
+	if _, err := database.AddCertificateChainToCertificateRequest(db.ByCSRID(1), InvalidCert); err == nil {
 		t.Fatalf("Expected adding certificate chain with invalid cert to fail")
 	}
-	if err := database.AddCertificateChainToCertificateRequest(db.ByCSRID(2), BananaCert); err == nil {
+	if _, err := database.AddCertificateChainToCertificateRequest(db.ByCSRID(2), BananaCert); err == nil {
 		t.Fatalf("Expected adding certificate chain with mismatched cert to fail")
 	}
-	if err := database.AddCertificateChainToCertificateRequest(db.ByCSRID(2), ""); err == nil {
+	if _, err := database.AddCertificateChainToCertificateRequest(db.ByCSRID(2), ""); err == nil {
 		t.Fatalf("Expected adding certificate chain with empty string to fail")
 	}
-	if err := database.AddCertificateChainToCertificateRequest(db.ByCSRID(2), "random string"); err == nil {
+	if _, err := database.AddCertificateChainToCertificateRequest(db.ByCSRID(2), "random string"); err == nil {
 		t.Fatalf("Expected adding certificate chain with random string to fail")
 	}
 }
@@ -201,15 +206,15 @@ func TestGetCertificateChainFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	err := database.CreateCertificateRequest(AppleCSR)
+	_, err := database.CreateCertificateRequest(AppleCSR)
 	if err != nil {
 		t.Fatalf("The certificate should have been uploaded successfully")
 	}
-	err = database.CreateCertificateRequest(BananaCSR)
+	_, err = database.CreateCertificateRequest(BananaCSR)
 	if err != nil {
 		t.Fatalf("The certificate should have been uploaded successfully")
 	}
-	err = database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(AppleCSR), AppleCert+IntermediateCert+RootCert)
+	_, err = database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(AppleCSR), AppleCert+IntermediateCert+RootCert)
 	if err != nil {
 		t.Fatalf("The certificate should have been uploaded successfully")
 	}

--- a/internal/db/db_csrs_test.go
+++ b/internal/db/db_csrs_test.go
@@ -16,17 +16,26 @@ func TestCSRsEndToEnd(t *testing.T) {
 	}
 	defer database.Close()
 
-	err = database.CreateCertificateRequest(AppleCSR)
+	csrID, err := database.CreateCertificateRequest(AppleCSR)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
-	err = database.CreateCertificateRequest(BananaCSR)
+	if csrID != 1 {
+		t.Fatalf("Couldn't complete Create: expected user id 1, but got %d", csrID)
+	}
+	csrID, err = database.CreateCertificateRequest(BananaCSR)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
-	err = database.CreateCertificateRequest(StrawberryCSR)
+	if csrID != 2 {
+		t.Fatalf("Couldn't complete Create: expected user id 2, but got %d", csrID)
+	}
+	csrID, err = database.CreateCertificateRequest(StrawberryCSR)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
+	}
+	if csrID != 3 {
+		t.Fatalf("Couldn't complete Create: expected user id 3, but got %d", csrID)
 	}
 	res, err := database.ListCertificateRequests()
 	if err != nil {
@@ -61,7 +70,7 @@ func TestCSRsEndToEnd(t *testing.T) {
 			t.Fatalf("CSR was not deleted from the DB")
 		}
 	}
-	err = database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(BananaCSR), BananaCert+IntermediateCert+RootCert)
+	_, err = database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(BananaCSR), BananaCert+IntermediateCert+RootCert)
 	if err != nil {
 		t.Fatalf("Couldn't add certificate chain to CSR: %s", err)
 	}
@@ -123,15 +132,15 @@ func TestCreateCertificateRequestFails(t *testing.T) {
 	defer db.Close()
 
 	InvalidCSR := strings.ReplaceAll(AppleCSR, "M", "i")
-	if err := db.CreateCertificateRequest(InvalidCSR); err == nil {
+	if _, err := db.CreateCertificateRequest(InvalidCSR); err == nil {
 		t.Fatalf("Expected error due to invalid CSR")
 	}
 
-	err := db.CreateCertificateRequest(AppleCSR)
+	_, err := db.CreateCertificateRequest(AppleCSR)
 	if err != nil {
 		t.Fatalf("Failed to create CSR: %s", err)
 	}
-	if err := db.CreateCertificateRequest(AppleCSR); err == nil {
+	if _, err := db.CreateCertificateRequest(AppleCSR); err == nil {
 		t.Fatalf("Expected error due to duplicate CSR")
 	}
 }
@@ -140,7 +149,7 @@ func TestGetCertificateRequestFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	err := database.CreateCertificateRequest(AppleCSR)
+	_, err := database.CreateCertificateRequest(AppleCSR)
 	if err != nil {
 		t.Fatalf("Failed to create CSR: %s", err)
 	}
@@ -151,7 +160,7 @@ func TestGetCertificateRequestFails(t *testing.T) {
 		t.Fatalf("Expected failure looking for nonexistent CSR")
 	}
 
-	err = database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(AppleCSR), AppleCert+IntermediateCert+RootCert)
+	_, err = database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(AppleCSR), AppleCert+IntermediateCert+RootCert)
 	if err != nil {
 		t.Fatalf("Failed to add certificate chain to CSR: %s", err)
 	}
@@ -166,7 +175,7 @@ func TestGetCertificateRequestFails(t *testing.T) {
 func TestDeleteCertificateRequest(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
-	err := database.CreateCertificateRequest(AppleCSR)
+	_, err := database.CreateCertificateRequest(AppleCSR)
 	if err != nil {
 		t.Fatalf("Failed to create CSR: %s", err)
 	}
@@ -191,7 +200,7 @@ func TestRevokeCertificateRequestFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	err := database.CreateCertificateRequest(AppleCSR)
+	_, err := database.CreateCertificateRequest(AppleCSR)
 	if err != nil {
 		t.Fatalf("Failed to create CSR: %s", err)
 	}
@@ -217,7 +226,7 @@ func TestRejectCertificateRequestFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	err := database.CreateCertificateRequest(AppleCSR)
+	_, err := database.CreateCertificateRequest(AppleCSR)
 	if err != nil {
 		t.Fatalf("Failed to create CSR: %s", err)
 	}

--- a/internal/db/db_private_keys_test.go
+++ b/internal/db/db_private_keys_test.go
@@ -23,9 +23,12 @@ func TestPrivateKeysEndToEnd(t *testing.T) {
 		t.Fatalf("Number of private keys is not 1")
 	}
 
-	err = database.CreatePrivateKey(selfSignedCACertificatePK)
+	pkID, err := database.CreatePrivateKey(selfSignedCACertificatePK)
 	if err != nil {
 		t.Fatalf("Couldn't create private key: %s", err)
+	}
+	if pkID != 1 {
+		t.Fatalf("Couldn't create private key: expected pk id 1, got %d", pkID)
 	}
 
 	pks, err = database.ListPrivateKeys()
@@ -73,11 +76,11 @@ func TestPrivateKeyFails(t *testing.T) {
 	}
 	defer database.Close()
 
-	err = database.CreatePrivateKey("")
+	_, err = database.CreatePrivateKey("")
 	if err == nil {
 		t.Fatalf("Should have failed to create private key")
 	}
-	err = database.CreatePrivateKey("nope")
+	_, err = database.CreatePrivateKey("nope")
 	if err == nil {
 		t.Fatalf("Should have failed to create private key")
 	}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -22,11 +22,11 @@ func Example() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	err = database.CreateCertificateRequest(BananaCSR)
+	csrID, err := database.CreateCertificateRequest(BananaCSR)
 	if err != nil {
 		log.Fatalln(err)
 	}
-	err = database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(BananaCSR), BananaCert)
+	_, err = database.AddCertificateChainToCertificateRequest(db.ByCSRID(csrID), BananaCert)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/internal/db/db_users_test.go
+++ b/internal/db/db_users_test.go
@@ -15,14 +15,20 @@ func TestUsersEndToEnd(t *testing.T) {
 	}
 	defer database.Close()
 
-	err = database.CreateUser("admin", "pw123", 1)
+	userID, err := database.CreateUser("admin", "pw123", 1)
 	if err != nil {
 		t.Fatalf("Couldn't complete Create: %s", err)
 	}
+	if userID != 1 {
+		t.Fatalf("Couldn't complete Create: expected user id 1, but got %d", userID)
+	}
 
-	err = database.CreateUser("norman", "pw456", 0)
+	userID, err = database.CreateUser("norman", "pw456", 0)
 	if err != nil {
 		t.Fatalf("Couldn't complete Create: %s", err)
+	}
+	if userID != 2 {
+		t.Fatalf("Couldn't complete Create: expected user id 1, but got %d", userID)
 	}
 
 	res, err := database.ListUsers()
@@ -82,11 +88,11 @@ func TestCreateUserFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	err := database.CreateUser("admin", "pw123", 1)
+	_, err := database.CreateUser("admin", "pw123", 1)
 	if err != nil {
 		t.Fatalf("Couldn't complete CreateUser: %s", err)
 	}
-	err = database.CreateUser("admin", "pw456", 1)
+	_, err = database.CreateUser("admin", "pw456", 1)
 	if err == nil {
 		t.Fatalf(
 			"An error should have been returned when creating a user with a duplicate username.",
@@ -106,7 +112,7 @@ func TestCreateUserFails(t *testing.T) {
 	if err == nil {
 		t.Fatalf("An error should have been returned when getting a non-existent user.")
 	}
-	err = database.CreateUser("", "pw456", 0)
+	_, err = database.CreateUser("", "pw456", 0)
 	if err == nil {
 		t.Fatalf("An error should have been returned when creating a user with an empty username.")
 	}
@@ -120,7 +126,7 @@ func TestCreateUserFails(t *testing.T) {
 	if num != 1 {
 		t.Fatalf("The number of users should be 1.")
 	}
-	err = database.CreateUser("newUser", "", 0)
+	_, err = database.CreateUser("newUser", "", 0)
 	if err == nil {
 		t.Fatalf("An error should have been returned when creating a user with a nil password.")
 	}
@@ -134,7 +140,7 @@ func TestCreateUserFails(t *testing.T) {
 	if num != 1 {
 		t.Fatalf("The number of users should be 1.")
 	}
-	err = database.CreateUser("newUser", "pw456", 2)
+	_, err = database.CreateUser("newUser", "pw456", 2)
 	if err == nil {
 		t.Fatalf("An error should have been returned when creating a user with an invalid permission level.")
 	}
@@ -147,7 +153,7 @@ func TestGetUserFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	err := database.CreateUser("admin", "pw123", 1)
+	_, err := database.CreateUser("admin", "pw123", 1)
 	if err != nil {
 		t.Fatalf("Couldn't complete CreateUser: %s", err)
 	}
@@ -172,7 +178,7 @@ func TestUpdateUserPasswordFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 	originalPassword := "pw123"
-	err := database.CreateUser("admin", originalPassword, 1)
+	_, err := database.CreateUser("admin", originalPassword, 1)
 	if err != nil {
 		t.Fatalf("Couldn't complete CreateUser: %s", err)
 	}
@@ -216,11 +222,11 @@ func TestDeleteUserFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	err := database.CreateUser("admin", "pw123", 1)
+	_, err := database.CreateUser("admin", "pw123", 1)
 	if err != nil {
 		t.Fatalf("Couldn't complete CreateUser: %s", err)
 	}
-	err = database.CreateUser("normal", "pw456", 0)
+	_, err = database.CreateUser("normal", "pw456", 0)
 	if err != nil {
 		t.Fatalf("Couldn't complete CreateUser: %s", err)
 	}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -98,11 +98,11 @@ func generateCertPair(daysRemaining int) (string, string, string) {
 func initializeTestDB(t *testing.T, database *db.Database) {
 	for _, v := range []int{5, 10, 32} {
 		csr, cert, ca := generateCertPair(v)
-		err := database.CreateCertificateRequest(csr)
+		csrID, err := database.CreateCertificateRequest(csr)
 		if err != nil {
 			t.Fatalf("couldn't create test csr: %s", err)
 		}
-		err = database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(csr), fmt.Sprintf("%s%s", cert, ca))
+		_, err = database.AddCertificateChainToCertificateRequest(db.ByCSRID(csrID), fmt.Sprintf("%s%s", cert, ca))
 		if err != nil {
 			t.Fatalf("couldn't create test cert: %s", err)
 		}

--- a/internal/server/handlers_accounts.go
+++ b/internal/server/handlers_accounts.go
@@ -168,7 +168,7 @@ func CreateAccount(env *HandlerConfig) http.HandlerFunc {
 		if numUsers == 0 {
 			permission = AdminPermission
 		}
-		err = env.DB.CreateUser(createAccountParams.Username, createAccountParams.Password, permission)
+		newUserID, err := env.DB.CreateUser(createAccountParams.Username, createAccountParams.Password, permission)
 		if err != nil {
 			if strings.Contains(err.Error(), "UNIQUE constraint failed") {
 				writeError(w, http.StatusBadRequest, "account with given username already exists")
@@ -178,7 +178,7 @@ func CreateAccount(env *HandlerConfig) http.HandlerFunc {
 			writeError(w, http.StatusInternalServerError, "Internal Error")
 			return
 		}
-		successResponse := SuccessResponse{Message: "success"}
+		successResponse := CreateSuccessResponse{Message: "success", ObjectID: newUserID}
 		err = writeResponse(w, successResponse, http.StatusCreated)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")

--- a/internal/server/handlers_accounts.go
+++ b/internal/server/handlers_accounts.go
@@ -178,7 +178,7 @@ func CreateAccount(env *HandlerConfig) http.HandlerFunc {
 			writeError(w, http.StatusInternalServerError, "Internal Error")
 			return
 		}
-		successResponse := CreateSuccessResponse{Message: "success", ObjectID: newUserID}
+		successResponse := CreateSuccessResponse{Message: "success", ID: newUserID}
 		err = writeResponse(w, successResponse, http.StatusCreated)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")

--- a/internal/server/handlers_certificate_authorities.go
+++ b/internal/server/handlers_certificate_authorities.go
@@ -254,17 +254,18 @@ func CreateCertificateAuthority(env *HandlerConfig) http.HandlerFunc {
 			writeError(w, http.StatusInternalServerError, "Failed to create certificate authority")
 			return
 		}
+		var newCAID int64
 		if certPEM != "" {
-			err = env.DB.CreateCertificateAuthority(csrPEM, privPEM, certPEM+certPEM)
+			newCAID, err = env.DB.CreateCertificateAuthority(csrPEM, privPEM, certPEM+certPEM)
 		} else {
-			err = env.DB.CreateCertificateAuthority(csrPEM, privPEM, "")
+			newCAID, err = env.DB.CreateCertificateAuthority(csrPEM, privPEM, "")
 		}
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "Failed to create certificate authority")
 			return
 		}
 
-		successResponse := SuccessResponse{Message: "Certificate Authority created successfully"}
+		successResponse := CreateSuccessResponse{Message: "Certificate Authority created successfully", ObjectID: newCAID}
 		err = writeResponse(w, successResponse, http.StatusCreated)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")

--- a/internal/server/handlers_certificate_authorities.go
+++ b/internal/server/handlers_certificate_authorities.go
@@ -265,7 +265,7 @@ func CreateCertificateAuthority(env *HandlerConfig) http.HandlerFunc {
 			return
 		}
 
-		successResponse := CreateSuccessResponse{Message: "Certificate Authority created successfully", ObjectID: newCAID}
+		successResponse := CreateSuccessResponse{Message: "Certificate Authority created successfully", ID: newCAID}
 		err = writeResponse(w, successResponse, http.StatusCreated)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")

--- a/internal/server/handlers_certificate_requests.go
+++ b/internal/server/handlers_certificate_requests.go
@@ -121,7 +121,7 @@ func CreateCertificateRequest(env *HandlerConfig) http.HandlerFunc {
 			writeError(w, http.StatusInternalServerError, "Internal Error")
 			return
 		}
-		successResponse := CreateSuccessResponse{Message: "success", ObjectID: newCSRID}
+		successResponse := CreateSuccessResponse{Message: "success", ID: newCSRID}
 		err = writeResponse(w, successResponse, http.StatusCreated)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")
@@ -231,7 +231,7 @@ func CreateCertificate(env *HandlerConfig) http.HandlerFunc {
 				log.Printf("pebble notify failed: %s. continuing silently.", err.Error())
 			}
 		}
-		successResponse := CreateSuccessResponse{Message: "success", ObjectID: newCertID}
+		successResponse := CreateSuccessResponse{Message: "success", ID: newCertID}
 		err = writeResponse(w, successResponse, http.StatusCreated)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")

--- a/internal/server/handlers_certificate_requests.go
+++ b/internal/server/handlers_certificate_requests.go
@@ -106,7 +106,7 @@ func CreateCertificateRequest(env *HandlerConfig) http.HandlerFunc {
 			writeError(w, http.StatusBadRequest, fmt.Errorf("Invalid request: %s", err).Error())
 			return
 		}
-		err = env.DB.CreateCertificateRequest(createCertificateRequestParams.CSR)
+		newCSRID, err := env.DB.CreateCertificateRequest(createCertificateRequestParams.CSR)
 		if err != nil {
 			if strings.Contains(err.Error(), "UNIQUE constraint failed") {
 				writeError(w, http.StatusBadRequest, "given csr already recorded")
@@ -121,7 +121,7 @@ func CreateCertificateRequest(env *HandlerConfig) http.HandlerFunc {
 			writeError(w, http.StatusInternalServerError, "Internal Error")
 			return
 		}
-		successResponse := SuccessResponse{Message: "success"}
+		successResponse := CreateSuccessResponse{Message: "success", ObjectID: newCSRID}
 		err = writeResponse(w, successResponse, http.StatusCreated)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")
@@ -213,7 +213,7 @@ func CreateCertificate(env *HandlerConfig) http.HandlerFunc {
 			writeError(w, http.StatusBadRequest, "Invalid ID")
 			return
 		}
-		err = env.DB.AddCertificateChainToCertificateRequest(db.ByCSRID(idNum), createCertificateParams.CertificateChain)
+		newCertID, err := env.DB.AddCertificateChainToCertificateRequest(db.ByCSRID(idNum), createCertificateParams.CertificateChain)
 		if err != nil {
 			log.Println(err)
 			if errors.Is(err, sqlair.ErrNoRows) ||
@@ -231,7 +231,7 @@ func CreateCertificate(env *HandlerConfig) http.HandlerFunc {
 				log.Printf("pebble notify failed: %s. continuing silently.", err.Error())
 			}
 		}
-		successResponse := SuccessResponse{Message: "success"}
+		successResponse := CreateSuccessResponse{Message: "success", ObjectID: newCertID}
 		err = writeResponse(w, successResponse, http.StatusCreated)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal error")

--- a/internal/server/response.go
+++ b/internal/server/response.go
@@ -11,8 +11,8 @@ type SuccessResponse struct {
 }
 
 type CreateSuccessResponse struct {
-	Message  string `json:"message"`
-	ObjectID int64  `json:"object_id"`
+	Message string `json:"message"`
+	ID      int64  `json:"id"`
 }
 
 // writeResponse is a helper function that writes a JSON response to the http.ResponseWriter

--- a/internal/server/response.go
+++ b/internal/server/response.go
@@ -10,6 +10,11 @@ type SuccessResponse struct {
 	Message string `json:"message"`
 }
 
+type CreateSuccessResponse struct {
+	Message  string `json:"message"`
+	ObjectID int64  `json:"object_id"`
+}
+
 // writeResponse is a helper function that writes a JSON response to the http.ResponseWriter
 func writeResponse(w http.ResponseWriter, v any, status int) error {
 	type response struct {


### PR DESCRIPTION
# Description

This change reintroduces the last inserted id parameter, but only to create type functions. Previously, I had determined that this value did not update if we did updates or deletes in SQL, which made the functions confusing. Since then I've learned how this value is populated (it always contains the last inserted id, even if an irrelevant SELECT or UPDATE statement was the actual SQL statement that ran), and have decided to reintroduce it to reduce complexity in parts of the code where we'd have to immediately query for rows we had just inserted because we didn't have a way to know the last inserted ID's.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
