### PR TITLE
feat: Use argon2id for password hashing as recommended by OWASP

### DIFF
--- a/internal/db/db_users.go
+++ b/internal/db/db_users.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/canonical/notary/internal/hashing"
 	"github.com/canonical/sqlair"
 )
 
@@ -75,10 +76,10 @@ func (db *Database) GetUser(filter UserFilter) (*User, error) {
 // The permission level 1 represents an admin, and a 0 represents a regular user.
 // The password passed in should be in plaintext. This function handles hashing and salting the password before storing it in the database.
 func (db *Database) CreateUser(username string, password string, permission int) (int64, error) {
-	pw, err := HashPassword(password)
+	pw, err := hashing.HashPassword(password)
 	if err != nil {
 		log.Println(err)
-		if errors.Is(err, ErrInvalidInput) {
+		if errors.Is(err, hashing.ErrInvalidPassword) {
 			return 0, fmt.Errorf("%w: invalid password", ErrInvalidInput)
 		}
 		return 0, fmt.Errorf("%w: failed to create user", ErrInternal)
@@ -122,10 +123,10 @@ func (db *Database) UpdateUserPassword(filter UserFilter, password string) error
 	if err != nil {
 		return err
 	}
-	hashedPassword, err := HashPassword(password)
+	hashedPassword, err := hashing.HashPassword(password)
 	if err != nil {
 		log.Println(err)
-		if errors.Is(err, ErrInvalidInput) {
+		if errors.Is(err, hashing.ErrInvalidPassword) {
 			return fmt.Errorf("%w: invalid password", ErrInvalidInput)
 		}
 		return fmt.Errorf("%w: failed to hash password", ErrInternal)

--- a/internal/db/db_users_test.go
+++ b/internal/db/db_users_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/canonical/notary/internal/db"
-	"golang.org/x/crypto/bcrypt"
+	"github.com/canonical/notary/internal/hashing"
 )
 
 func TestUsersEndToEnd(t *testing.T) {
@@ -62,7 +62,7 @@ func TestUsersEndToEnd(t *testing.T) {
 	if retrievedUser.Username != "admin" {
 		t.Fatalf("The user from the database doesn't match the user that was given")
 	}
-	if err := bcrypt.CompareHashAndPassword([]byte(retrievedUser.HashedPassword), []byte("pw123")); err != nil {
+	if err := hashing.CompareHashAndPassword(retrievedUser.HashedPassword, "pw123"); err != nil {
 		t.Fatalf("The user's password doesn't match the one stored in the database")
 	}
 
@@ -79,7 +79,7 @@ func TestUsersEndToEnd(t *testing.T) {
 		t.Fatalf("Couldn't complete Update: %s", err)
 	}
 	retrievedUser, _ = database.GetUser(db.ByUsername("norman"))
-	if err := bcrypt.CompareHashAndPassword([]byte(retrievedUser.HashedPassword), []byte("thebestpassword")); err != nil {
+	if err := hashing.CompareHashAndPassword(retrievedUser.HashedPassword, "thebestpassword"); err != nil {
 		t.Fatalf("The new password that was given does not match the password that was stored.")
 	}
 }
@@ -191,7 +191,7 @@ func TestUpdateUserPasswordFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't complete GetUser: %s", err)
 	}
-	if err := bcrypt.CompareHashAndPassword([]byte(retrievedUser.HashedPassword), []byte(originalPassword)); err != nil {
+	if err := hashing.CompareHashAndPassword(retrievedUser.HashedPassword, originalPassword); err != nil {
 		t.Fatalf("The user's password doesn't match the one stored in the database")
 	}
 	num, err := database.NumUsers()
@@ -213,7 +213,7 @@ func TestUpdateUserPasswordFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't complete GetUser: %s", err)
 	}
-	if err := bcrypt.CompareHashAndPassword([]byte(retrievedUser.HashedPassword), []byte(originalPassword)); err != nil {
+	if err := hashing.CompareHashAndPassword(retrievedUser.HashedPassword, originalPassword); err != nil {
 		t.Fatalf("The user's password doesn't match the one stored in the database")
 	}
 }

--- a/internal/db/validation.go
+++ b/internal/db/validation.go
@@ -7,9 +7,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"strings"
-
-	"golang.org/x/crypto/bcrypt"
 )
 
 // ValidateCertificateRequest validates the given CSR string to the following:
@@ -155,16 +152,4 @@ func sanitizeCertificateBundle(cert string) ([]string, error) {
 		certData = rest
 	}
 	return output, nil
-}
-
-// Takes the password string, makes sure it's not empty, and hashes it using bcrypt
-func HashPassword(password string) (string, error) {
-	if strings.TrimSpace(password) == "" {
-		return "", fmt.Errorf("%w: password cannot be empty", ErrInvalidInput)
-	}
-	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
-	if err != nil {
-		return "", err
-	}
-	return string(hashedPassword), nil
 }

--- a/internal/hashing/argon2id.go
+++ b/internal/hashing/argon2id.go
@@ -46,7 +46,7 @@ func HashPassword(password string) (string, error) {
 
 	encoded_salt := base64.RawStdEncoding.EncodeToString(salt)
 	encoded_hash := base64.RawStdEncoding.EncodeToString(hash)
-	hashedPassword := fmt.Sprintf("$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+	hashedPassword := fmt.Sprintf(phcFormat,
 		argon2.Version,
 		DefaultArgon2IDParameters.Memory,
 		DefaultArgon2IDParameters.Time,

--- a/internal/hashing/argon2id.go
+++ b/internal/hashing/argon2id.go
@@ -1,0 +1,162 @@
+package hashing
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"golang.org/x/crypto/argon2"
+)
+
+const ARGON2_VERSION = 19
+
+type Argon2IDParameters struct {
+	SaltLength uint32
+	Time       uint32
+	Memory     uint32
+	Threads    uint8
+	KeyLength  uint32
+}
+
+// Default parameters recommended by OWASP
+var DefaultArgon2IDParameters = Argon2IDParameters{
+	SaltLength: 16,
+	Time:       2,
+	Memory:     19 * 1024, // 19 MiB
+	Threads:    1,
+	KeyLength:  32,
+}
+
+var ErrInvalidPassword = errors.New("invalid password")
+
+// Takes the password string, makes sure it's not empty, and hashes it using argon2id
+func HashPassword(password string) (string, error) {
+	if strings.TrimSpace(password) == "" {
+		return "", fmt.Errorf("%w: password cannot be empty", ErrInvalidPassword)
+	}
+	salt, err := generateSalt(DefaultArgon2IDParameters.SaltLength)
+	if err != nil {
+		return "", err
+	}
+	hash := hashPasswordWithSaltAndParams(password, salt, DefaultArgon2IDParameters)
+
+	encoded_salt := base64.RawStdEncoding.EncodeToString(salt)
+	encoded_hash := base64.RawStdEncoding.EncodeToString(hash)
+	hashedPassword := fmt.Sprintf("$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		ARGON2_VERSION,
+		DefaultArgon2IDParameters.Memory,
+		DefaultArgon2IDParameters.Time,
+		DefaultArgon2IDParameters.Threads,
+		encoded_salt,
+		encoded_hash,
+	)
+	return string(hashedPassword), nil
+}
+
+// CompareHashAndPassword takes a hashed password string and a password,
+// hashes the password with the same parameters as the hashed password and
+// compares the resulting value, returning an error if they do not match.
+//
+// When this function is passed an invalid hashed password string, it will
+// hash the password with the default parameters to prevent an attacker from
+// getting information from the timing of a login failure.
+func CompareHashAndPassword(hashedPassword string, password string) error {
+	params, salt, hash, err := parseArgon2IDPHC(hashedPassword)
+	if err != nil {
+		// The hashedPassword was not parseable, hash the password with default values
+		// to spend the same amount of time.
+		_, _ = HashPassword(password)
+		return fmt.Errorf("password did not match")
+	}
+	newHash := hashPasswordWithSaltAndParams(password, salt, params)
+	if string(newHash) == string(hash) {
+		return nil
+	}
+	return fmt.Errorf("password did not match")
+}
+
+func hashPasswordWithSaltAndParams(password string, salt []byte, params Argon2IDParameters) []byte {
+	return argon2.IDKey(
+		[]byte(password),
+		salt,
+		params.Time,
+		params.Memory,
+		params.Threads,
+		params.KeyLength,
+	)
+}
+
+func generateSalt(n uint32) ([]byte, error) {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// Parses a PHC string for Argon2id, and returns Argon2id parameters, the salt and the hash
+func parseArgon2IDPHC(phc string) (Argon2IDParameters, []byte, []byte, error) {
+	fields := strings.Split(phc, "$")
+	if len(fields) != 6 {
+		return DefaultArgon2IDParameters, nil, nil, fmt.Errorf("cannot parse hashed password strings for argon2id")
+	}
+	if fields[1] != "argon2id" || fields[2] != fmt.Sprintf("v=%d", ARGON2_VERSION) {
+		return DefaultArgon2IDParameters, nil, nil, fmt.Errorf("cannot parse hashed password strings for argon2id")
+	}
+
+	kvs := strings.Split(fields[3], ",")
+	
+	params := make(map[string]string)
+	for _, kv := range kvs {
+		parts := strings.Split(kv, "=")
+		if len(parts) != 2 {
+			return DefaultArgon2IDParameters, nil, nil, fmt.Errorf("cannot parse hashed password strings for argon2id")
+		}
+		params[parts[0]] = parts[1]
+	}
+
+	m, ok := params["m"]
+	if !ok {
+		return DefaultArgon2IDParameters, nil, nil, fmt.Errorf("cannot parse hashed password strings for argon2id")
+	}
+	t, ok := params["t"]
+	if !ok {
+		return DefaultArgon2IDParameters, nil, nil, fmt.Errorf("cannot parse hashed password strings for argon2id")
+	}
+	p, ok := params["p"]
+	if !ok {
+		return DefaultArgon2IDParameters, nil, nil, fmt.Errorf("cannot parse hashed password strings for argon2id")
+	}
+	memory, err := strconv.ParseUint(m, 10, 32)
+	if err != nil {
+		return DefaultArgon2IDParameters, nil, nil, fmt.Errorf("cannot parse hashed password strings for argon2id")
+	}
+	time, err := strconv.ParseUint(t, 10, 32)
+	if err != nil {
+		return DefaultArgon2IDParameters, nil, nil, fmt.Errorf("cannot parse hashed password strings for argon2id")
+	}
+	threads, err := strconv.ParseUint(p, 10, 8)
+	if err != nil {
+		return DefaultArgon2IDParameters, nil, nil, fmt.Errorf("cannot parse hashed password strings for argon2id")
+	}
+
+	parameters := DefaultArgon2IDParameters
+	parameters.Memory = uint32(memory)
+	parameters.Time = uint32(time)
+	parameters.Threads = uint8(threads)
+
+	salt, err := base64.RawStdEncoding.DecodeString(fields[4])
+	if err != nil {
+		return DefaultArgon2IDParameters, nil, nil, fmt.Errorf("cannot parse hashed password strings for argon2id")
+	}
+	hashedPassword, err := base64.RawStdEncoding.DecodeString(fields[5])
+	if err != nil {
+		return DefaultArgon2IDParameters, nil, nil, fmt.Errorf("cannot parse hashed password strings for argon2id")
+	}
+
+	return parameters, salt, hashedPassword, nil
+}

--- a/internal/hashing/argon2id_test.go
+++ b/internal/hashing/argon2id_test.go
@@ -37,67 +37,67 @@ func TestExternallyGeneratedHashMatchesCanBeValidated(t *testing.T) {
 
 func TestInvalidPHCArgon2idStringsReturnDefaultParamsAndError(t *testing.T) {
 	testCases := []struct {
-		desc string
+		desc  string
 		input string
 	}{
 		{
-			desc: "Empty string",
+			desc:  "Empty string",
 			input: "",
 		},
 		{
-			desc: "Random string",
+			desc:  "Random string",
 			input: "hjljdh7223%%asduy$$dcfas kjf",
 		},
 		{
-			desc: "Not enough fields",
+			desc:  "Not enough fields",
 			input: "$argon2id$v=19$salt$password",
 		},
 		{
-			desc: "Too many fields",
+			desc:  "Too many fields",
 			input: "$argon2id$v=19$m=6,t=2,p=1$salt$password$extra",
 		},
 		{
-			desc: "Wrong hash identifier",
+			desc:  "Wrong hash identifier",
 			input: "$argon2i$v=19$m=16,t=2,p=1$cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
 		},
 		{
-			desc: "Wrong hash version",
+			desc:  "Wrong hash version",
 			input: "$argon2id$v=42$m=16,t=2,p=1$cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
 		},
 		{
-			desc: "Badly formatted parameters",
+			desc:  "Badly formatted parameters",
 			input: "$argon2id$v=19$m:16,t:2,p:1$cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
 		},
 		{
-			desc: "Missing memory parameter",
+			desc:  "Missing memory parameter",
 			input: "$argon2id$v=19$t=2,p=1$cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
 		},
 		{
-			desc: "Missing time parameter",
+			desc:  "Missing time parameter",
 			input: "$argon2id$v=19$m=16,p=1$cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
 		},
 		{
-			desc: "Missing parallelism parameter",
+			desc:  "Missing parallelism parameter",
 			input: "$argon2id$v=19$m=16,t=2$cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
 		},
 		{
-			desc: "Memory not uint",
+			desc:  "Memory not uint",
 			input: "$argon2id$v=19$m=sixteen,t=2,p=1$cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
 		},
 		{
-			desc: "Time not uint",
+			desc:  "Time not uint",
 			input: "$argon2id$v=19$m=16,t=two,p=1$cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
 		},
 		{
-			desc: "Parallelism not uint",
+			desc:  "Parallelism not uint",
 			input: "$argon2id$v=19$m=16,t=2,p=one$cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
 		},
 		{
-			desc: "Salt not valid base64",
+			desc:  "Salt not valid base64",
 			input: "$argon2id$v=19$m=16,t=2,p=1$%cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
 		},
 		{
-			desc: "Hash valid base64",
+			desc:  "Hash valid base64",
 			input: "$argon2id$v=19$m=16,t=2,p=1$cE5sS1k4eTNkdEhjRENsag$R%d6mkWZZPLjfbXG9Uaia4Q",
 		},
 	}

--- a/internal/hashing/argon2id_test.go
+++ b/internal/hashing/argon2id_test.go
@@ -1,0 +1,116 @@
+package hashing
+
+import (
+	"testing"
+)
+
+func TestHashPasswordMatchesCanBeValidated(t *testing.T) {
+	password := "correct horse battery staple"
+	hash, err := HashPassword(password)
+	if err != nil {
+		t.Fatalf("could not hash password: %v", err)
+	}
+
+	err = CompareHashAndPassword(hash, password)
+	if err != nil {
+		t.Fatalf("password should match hash: %v", err)
+	}
+}
+
+func TestHashPasswordEmptyPasswordReturnsError(t *testing.T) {
+	_, err := HashPassword("")
+	if err == nil {
+		t.Fatalf("hashing empty password should fail")
+	}
+}
+
+func TestExternallyGeneratedHashMatchesCanBeValidated(t *testing.T) {
+	password := "correct horse battery staple"
+	// This hash was generated online: https://argon2.online/
+	hash := "$argon2id$v=19$m=16,t=2,p=1$cE5sS1k4eTNkdEhjRENsag$8wrqyGXxX5LBqt1Ixr7NSOW9WgM6ggS9XRrQM1Bt2Mw"
+
+	err := CompareHashAndPassword(hash, password)
+	if err != nil {
+		t.Fatalf("password: %v should match hash: %v but got error: %v", password, hash, err)
+	}
+}
+
+func TestInvalidPHCArgon2idStringsReturnDefaultParamsAndError(t *testing.T) {
+	testCases := []struct {
+		desc string
+		input string
+	}{
+		{
+			desc: "Empty string",
+			input: "",
+		},
+		{
+			desc: "Random string",
+			input: "hjljdh7223%%asduy$$dcfas kjf",
+		},
+		{
+			desc: "Not enough fields",
+			input: "$argon2id$v=19$salt$password",
+		},
+		{
+			desc: "Too many fields",
+			input: "$argon2id$v=19$m=6,t=2,p=1$salt$password$extra",
+		},
+		{
+			desc: "Wrong hash identifier",
+			input: "$argon2i$v=19$m=16,t=2,p=1$cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
+		},
+		{
+			desc: "Wrong hash version",
+			input: "$argon2id$v=42$m=16,t=2,p=1$cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
+		},
+		{
+			desc: "Badly formatted parameters",
+			input: "$argon2id$v=19$m:16,t:2,p:1$cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
+		},
+		{
+			desc: "Missing memory parameter",
+			input: "$argon2id$v=19$t=2,p=1$cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
+		},
+		{
+			desc: "Missing time parameter",
+			input: "$argon2id$v=19$m=16,p=1$cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
+		},
+		{
+			desc: "Missing parallelism parameter",
+			input: "$argon2id$v=19$m=16,t=2$cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
+		},
+		{
+			desc: "Memory not uint",
+			input: "$argon2id$v=19$m=sixteen,t=2,p=1$cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
+		},
+		{
+			desc: "Time not uint",
+			input: "$argon2id$v=19$m=16,t=two,p=1$cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
+		},
+		{
+			desc: "Parallelism not uint",
+			input: "$argon2id$v=19$m=16,t=2,p=one$cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
+		},
+		{
+			desc: "Salt not valid base64",
+			input: "$argon2id$v=19$m=16,t=2,p=1$%cE5sS1k4eTNkdEhjRENsag$Rd6mkWZZPLjfbXG9Uaia4Q",
+		},
+		{
+			desc: "Hash valid base64",
+			input: "$argon2id$v=19$m=16,t=2,p=1$cE5sS1k4eTNkdEhjRENsag$R%d6mkWZZPLjfbXG9Uaia4Q",
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			params, _, _, err := parseArgon2IDPHC(tC.input)
+			if err == nil {
+				t.Errorf("should have failed parsing: %s", tC.input)
+			}
+			if params != DefaultArgon2IDParameters {
+				t.Errorf("expected default parameters, got: %v", params)
+			}
+		})
+	}
+
+}

--- a/internal/hashing/argon2id_test.go
+++ b/internal/hashing/argon2id_test.go
@@ -13,7 +13,7 @@ func TestHashPasswordMatchesCanBeValidated(t *testing.T) {
 
 	err = CompareHashAndPassword(hash, password)
 	if err != nil {
-		t.Fatalf("password should match hash: %v", err)
+		t.Fatalf("password %v should match hash %v, got error: %v", password, hash, err)
 	}
 }
 
@@ -103,12 +103,12 @@ func TestInvalidPHCArgon2idStringsReturnDefaultParamsAndError(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			params, _, _, err := parseArgon2IDPHC(tC.input)
+			encoding, err := parseArgon2IDPHC(tC.input)
 			if err == nil {
 				t.Errorf("should have failed parsing: %s", tC.input)
 			}
-			if params != DefaultArgon2IDParameters {
-				t.Errorf("expected default parameters, got: %v", params)
+			if encoding.params != DefaultArgon2IDParameters {
+				t.Errorf("expected default parameters, got: %v", encoding.params)
 			}
 		})
 	}


### PR DESCRIPTION
# Description

This PR replaces the use of `bcrypt` by `argon2id` as recommended by [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#password-hashing-algorithms). It uses the default parameters recommended by the same organization and creates a struct that can be used in the future to configure the parameters.

Because the Go library for `argon2id` is less complete than `bcrypt`, I also had to implement the salt generation, and the PHC formatting.

I took the opportunity to refactor a bit the login operation, so that when a user is not found, we still hash the password, so that an attacker cannot extract information about existing users by analyzing the timing.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
