### PR TITLE
chore: update test to use tempdir

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -12,6 +12,9 @@ import (
 )
 
 func TestNewSuccess(t *testing.T) {
+	tempDir := t.TempDir()
+	db_path := filepath.Join(tempDir, "db.sqlite3")
+
 	certPath := filepath.Join("testdata", "cert.pem")
 	cert, err := os.ReadFile(certPath)
 	if err != nil {
@@ -22,7 +25,7 @@ func TestNewSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot read file: %s", err)
 	}
-	s, err := server.New(8000, cert, key, "certs.db", false)
+	s, err := server.New(8000, cert, key, db_path, false)
 	if err != nil {
 		t.Errorf("Error occurred: %s", err)
 	}


### PR DESCRIPTION
# Description

This quirk has been nagging me for a while where one of the tests don't use a tempdir so I have a rouge `certs.db` file in my folder every time i run this test

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
