### PR TITLE
chore: don't publish manifests separately

### DIFF
--- a/.github/workflows/rock-publish.yaml
+++ b/.github/workflows/rock-publish.yaml
@@ -40,13 +40,11 @@ jobs:
             copy \
             oci-archive:"${amd64_rock_file}" \
             docker-daemon:"ghcr.io/canonical/${image_name}:${version}-amd64"
-          docker push ghcr.io/canonical/${image_name}:${version}-amd64
           sudo rockcraft.skopeo \
             --insecure-policy \
             copy \
             oci-archive:"${arm64_rock_file}" \
             docker-daemon:"ghcr.io/canonical/${image_name}:${version}-arm64"
-          docker push ghcr.io/canonical/${image_name}:${version}-arm64
           docker manifest create ghcr.io/canonical/${image_name}:${version} \
             ghcr.io/canonical/${image_name}:${version}-amd64 \
             ghcr.io/canonical/${image_name}:${version}-arm64


### PR DESCRIPTION
# Description

This change removes pushing the rock images to the registry alone, and instead pushes the single manifest list only. It's simpler.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
