### PR TITLE
chore: add gosec security scanning

### DIFF
--- a/.github/workflows/go-sec.yaml
+++ b/.github/workflows/go-sec.yaml
@@ -1,0 +1,18 @@
+name: Run Gosec
+
+permissions:
+  contents: read
+
+on:
+    workflow_call:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@43fee884f668c23601e0bec7a8c095fba226f889 # v2.22.1

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,7 +28,7 @@ type Config struct {
 // Validate opens and processes the given yaml file, and catches errors in the process
 func Validate(filePath string) (Config, error) {
 	config := Config{}
-	configYaml, err := os.ReadFile(filePath)
+	configYaml, err := os.ReadFile(filePath) // #nosec: G304
 	if err != nil {
 		return Config{}, err
 	}
@@ -53,7 +53,7 @@ func Validate(filePath string) (Config, error) {
 	if c.DBPath == "" {
 		return Config{}, errors.New("`db_path` is empty")
 	}
-	dbfile, err := os.OpenFile(c.DBPath, os.O_CREATE|os.O_RDONLY, 0o644)
+	dbfile, err := os.OpenFile(c.DBPath, os.O_CREATE|os.O_RDONLY, 0o600)
 	if err != nil {
 		return Config{}, err
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -36,7 +36,7 @@ func SendPebbleNotification(key NotificationKey, request_id int64) error {
 	if err != nil {
 		return fmt.Errorf("couldn't get a string representation of the notification key: %w", err)
 	}
-	cmd := exec.Command("pebble", "notify", keyStr, fmt.Sprintf("request_id=%v", request_id))
+	cmd := exec.Command("pebble", "notify", keyStr, fmt.Sprintf("request_id=%v", request_id)) // #nosec: G204
 	err = cmd.Run()
 	if err != nil {
 		return fmt.Errorf("couldn't execute a pebble notify: %w", err)


### PR DESCRIPTION
# Description

Here we add vulnerabiltiy scanning using `gosec` which is an helpful tool in finding common vulnerabilities. For instance, I used it to identify and address those issues:
- https://github.com/canonical/notary/commit/bf18cac429c46553cf7552860c777ee71a9a5d0b
- https://github.com/canonical/notary/commit/48d38e516965f337a2aca4ef9e3222b46cf734dc

Gosec is a well-known, widely used go security code scanner. 


## Nosec

Gosec can ignore some issues, and you will see two instances of those ignores added to our code base. Here are the gosec warnings:

```
[/home/guillaume/code/notary/internal/config/config.go:31] - G304 (CWE-22): Potential file inclusion via variable (Confidence: HIGH, Severity: MEDIUM)
    30:         config := Config{}
  > 31:         configYaml, err := os.ReadFile(filePath)
    32:         if err != nil {
```

```
[/home/guillaume/code/notary/internal/server/server.go:39] - G204 (CWE-78): Subprocess launched with variable (Confidence: HIGH, Severity: MEDIUM)
    38:         }
  > 39:         cmd := exec.Command("pebble", "notify", keyStr, fmt.Sprintf("request_id=%v", request_id))
    40:         err = cmd.Run()
```
This last issue was mitigated by only allowing ints to define the content of the `pebble exec` command, limiting it to a very specific format. 

## Reference
- https://github.com/securego/gosec

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
