### PR TITLE
docs: add Notary resource descriptions

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -1,6 +1,7 @@
 APIs
 bool
 CAs
+CSR
 DNS
 frontend
 HTTPS

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -11,7 +11,7 @@ The API exposes both Notary-specific and generic resources. The Notary-specific 
 | [**Certificate Authority**](certificate_authorities.md) | Represents a Notary-owned Certificate Authority. These authorities can be used by Notary users to sign certificate requests submitted by external entities.                                                                                                                                                                                                             |
 | [**Certificate Request**](certificate_requests.md)      | Represents a certificate request made by an external entity. Users can get the certificate request signed in one of two ways:<ul><li>Internally: the request is signed with one of Notary's Certificate Authorities</li><li>Externally: The CSR is retrieved, signed by an external process, and the resulting certificate is then imported back into Notary.</li></ul> |
 
-In addition to the Notary-specific resources, the API also provides access to generic resources (e.g., accounts, login, metrics) with commonly understood definitions.
+In addition to the Notary-specific resources, the API also provides access to generic resources (e.g., `accounts`, `login`, `metrics`) with commonly understood definitions.
 
 ## Authentication
 

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -2,6 +2,17 @@
 
 Notary exposes a RESTful API for managing certificate requests, certificate authorities, users, and more.
 
+## Resources
+
+The API exposes the following Notary-specific resources:
+
+| Resource                                                | Description                                                                                                                                       |
+| :------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [**Certificate Authority**](certificate_authorities.md) | Represents a Notary owned Certificate Authority. Notary users can use Certificate Authorities to sign certificate requests for external entities. |
+| [**Certificate Request**](certificate_requests.md)      | Represents a certificate request made by an external entity.                                                                                      |
+
+The API also exposes generic resources with commonly understood definitions (ex.`accounts`, `login`, `metrics`).
+
 ## Authentication
 
 Almost every operation requires a client token, in the form of a Bearer Token.
@@ -18,7 +29,7 @@ Notary's API responses are JSON objects with the following structure:
 ```
 
 ```{note}
-GET calls to the `/metrics` endpoint don't follow this rule, it returns text response in the [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-format-details).
+GET calls to the `/metrics` endpoint don't follow this rule; they return text response in the [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-format-details).
 ```
 
 ## Table of contents

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -4,14 +4,14 @@ Notary exposes a RESTful API for managing certificate requests, certificate auth
 
 ## Resources
 
-The API exposes the following Notary-specific resources:
+The API exposes both Notary-specific and generic resources. The Notary-specific resources are described below:
 
-| Resource                                                | Description                                                                                                                                                                      |
-| :------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [**Certificate Authority**](certificate_authorities.md) | Represents a Notary-owned Certificate Authority. Notary users can use Certificate Authorities to sign certificate requests for external entities.                                |
-| [**Certificate Request**](certificate_requests.md)      | Represents a certificate request made by an external entity. Users can sign the request with one of Notary's Certificate Authorities or with any external Certificate Authority. |
+| Resource                                                | Description                                                                                                                                                                                                                                                                                                                                                             |
+| :------------------------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [**Certificate Authority**](certificate_authorities.md) | Represents a Notary-owned Certificate Authority. These authorities can be used by Notary users to sign certificate requests submitted by external entities.                                                                                                                                                                                                             |
+| [**Certificate Request**](certificate_requests.md)      | Represents a certificate request made by an external entity. Users can get the certificate request signed in one of two ways:<ul><li>Internally: the request is signed with one of Notary's Certificate Authorities</li><li>Externally: The CSR is retrieved, signed by an external process, and the resulting certificate is then imported back into Notary.</li></ul> |
 
-The API also exposes generic resources with commonly understood definitions (ex.`accounts`, `login`, `metrics`).
+In addition to the Notary-specific resources, the API also provides access to generic resources (e.g., accounts, login, metrics) with commonly understood definitions.
 
 ## Authentication
 

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -6,10 +6,10 @@ Notary exposes a RESTful API for managing certificate requests, certificate auth
 
 The API exposes the following Notary-specific resources:
 
-| Resource                                                | Description                                                                                                                                       |
-| :------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [**Certificate Authority**](certificate_authorities.md) | Represents a Notary owned Certificate Authority. Notary users can use Certificate Authorities to sign certificate requests for external entities. |
-| [**Certificate Request**](certificate_requests.md)      | Represents a certificate request made by an external entity.                                                                                      |
+| Resource                                                | Description                                                                                                                                                                       |
+| :------------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [**Certificate Authority**](certificate_authorities.md) | Represents a Notary-owned Certificate Authority. Notary users can use Certificate Authorities to sign certificate requests for external entities.                                 |
+| [**Certificate Request**](certificate_requests.md)      | Represents a certificate request made by an external entity. Users can sign the request with one of Notary's Certificate Authorities, or with any external Certificate Authority. |
 
 The API also exposes generic resources with commonly understood definitions (ex.`accounts`, `login`, `metrics`).
 

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -6,10 +6,10 @@ Notary exposes a RESTful API for managing certificate requests, certificate auth
 
 The API exposes the following Notary-specific resources:
 
-| Resource                                                | Description                                                                                                                                                                       |
-| :------------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [**Certificate Authority**](certificate_authorities.md) | Represents a Notary-owned Certificate Authority. Notary users can use Certificate Authorities to sign certificate requests for external entities.                                 |
-| [**Certificate Request**](certificate_requests.md)      | Represents a certificate request made by an external entity. Users can sign the request with one of Notary's Certificate Authorities, or with any external Certificate Authority. |
+| Resource                                                | Description                                                                                                                                                                      |
+| :------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [**Certificate Authority**](certificate_authorities.md) | Represents a Notary-owned Certificate Authority. Notary users can use Certificate Authorities to sign certificate requests for external entities.                                |
+| [**Certificate Request**](certificate_requests.md)      | Represents a certificate request made by an external entity. Users can sign the request with one of Notary's Certificate Authorities or with any external Certificate Authority. |
 
 The API also exposes generic resources with commonly understood definitions (ex.`accounts`, `login`, `metrics`).
 


### PR DESCRIPTION
# Description

Document the definition of Notary resources. For now this only includes:
- **Certificate Authorities**: Represents a Notary-owned Certificate Authority. Notary users can use Certificate Authorities to sign certificate requests for external entities.
- **Certificate Requests**: Represents a certificate request made by an external entity.

## Context

@ghislainbourgeois , @kayra1 , and I had an internal discussion around the various Notary resources and their meaning. We came to an agreement:
- Base level endpoints (ex. `/certificate_requests`) represent Notary resources
- The definition of those resources should be documented

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
