### PR TITLE
feat: Increase bcrypt cost for higher security

### DIFF
--- a/internal/db/validation.go
+++ b/internal/db/validation.go
@@ -12,6 +12,13 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+// BCRYPT_COST is used to tune the password hashing algorithm's time.
+// For better protection against brute-force attacks, this should be
+// set higher, at the cost of performance.
+// A good rule of thumb is to set this so that it takes over 250 ms
+// to hash a password on common hardware.
+const BCRYPT_COST = 13
+
 // ValidateCertificateRequest validates the given CSR string to the following:
 // The string must be a valid PEM string, and should be of type CERTIFICATE REQUEST
 // The PEM string should be able to be parsed into a x509 Certificate Request
@@ -149,7 +156,7 @@ func HashPassword(password string) (string, error) {
 	if strings.TrimSpace(password) == "" {
 		return "", fmt.Errorf("password cannot be empty")
 	}
-	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), BCRYPT_COST)
 	if err != nil {
 		return "", err
 	}

--- a/internal/db/validation_test.go
+++ b/internal/db/validation_test.go
@@ -418,3 +418,9 @@ func TestCertificateMatchesCSRFail(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkHashPassword(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		db.HashPassword("Correct Staple Horse")
+	}
+}

--- a/internal/db/validation_test.go
+++ b/internal/db/validation_test.go
@@ -421,6 +421,6 @@ func TestCertificateMatchesCSRFail(t *testing.T) {
 
 func BenchmarkHashPassword(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		db.HashPassword("Correct Staple Horse")
+		db.HashPassword("Correct Staple Horse") // nolint:errcheck
 	}
 }


### PR DESCRIPTION
# Description

Bcrypt's cost is used to tune the password hashing algorithm's compute time. For better protection against brute-force attacks, it should be set higher, at the cost of performance.
A good rule of thumb is to set this so that it takes over 250 ms to hash a password on common hardware.

I added a benchmark test that can be used to evaluate the value. I selected the proposed value in this PR so that each operation takes over 250 ms on my laptop.

The previous value was set by the language to 10, and it took only 43 ms per hash on my laptop.

A future improvement here would be to make this cost configurable. Another improvement would be to automatically increase this cost as time moves on, and rehash passwords with the new cost on logins.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
