### PR TITLE
chore: bump jwt version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/canonical/notary
 go 1.24.0
 
 require (
-	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/mattn/go-sqlite3 v1.14.24
 	github.com/prometheus/client_golang v1.21.1
 	golang.org/x/crypto v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=

--- a/internal/server/handlers_login.go
+++ b/internal/server/handlers_login.go
@@ -9,19 +9,19 @@ import (
 
 	"github.com/canonical/notary/internal/db"
 	"github.com/canonical/sqlair"
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 	"golang.org/x/crypto/bcrypt"
 )
 
-func expireAfter() int64 {
-	return time.Now().Add(time.Hour * 1).Unix()
+func expireAfter() time.Time {
+	return time.Now().Add(time.Hour * 1)
 }
 
 type jwtNotaryClaims struct {
 	ID          int64  `json:"id"`
 	Username    string `json:"username"`
 	Permissions int    `json:"permissions"`
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 }
 
 type LoginParams struct {
@@ -35,12 +35,13 @@ type LoginResponse struct {
 
 // Helper function to generate a JWT
 func generateJWT(id int64, username string, jwtSecret []byte, permissions int) (string, error) {
+	expiresAt := jwt.NewNumericDate(expireAfter())
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwtNotaryClaims{
 		ID:          id,
 		Username:    username,
 		Permissions: permissions,
-		StandardClaims: jwt.StandardClaims{
-			ExpiresAt: expireAfter(),
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: expiresAt,
 		},
 	})
 	tokenString, err := token.SignedString(jwtSecret)

--- a/internal/server/handlers_login_test.go
+++ b/internal/server/handlers_login_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 type LoginParams struct {

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/canonical/notary/internal/db"
 	"github.com/canonical/notary/internal/metrics"
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 


### PR DESCRIPTION
# Description

We were using an old version of jwt, released in 2021. Here we bump jwt to the latest stable release and make the necessary changes to adapt to the lib's new API's.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
