### PR TITLE
chore: rename db to notary.db

### DIFF
--- a/.github/workflows/rock-test.yaml
+++ b/.github/workflows/rock-test.yaml
@@ -27,7 +27,7 @@ jobs:
           sudo snap install rockcraft --classic
       - name: Create files required by Notary
         run: |
-          printf 'key_path:  "/etc/notary/config/key.pem"\ncert_path: "/etc/notary/config/cert.pem"\ndb_path: "/var/lib/notary/database/certs.db"\nport: 3000\npebble_notifications: true\n' > config.yaml
+          printf 'key_path:  "/etc/notary/config/key.pem"\ncert_path: "/etc/notary/config/cert.pem"\ndb_path: "/var/lib/notary/database/notary.db"\nport: 3000\npebble_notifications: true\n' > config.yaml
           openssl req -newkey rsa:2048 -nodes -keyout key.pem -x509 -days 1 -out cert.pem -subj "/CN=githubaction.example"
       - name: Import the image to Docker registry
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Create a `notary.yaml` file with the following content:
 ```yaml
 key_path:  "key.pem"
 cert_path: "cert.pem"
-db_path: "certs.db"
+db_path: "notary.db"
 port: 3000
 pebble_notifications: false
 ```

--- a/docs/reference/config_file.md
+++ b/docs/reference/config_file.md
@@ -17,7 +17,7 @@ Start Notary with the `--config` flag to specify the path to the configuration f
 ```yaml
 key_path:  "/etc/notary/config/key.pem"
 cert_path: "/etc/notary/config/cert.pem"
-db_path: "/var/lib/notary/database/certs.db"
+db_path: "/var/lib/notary/database/notary.db"
 port: 3000
 pebble_notifications: true
 ```

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,24 +14,24 @@ const (
 	validPK     = `Whatever key content`
 	validConfig = `key_path:  "./key_test.pem"
 cert_path: "./cert_test.pem"
-db_path: "./certs.db"
+db_path: "./notary.db"
 port: 8000`
 	noCertPathConfig = `key_path:  "./key_test.pem"
-db_path: "./certs.db"
+db_path: "./notary.db"
 port: 8000`
 	noKeyPathConfig = `cert_path: "./cert_test.pem"
-db_path: "./certs.db"
+db_path: "./notary.db"
 port: 8000`
 	noDBPathConfig = `key_path:  "./key_test.pem"
 cert_path: "./cert_test.pem"
 port: 8000`
 	wrongCertPathConfig = `key_path:  "./key_test.pem"
 cert_path: "./cert_test_wrong.pem"
-db_path: "./certs.db"
+db_path: "./notary.db"
 port: 8000`
 	wrongKeyPathConfig = `key_path:  "./key_test_wrong.pem"
 cert_path: "./cert_test.pem"
-db_path: "./certs.db"
+db_path: "./notary.db"
 port: 8000`
 	invalidYAMLConfig = `just_an=invalid
 yaml.here`

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -18,7 +18,7 @@ func TestConnect(t *testing.T) {
 }
 
 func Example() {
-	database, err := db.NewDatabase("./certs.db")
+	database, err := db.NewDatabase("./notary.db")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -40,7 +40,7 @@ func TestInvalidKeyFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot read file: %s", err)
 	}
-	_, err = server.New(8000, cert, []byte{}, "certs.db", false)
+	_, err = server.New(8000, cert, []byte{}, "notary.db", false)
 	if err == nil {
 		t.Errorf("No error was thrown for invalid key")
 	}

--- a/service/notary.yaml
+++ b/service/notary.yaml
@@ -1,5 +1,5 @@
 key_path:  "/var/snap/notary/common/key.pem"
 cert_path: "/var/snap/notary/common/cert.pem"
-db_path: "/var/snap/notary/common/certs.db"
+db_path: "/var/snap/notary/common/notary.db"
 port: 3000
 pebble_notifications: false


### PR DESCRIPTION
# Description

The database name was misleading as it not only contains certs but everything persistent in Notary. Here I renamed the database from `certs.db` to the more appropriate `notary.db`.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
