### PR TITLE
feat: enforce frontend formatting and linting

### DIFF
--- a/.github/workflows/frontend-build.yaml
+++ b/.github/workflows/frontend-build.yaml
@@ -11,8 +11,12 @@ jobs:
         working-directory: ui
     steps:
       - uses: actions/checkout@v4
-      - name: Use npm
+      - name: use npm
         uses: actions/setup-node@v4
+
+      - name: check format
+        run: |
+          npx prettier -c src/
 
       - name: Build frontend
         run: |

--- a/ui/eslint.config.ts
+++ b/ui/eslint.config.ts
@@ -1,0 +1,38 @@
+import tseslint from "typescript-eslint";
+import eslint from "typescript-eslint";
+import globals from "globals";
+import { FlatCompat } from '@eslint/eslintrc'
+
+const compat = new FlatCompat({
+  baseDirectory: import.meta.dirname,
+})
+
+export default tseslint.config(
+  {
+    // Add browser globals
+    files: ["src/**/*.{ts,tsx}"],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+      }
+    }
+  },
+  {
+    // Add javascript and typescript rules
+    files: ["src/**/*.{ts,tsx}"],
+    extends: [
+      eslint.configs.recommended,
+      tseslint.configs.recommendedTypeChecked,
+    ],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  // Add Next.js rules and avoid conflicts with prettier
+  ...compat.config({
+    extends: ['next', 'prettier'],
+  }),
+)

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,15 +18,23 @@
         "vanilla-framework": "^4.21.1"
       },
       "devDependencies": {
+        "@eslint/js": "^9.23.0",
+        "@next/eslint-plugin-next": "^15.2.4",
         "@testing-library/react": "^16.2.0",
         "@types/node": "^22",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "@vitejs/plugin-react": "^4.3.4",
-        "eslint": "^8",
+        "eslint": "^9.23.0",
         "eslint-config-next": "15.2.3",
+        "eslint-config-prettier": "^10.1.1",
+        "eslint-plugin-prettier": "^5.2.5",
+        "globals": "^16.0.0",
+        "jiti": "^2.4.2",
         "jsdom": "^26.0.0",
+        "prettier": "3.5.3",
         "typescript": "^5",
+        "typescript-eslint": "^8.29.0",
         "vitest": "^3.0.9"
       }
     },
@@ -227,27 +235,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.0"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
-      "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.0"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -289,10 +297,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
-      "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -301,15 +310,15 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -334,10 +343,20 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/traverse/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@babel/types": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
-      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -494,168 +513,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
-      "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.1.tgz",
-      "integrity": "sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.1.tgz",
-      "integrity": "sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.1.tgz",
-      "integrity": "sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.1.tgz",
-      "integrity": "sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.1.tgz",
-      "integrity": "sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.1.tgz",
-      "integrity": "sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.1.tgz",
-      "integrity": "sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.1.tgz",
-      "integrity": "sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.1.tgz",
-      "integrity": "sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.1.tgz",
@@ -668,261 +525,6 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.1.tgz",
-      "integrity": "sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.1.tgz",
-      "integrity": "sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.1.tgz",
-      "integrity": "sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.1.tgz",
-      "integrity": "sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.1.tgz",
-      "integrity": "sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.1.tgz",
-      "integrity": "sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.1.tgz",
-      "integrity": "sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.1.tgz",
-      "integrity": "sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.1.tgz",
-      "integrity": "sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.1.tgz",
-      "integrity": "sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.1.tgz",
-      "integrity": "sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.1.tgz",
-      "integrity": "sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.1.tgz",
-      "integrity": "sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.1.tgz",
-      "integrity": "sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.1.tgz",
-      "integrity": "sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -944,24 +546,64 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
-      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
-    "node_modules/@eslint/eslintrc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+    "node_modules/@eslint/config-array": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
+      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
       "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.1.tgz",
+      "integrity": "sha512-RI17tsD2frtDu/3dmI7QRrD4bedNKPM08ziRYaC5AhkGrzIAJelm9kJU1TznK+apx6V+cqRz8tfpEeG3oIyjxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
+      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.6.0",
-        "globals": "^13.19.0",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -969,49 +611,108 @@
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "version": "9.23.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.23.0.tgz",
+      "integrity": "sha512-35MJ8vCPU0ZMxo7zfev2pypqTwWTofFZO6m4KAtdoFhRpLJUpHTZZ+KB3C7Hb1d7bULYwO4lJXGCi5Se+8OMbw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@humanwhocodes/config-array": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
-      "deprecated": "Use @eslint/config-array instead",
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
       "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
+      "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
+      "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.3",
-        "debug": "^4.3.1",
-        "minimatch": "^3.0.5"
+        "@eslint/core": "^0.13.0",
+        "levn": "^0.4.1"
       },
       "engines": {
-        "node": ">=10.10.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
+      "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -1027,98 +728,18 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-      "deprecated": "Use @eslint/object-schema instead",
-      "dev": true
-    },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
+      "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=18.18"
       },
       "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
@@ -1127,36 +748,6 @@
       "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
       "cpu": [
         "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
-      "cpu": [
-        "s390x"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
-      "cpu": [
-        "x64"
       ],
       "optional": true,
       "os": [
@@ -1181,42 +772,6 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
-      }
-    },
     "node_modules/@img/sharp-linux-arm64": {
       "version": "0.33.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
@@ -1238,48 +793,6 @@
         "@img/sharp-libvips-linux-arm64": "1.0.4"
       }
     },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
-      }
-    },
     "node_modules/@img/sharp-linuxmusl-arm64": {
       "version": "0.33.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
@@ -1299,81 +812,6 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.2.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@jest/environment": {
@@ -1508,9 +946,9 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.2.3.tgz",
-      "integrity": "sha512-eNSOIMJtjs+dp4Ms1tB1PPPJUQHP3uZK+OQ7iFY9qXpGO6ojT6imCL+KcUOqE/GXGidWbBZJzYdgAdPHqeCEPA==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.2.4.tgz",
+      "integrity": "sha512-O8ScvKtnxkp8kL9TpJTTKnMqlkZnS+QxwoQnJwPGBxjBbzd6OVVPEJ5/pMNrktSyXQD/chEfzfFzYLM6JANOOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1754,101 +1192,6 @@
         "@parcel/watcher-win32-x64": "2.4.1"
       }
     },
-    "node_modules/@parcel/watcher-android-arm64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.4.1.tgz",
-      "integrity": "sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-darwin-arm64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.4.1.tgz",
-      "integrity": "sha512-ln41eihm5YXIY043vBrrHfn94SIBlqOWmoROhsMVTSXGh0QahKGy77tfEywQ7v3NywyxBBkGIfrWRHm0hsKtzA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-darwin-x64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.4.1.tgz",
-      "integrity": "sha512-yrw81BRLjjtHyDu7J61oPuSoeYWR3lDElcPGJyOvIXmor6DEo7/G2u1o7I38cwlcoBHQFULqF6nesIX3tsEXMg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-freebsd-x64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.4.1.tgz",
-      "integrity": "sha512-TJa3Pex/gX3CWIx/Co8k+ykNdDCLx+TuZj3f3h7eOjgpdKM+Mnix37RYsYU4LHhiYJz3DK5nFCCra81p6g050w==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm-glibc": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.4.1.tgz",
-      "integrity": "sha512-4rVYDlsMEYfa537BRXxJ5UF4ddNwnr2/1O4MHM5PjI9cvV2qymvhwZSFgXqbS8YoTk5i/JR0L0JDs69BUn45YA==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/@parcel/watcher-linux-arm64-glibc": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.4.1.tgz",
@@ -1887,99 +1230,17 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/watcher-linux-x64-glibc": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.4.1.tgz",
-      "integrity": "sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
+    "node_modules/@pkgr/core": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.0.tgz",
+      "integrity": "sha512-vsJDAkYR6qCPu+ioGScGiMYR7LvZYIXh/dlQeviqoTWNCVfKTLYD/LkNWH4Mxsv2a5vpIRc77FN5DnmK1eBggQ==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 10.0.0"
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
       },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-musl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.4.1.tgz",
-      "integrity": "sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-arm64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.4.1.tgz",
-      "integrity": "sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-ia32": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.4.1.tgz",
-      "integrity": "sha512-maNRit5QQV2kgHFSYwftmPBxiuK5u4DXjbXx7q6eKjq5dsLXZ4FJiVvlcw35QXzk0KrUecJmuVFbj4uV9oYrcw==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-x64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.4.1.tgz",
-      "integrity": "sha512-+DvS92F9ezicfswqrvIRM2njcYJbd5mb9CUgtrHCHmvn7pPPa+nMDRu1o1bYYz/l5IB2NVGNJWiH7h1E58IF2A==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -2264,7 +1525,8 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -2320,12 +1582,6 @@
         "@types/react": "*"
       }
     },
-    "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-      "dev": true
-    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -2354,91 +1610,72 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.2.0.tgz",
-      "integrity": "sha512-mdekAHOqS9UjlmyF/LSs6AIEvfceV749GFxoBAjwAv0nkevfKHWQFDMcBZWUiIC5ft6ePWivXoS36aKQ0Cy3sw==",
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.29.0.tgz",
+      "integrity": "sha512-PAIpk/U7NIS6H7TEtN45SPGLQaHNgB7wSjsQV/8+KYokAb2T/gloOA/Bee2yd4/yKVhPKe5LlaUGhAZk5zmSaQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "7.2.0",
-        "@typescript-eslint/type-utils": "7.2.0",
-        "@typescript-eslint/utils": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0",
-        "debug": "^4.3.4",
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.29.0",
+        "@typescript-eslint/type-utils": "8.29.0",
+        "@typescript-eslint/utils": "8.29.0",
+        "@typescript-eslint/visitor-keys": "8.29.0",
         "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
+        "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^7.0.0",
-        "eslint": "^8.56.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.2.0.tgz",
-      "integrity": "sha512-5FKsVcHTk6TafQKQbuIVkXq58Fnbkd2wDL4LB7AURN7RUOu1utVP+G8+6u3ZhEroW3DF6hyo3ZEXxgKgp4KeCg==",
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.29.0.tgz",
+      "integrity": "sha512-8C0+jlNJOwQso2GapCVWWfW/rzaq7Lbme+vGUFKE31djwNncIpgXD7Cd4weEsDdkoZDjH0lwwr3QDQFuyrMg9g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.2.0",
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/typescript-estree": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0",
+        "@typescript-eslint/scope-manager": "8.29.0",
+        "@typescript-eslint/types": "8.29.0",
+        "@typescript-eslint/typescript-estree": "8.29.0",
+        "@typescript-eslint/visitor-keys": "8.29.0",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.2.0.tgz",
-      "integrity": "sha512-Qh976RbQM/fYtjx9hs4XkayYujB/aPwglw2choHmf3zBjB4qOywWSdt9+KLRdHubGcoSwBnXUH2sR3hkyaERRg==",
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.29.0.tgz",
+      "integrity": "sha512-aO1PVsq7Gm+tcghabUpzEnVSFMCU4/nYIgC2GOatJcllvWfnhrgW0ZEbnTxm36QsikmCN1K/6ZgM7fok2I7xNw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0"
+        "@typescript-eslint/types": "8.29.0",
+        "@typescript-eslint/visitor-keys": "8.29.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2446,39 +1683,37 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.2.0.tgz",
-      "integrity": "sha512-xHi51adBHo9O9330J8GQYQwrKBqbIPJGZZVQTHHmy200hvkLZFWJIFtAG/7IYTWUyun6DE6w5InDReePJYJlJA==",
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.29.0.tgz",
+      "integrity": "sha512-ahaWQ42JAOx+NKEf5++WC/ua17q5l+j1GFrbbpVKzFL/tKVc0aYY8rVSYUpUvt2hUP1YBr7mwXzx+E/DfUWI9Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.2.0",
-        "@typescript-eslint/utils": "7.2.0",
+        "@typescript-eslint/typescript-estree": "8.29.0",
+        "@typescript-eslint/utils": "8.29.0",
         "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.2.0.tgz",
-      "integrity": "sha512-XFtUHPI/abFhm4cbCDc5Ykc8npOKBSJePY3a3s+lwumt7XWJuzP5cZcfZ610MIPHjQjNsOLlYK8ASPaNG8UiyA==",
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.29.0.tgz",
+      "integrity": "sha512-wcJL/+cOXV+RE3gjCyl/V2G877+2faqvlgtso/ZRbTCnZazh0gXhe+7gbAnfubzN2bNsBtZjDvlh7ero8uIbzg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2486,31 +1721,30 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.2.0.tgz",
-      "integrity": "sha512-cyxS5WQQCoBwSakpMrvMXuMDEbhOo9bNHHrNcEWis6XHx6KF518tkF1wBvKIn/tpq5ZpUYK7Bdklu8qY0MsFIA==",
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.29.0.tgz",
+      "integrity": "sha512-yOfen3jE9ISZR/hHpU/bmNvTtBW1NjRbkSFdZOksL1N+ybPEE7UVGMwqvS6CP022Rp00Sb0tdiIkhSCe6NI8ow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0",
+        "@typescript-eslint/types": "8.29.0",
+        "@typescript-eslint/visitor-keys": "8.29.0",
         "debug": "^4.3.4",
-        "globby": "^11.1.0",
+        "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
@@ -2518,15 +1752,17 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -2550,64 +1786,59 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.2.0.tgz",
-      "integrity": "sha512-YfHpnMAGb1Eekpm3XRK8hcMwGLGsnT6L+7b2XyRv6ouDuJU1tZir1GS2i0+VXRatMwSI1/UfcyPe53ADkU+IuA==",
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.29.0.tgz",
+      "integrity": "sha512-gX/A0Mz9Bskm8avSWFcK0gP7cZpbY4AIo6B0hWYFCaIsz750oaiWR4Jr2CI+PQhfW1CpcQr9OlfPS+kMFegjXA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "7.2.0",
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/typescript-estree": "7.2.0",
-        "semver": "^7.5.4"
+        "@typescript-eslint/scope-manager": "8.29.0",
+        "@typescript-eslint/types": "8.29.0",
+        "@typescript-eslint/typescript-estree": "8.29.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.2.0.tgz",
-      "integrity": "sha512-c6EIQRHhcpl6+tO8EMR+kjkkV+ugUNXOmeASA1rlzkd8EPIriavpWoiEz1HR/VLhbVIdhqnV6E7JZm00cBDx2A==",
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.29.0.tgz",
+      "integrity": "sha512-Sne/pVz8ryR03NFK21VpN88dZ2FdQXOlq3VIklbrTYEt8yXtRFr9tvUhqvCeKjqYk5FSim37sHbooT6vzBTZcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.2.0",
-        "eslint-visitor-keys": "^3.4.1"
+        "@typescript-eslint/types": "8.29.0",
+        "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-      "dev": true
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.3.4",
@@ -2750,9 +1981,10 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2775,6 +2007,7 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -2805,6 +2038,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2821,6 +2055,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2843,7 +2078,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -2856,13 +2092,14 @@
       }
     },
     "node_modules/array-buffer-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
-      "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
-        "is-array-buffer": "^3.0.4"
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2889,15 +2126,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/array.prototype.findlast": {
@@ -2959,15 +2187,16 @@
       }
     },
     "node_modules/array.prototype.flatmap": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
-      "integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2993,19 +2222,19 @@
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
-      "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.22.3",
-        "es-errors": "^1.2.1",
-        "get-intrinsic": "^1.2.3",
-        "is-array-buffer": "^3.0.4",
-        "is-shared-array-buffer": "^1.0.2"
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3043,6 +2272,16 @@
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
     },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3053,6 +2292,7 @@
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -3171,16 +2411,47 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3194,6 +2465,7 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -3372,10 +2644,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -3429,14 +2702,15 @@
       }
     },
     "node_modules/data-view-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
-      "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
+        "is-data-view": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3446,29 +2720,31 @@
       }
     },
     "node_modules/data-view-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
-      "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
+        "is-data-view": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "url": "https://github.com/sponsors/inspect-js"
       }
     },
     "node_modules/data-view-byte-offset": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
-      "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
         "is-data-view": "^1.0.1"
       },
@@ -3599,30 +2875,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -3641,6 +2893,21 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -3681,57 +2948,63 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
-      "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+      "version": "1.23.9",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
+      "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.1",
-        "arraybuffer.prototype.slice": "^1.0.3",
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
-        "data-view-buffer": "^1.0.1",
-        "data-view-byte-length": "^1.0.1",
-        "data-view-byte-offset": "^1.0.0",
-        "es-define-property": "^1.0.0",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
-        "es-set-tostringtag": "^2.0.3",
-        "es-to-primitive": "^1.2.1",
-        "function.prototype.name": "^1.1.6",
-        "get-intrinsic": "^1.2.4",
-        "get-symbol-description": "^1.0.2",
-        "globalthis": "^1.0.3",
-        "gopd": "^1.0.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.0",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
         "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.0.3",
-        "has-symbols": "^1.0.3",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
-        "internal-slot": "^1.0.7",
-        "is-array-buffer": "^3.0.4",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
         "is-callable": "^1.2.7",
-        "is-data-view": "^1.0.1",
-        "is-negative-zero": "^2.0.3",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.3",
-        "is-string": "^1.0.7",
-        "is-typed-array": "^1.1.13",
-        "is-weakref": "^1.0.2",
-        "object-inspect": "^1.13.1",
+        "is-data-view": "^1.0.2",
+        "is-regex": "^1.2.1",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.0",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.3",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.5",
-        "regexp.prototype.flags": "^1.5.2",
-        "safe-array-concat": "^1.1.2",
-        "safe-regex-test": "^1.0.3",
-        "string.prototype.trim": "^1.2.9",
-        "string.prototype.trimend": "^1.0.8",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.3",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
         "string.prototype.trimstart": "^1.0.8",
-        "typed-array-buffer": "^1.0.2",
-        "typed-array-byte-length": "^1.0.1",
-        "typed-array-byte-offset": "^1.0.2",
-        "typed-array-length": "^1.0.6",
-        "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.15"
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.18"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3741,13 +3014,11 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -3762,25 +3033,28 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.1.0.tgz",
-      "integrity": "sha512-/SurEfycdyssORP/E+bj4sEu1CWw4EmLDsHynHwSXQ7utgbrMRWW195pTrCjFgFCddf/UkYm3oqKPRq5i8bJbw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
+      "integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.3",
+        "es-abstract": "^1.23.6",
         "es-errors": "^1.3.0",
         "es-set-tostringtag": "^2.0.3",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
+        "get-intrinsic": "^1.2.6",
         "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
         "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.0.3",
-        "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.7",
-        "iterator.prototype": "^1.1.3",
-        "safe-array-concat": "^1.1.2"
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.4",
+        "safe-array-concat": "^1.1.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3794,10 +3068,11 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -3806,14 +3081,16 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.4",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.1"
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3829,14 +3106,15 @@
       }
     },
     "node_modules/es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3930,58 +3208,64 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
-      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "version": "9.23.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.23.0.tgz",
+      "integrity": "sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.1",
-        "@humanwhocodes/config-array": "^0.13.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.19.2",
+        "@eslint/config-helpers": "^0.2.0",
+        "@eslint/core": "^0.12.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.23.0",
+        "@eslint/plugin-kit": "^0.2.7",
+        "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@nodelib/fs.walk": "^1.2.8",
-        "@ungap/structured-clone": "^1.2.0",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.3",
-        "espree": "^9.6.1",
-        "esquery": "^1.4.2",
+        "eslint-scope": "^8.3.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
+        "file-entry-cache": "^8.0.0",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
-        "globals": "^13.19.0",
-        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
-        "url": "https://opencollective.com/eslint"
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-config-next": {
@@ -4010,6 +3294,59 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/@next/eslint-plugin-next": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.2.3.tgz",
+      "integrity": "sha512-eNSOIMJtjs+dp4Ms1tB1PPPJUQHP3uZK+OQ7iFY9qXpGO6ojT6imCL+KcUOqE/GXGidWbBZJzYdgAdPHqeCEPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "3.3.1"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.1.tgz",
+      "integrity": "sha512-4EQQr6wXwS+ZJSzaR5ZCrYgLxqvUjdXctaEtBqHcbkW944B1NQyO4qpdHQbXBONfwxXdkAY81HH4+LUfrg+zPw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -4175,29 +3512,61 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/eslint-plugin-react": {
-      "version": "7.37.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.2.tgz",
-      "integrity": "sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==",
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.5.tgz",
+      "integrity": "sha512-IKKP8R87pJyMl7WWamLgPkloB16dagPIdd2FjBDbyRYPKo93wS/NbCOPh6gH+ieNLC+XZrhJt/kWj0PS/DFdmg==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.10.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.4.tgz",
+      "integrity": "sha512-BGP0jRmfYyvOyvMoRX/uoUeW+GqNj9y16bPQzqAHf3AYII/tDs+jMN0dBVkl88/OZwNGwrVFxE7riHsXVfy/LQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
-        "array.prototype.flatmap": "^1.3.2",
+        "array.prototype.flatmap": "^1.3.3",
         "array.prototype.tosorted": "^1.1.4",
         "doctrine": "^2.1.0",
-        "es-iterator-helpers": "^1.1.0",
+        "es-iterator-helpers": "^1.2.1",
         "estraverse": "^5.3.0",
         "hasown": "^2.0.2",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
         "object.entries": "^1.1.8",
         "object.fromentries": "^2.0.8",
-        "object.values": "^1.2.0",
+        "object.values": "^1.2.1",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.5",
         "semver": "^6.3.1",
-        "string.prototype.matchall": "^4.0.11",
+        "string.prototype.matchall": "^4.0.12",
         "string.prototype.repeat": "^1.0.0"
       },
       "engines": {
@@ -4249,16 +3618,17 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
+      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -4276,33 +3646,52 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+    "node_modules/eslint/node_modules/@types/estree": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
       "dev": true,
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=8"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.9.0",
+        "acorn": "^8.14.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
+        "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -4338,6 +3727,7 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -4400,7 +3790,15 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -4434,7 +3832,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -4452,15 +3851,16 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "flat-cache": "^3.0.4"
+        "flat-cache": "^4.0.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -4491,32 +3891,40 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
-        "keyv": "^4.5.3",
-        "rimraf": "^3.0.2"
+        "keyv": "^4.5.4"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-      "dev": true
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-callable": "^1.1.3"
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/form-data": {
@@ -4558,26 +3966,6 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -4588,15 +3976,18 @@
       }
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
-      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "functions-have-names": "^1.2.3"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4625,16 +4016,22 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4643,15 +4040,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-symbol-description": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
-      "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4"
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4685,13 +4097,16 @@
       }
     },
     "node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.0.0.tgz",
+      "integrity": "sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globalthis": {
@@ -4710,33 +4125,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4754,10 +4150,14 @@
       "dev": true
     },
     "node_modules/has-bigints": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4783,10 +4183,14 @@
       }
     },
     "node_modules/has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -4795,10 +4199,11 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4912,10 +4317,11 @@
       "integrity": "sha512-1NU7hWZDkV7hJ4PJ9dur9gTNQ4ePNPN4k9/0YhwjzykTi/+3Q5pF93YU5QoVj8BuOnhLgaY8gs0U2pj4kSYVcw=="
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -4936,44 +4342,31 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
     "node_modules/internal-slot": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
-      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "hasown": "^2.0.0",
-        "side-channel": "^1.0.4"
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/is-array-buffer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
-      "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4989,12 +4382,17 @@
       "optional": true
     },
     "node_modules/is-async-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
-      "integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5004,25 +4402,30 @@
       }
     },
     "node_modules/is-bigint": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-bigints": "^1.0.1"
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-boolean-object": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5036,6 +4439,7 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5059,11 +4463,14 @@
       }
     },
     "node_modules/is-data-view": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
-      "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
         "is-typed-array": "^1.1.13"
       },
       "engines": {
@@ -5074,12 +4481,14 @@
       }
     },
     "node_modules/is-date-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5098,24 +4507,32 @@
       }
     },
     "node_modules/is-finalizationregistry": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.0.2.tgz",
-      "integrity": "sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5141,18 +4558,7 @@
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-negative-zero": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5169,12 +4575,14 @@
       }
     },
     "node_modules/is-number-object": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5183,28 +4591,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
     },
     "node_modules/is-regex": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5218,6 +4620,7 @@
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5226,12 +4629,13 @@
       }
     },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
-      "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7"
+        "call-bound": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5241,12 +4645,14 @@
       }
     },
     "node_modules/is-string": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5256,12 +4662,15 @@
       }
     },
     "node_modules/is-symbol": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5271,12 +4680,13 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "which-typed-array": "^1.1.14"
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5290,6 +4700,7 @@
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5298,25 +4709,30 @@
       }
     },
     "node_modules/is-weakref": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-weakset": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
-      "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "get-intrinsic": "^1.2.4"
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5329,7 +4745,8 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5338,16 +4755,18 @@
       "dev": true
     },
     "node_modules/iterator.prototype": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.3.tgz",
-      "integrity": "sha512-FW5iMbeQ6rBGm/oKgzq2aW4KvAGpxPzYES8N4g4xNXUKpL1mclMvOe+76AcLDTvD+Ze+sOpVhgdAQEKF4L9iGQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "define-properties": "^1.2.1",
-        "get-intrinsic": "^1.2.1",
-        "has-symbols": "^1.0.3",
-        "reflect.getprototypeof": "^1.0.4",
-        "set-function-name": "^2.0.1"
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5761,6 +5180,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5771,6 +5200,7 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -5848,13 +5278,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5904,6 +5336,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -6026,6 +5459,16 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/merge2": {
@@ -6198,10 +5641,14 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6216,14 +5663,17 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
-        "has-symbols": "^1.0.3",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -6280,12 +5730,14 @@
       }
     },
     "node_modules/object.values": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.0.tgz",
-      "integrity": "sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
         "es-object-atoms": "^1.0.0"
       },
@@ -6294,15 +5746,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/optionator": {
@@ -6320,6 +5763,24 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-limit": {
@@ -6357,6 +5818,7 @@
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -6384,15 +5846,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -6407,15 +5860,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
-    },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -6469,10 +5913,11 @@
       }
     },
     "node_modules/possible-typed-array-names": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -6511,6 +5956,35 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-format": {
@@ -6698,18 +6172,20 @@
       }
     },
     "node_modules/reflect.getprototypeof": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
-      "integrity": "sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.1",
+        "es-abstract": "^1.23.9",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "globalthis": "^1.0.3",
-        "which-builtin-type": "^1.1.3"
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6725,15 +6201,18 @@
       "dev": true
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
-      "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
         "es-errors": "^1.3.0",
-        "set-function-name": "^2.0.1"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6764,6 +6243,7 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -6785,41 +6265,6 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rollup": {
@@ -6872,14 +6317,16 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
-      "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "get-intrinsic": "^1.2.4",
-        "has-symbols": "^1.0.3",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
       "engines": {
@@ -6889,15 +6336,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-regex-test": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
-      "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
-        "is-regex": "^1.1.4"
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6991,6 +6456,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/sharp": {
       "version": "0.33.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
@@ -7073,15 +6553,73 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7187,23 +6725,25 @@
       }
     },
     "node_modules/string.prototype.matchall": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.11.tgz",
-      "integrity": "sha512-NUdh0aDavY2og7IbBPenWqR9exH+E26Sv8e0/eTe1tltDGZL+GtBkDAnnyBtmekfK6/Dq3MkcGtzXFEd1LQrtg==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
+        "es-abstract": "^1.23.6",
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.7",
-        "regexp.prototype.flags": "^1.5.2",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
         "set-function-name": "^2.0.2",
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7223,15 +6763,19 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
-      "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.0",
-        "es-object-atoms": "^1.0.0"
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7241,14 +6785,19 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
-      "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
         "define-properties": "^1.2.1",
         "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7271,18 +6820,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -7297,6 +6834,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -7354,6 +6892,23 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
+    "node_modules/synckit": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.10.3.tgz",
+      "integrity": "sha512-R1urvuyiTaWfeCggqEvpDJwAlDVdsT9NM+IP//Tk2x7qHCkSvBk/fwFgw/TLAHzZlrAnnazMcRw0ZD8HlYFTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -7362,12 +6917,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
     },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
@@ -7468,15 +7017,16 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
-      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18.12"
       },
       "peerDependencies": {
-        "typescript": ">=4.2.0"
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -7529,43 +7079,33 @@
         "node": ">=4"
       }
     },
-    "node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typed-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.13"
+        "is-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/typed-array-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
-      "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-proto": "^1.0.3",
-        "is-typed-array": "^1.1.13"
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7575,17 +7115,19 @@
       }
     },
     "node_modules/typed-array-byte-offset": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
-      "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-proto": "^1.0.3",
-        "is-typed-array": "^1.1.13"
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7595,17 +7137,18 @@
       }
     },
     "node_modules/typed-array-length": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
-      "integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-proto": "^1.0.3",
         "is-typed-array": "^1.1.13",
-        "possible-typed-array-names": "^1.0.0"
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7628,16 +7171,43 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/unbox-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+    "node_modules/typescript-eslint": {
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.29.0.tgz",
+      "integrity": "sha512-ep9rVd9B4kQsZ7ZnWCVxUE/xDLUUUsRzE0poAeNu+4CkFErLfuvPt/qtm2EpnSyfvsR0S6QzDFSrPCFBwf64fg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "@typescript-eslint/eslint-plugin": "8.29.0",
+        "@typescript-eslint/parser": "8.29.0",
+        "@typescript-eslint/utils": "8.29.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
         "has-bigints": "^1.0.2",
-        "has-symbols": "^1.0.3",
-        "which-boxed-primitive": "^1.0.2"
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7694,6 +7264,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -7981,39 +7552,45 @@
       }
     },
     "node_modules/which-boxed-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-bigint": "^1.0.1",
-        "is-boolean-object": "^1.1.0",
-        "is-number-object": "^1.0.4",
-        "is-string": "^1.0.5",
-        "is-symbol": "^1.0.3"
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which-builtin-type": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.4.tgz",
-      "integrity": "sha512-bppkmBSsHFmIMSl8BO9TbsyzsvGjVoppt8xUiGzwiu/bhDCGxnpOKCxgqj6GuyHE0mINMDecBFPlOm2hzY084w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "call-bound": "^1.0.2",
         "function.prototype.name": "^1.1.6",
         "has-tostringtag": "^1.0.2",
         "is-async-function": "^2.0.0",
-        "is-date-object": "^1.0.5",
-        "is-finalizationregistry": "^1.0.2",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
         "is-generator-function": "^1.0.10",
-        "is-regex": "^1.1.4",
+        "is-regex": "^1.2.1",
         "is-weakref": "^1.0.2",
         "isarray": "^2.0.5",
-        "which-boxed-primitive": "^1.0.2",
+        "which-boxed-primitive": "^1.1.0",
         "which-collection": "^1.0.2",
-        "which-typed-array": "^1.1.15"
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8027,6 +7604,7 @@
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-map": "^2.0.3",
         "is-set": "^2.0.3",
@@ -8041,15 +7619,18 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
-      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -8083,12 +7664,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
     },
     "node_modules/ws": {
       "version": "8.18.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "format": "prettier --write src/",
     "test": "vitest run",
     "test-live": "vitest"
   },
@@ -23,15 +24,23 @@
     "vanilla-framework": "^4.21.1"
   },
   "devDependencies": {
+    "@eslint/js": "^9.23.0",
+    "@next/eslint-plugin-next": "^15.2.4",
     "@testing-library/react": "^16.2.0",
     "@types/node": "^22",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@vitejs/plugin-react": "^4.3.4",
-    "eslint": "^8",
+    "eslint": "^9.23.0",
     "eslint-config-next": "15.2.3",
+    "eslint-config-prettier": "^10.1.1",
+    "eslint-plugin-prettier": "^5.2.5",
+    "globals": "^16.0.0",
+    "jiti": "^2.4.2",
     "jsdom": "^26.0.0",
+    "prettier": "3.5.3",
     "typescript": "^5",
+    "typescript-eslint": "^8.29.0",
     "vitest": "^3.0.9"
   },
   "overrides": {

--- a/ui/src/app/(auth)/initialize/page.tsx
+++ b/ui/src/app/(auth)/initialize/page.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { passwordIsValid } from "@/utils"
-import { statusResponse } from "@/types"
 import { getStatus, login, postFirstUser } from "@/queries"
 import { useAuth } from "@/hooks/useAuth"
 import { Input, PasswordToggle, Button, Form, LoginPageLayout } from "@canonical/react-components";
@@ -14,8 +13,8 @@ import { useCookies } from "react-cookie"
 export default function Initialize() {
     const router = useRouter()
     const auth = useAuth()
-    const [cookies, setCookie, removeCookie] = useCookies(['user_token']);
-    const statusQuery = useQuery<statusResponse, Error>({
+    const [, setCookie] = useCookies(['user_token']);
+    const statusQuery = useQuery({
         queryKey: ["status"],
         queryFn: () => getStatus(),
     })
@@ -27,7 +26,7 @@ export default function Initialize() {
         mutationFn: login,
         onSuccess: (result) => {
             setErrorText("")
-            setCookie('user_token', result?.token, {
+            setCookie('user_token', result.token, {
                 sameSite: true,
                 secure: true,
                 expires: new Date(new Date().getTime() + 60 * 60 * 1000),
@@ -56,7 +55,7 @@ export default function Initialize() {
     const password1Error = password1 && !passwordIsValid(password1) ? "Password is not valid" : ""
     const password2Error = password2 && !passwordsMatch ? "Passwords do not match" : ""
 
-    const [errorText, setErrorText] = useState<string>("")
+    const [, setErrorText] = useState<string>("")
     const handleUsernameChange = (event: ChangeEvent<HTMLInputElement>) => { setUsername(event.target.value) }
     const handlePassword1Change = (event: ChangeEvent<HTMLInputElement>) => { setPassword1(event.target.value) }
     const handlePassword2Change = (event: ChangeEvent<HTMLInputElement>) => { setPassword2(event.target.value) }

--- a/ui/src/app/(auth)/initialize/page.tsx
+++ b/ui/src/app/(auth)/initialize/page.tsx
@@ -1,112 +1,128 @@
-"use client"
+"use client";
 
-import { passwordIsValid } from "@/utils"
-import { getStatus, login, postFirstUser } from "@/queries"
-import { useAuth } from "@/hooks/useAuth"
-import { Input, PasswordToggle, Button, Form, LoginPageLayout } from "@canonical/react-components";
-import { useMutation, useQuery } from "@tanstack/react-query"
-import { useState, ChangeEvent } from "react"
-import { useRouter } from "next/navigation"
-import { useCookies } from "react-cookie"
-
+import { passwordIsValid } from "@/utils";
+import { getStatus, login, postFirstUser } from "@/queries";
+import { useAuth } from "@/hooks/useAuth";
+import {
+  Input,
+  PasswordToggle,
+  Button,
+  Form,
+  LoginPageLayout,
+} from "@canonical/react-components";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useState, ChangeEvent } from "react";
+import { useRouter } from "next/navigation";
+import { useCookies } from "react-cookie";
 
 export default function Initialize() {
-    const router = useRouter()
-    const auth = useAuth()
-    const [, setCookie] = useCookies(['user_token']);
-    const statusQuery = useQuery({
-        queryKey: ["status"],
-        queryFn: () => getStatus(),
-    })
-    if (statusQuery.data && statusQuery.data.initialized) {
-        auth.setFirstUserCreated(true)
-        router.push("/login")
-    }
-    const loginMutation = useMutation({
-        mutationFn: login,
-        onSuccess: (result) => {
-            setErrorText("")
-            setCookie('user_token', result.token, {
-                sameSite: true,
-                secure: true,
-                expires: new Date(new Date().getTime() + 60 * 60 * 1000),
-            })
-            router.push('/certificate_requests')
-        },
-        onError: (e: Error) => {
-            setErrorText(e.message)
-        }
-    })
-    const postUserMutation = useMutation({
-        mutationFn: postFirstUser,
-        onSuccess: () => {
-            setErrorText("")
-            auth.setFirstUserCreated(true)
-            loginMutation.mutate({ username: username, password: password1 })
-        },
-        onError: (e: Error) => {
-            setErrorText(e.message)
-        }
-    })
-    const [username, setUsername] = useState<string>("")
-    const [password1, setPassword1] = useState<string>("")
-    const [password2, setPassword2] = useState<string>("")
-    const passwordsMatch = password1 === password2
-    const password1Error = password1 && !passwordIsValid(password1) ? "Password is not valid" : ""
-    const password2Error = password2 && !passwordsMatch ? "Passwords do not match" : ""
+  const router = useRouter();
+  const auth = useAuth();
+  const [, setCookie] = useCookies(["user_token"]);
+  const statusQuery = useQuery({
+    queryKey: ["status"],
+    queryFn: () => getStatus(),
+  });
+  if (statusQuery.data && statusQuery.data.initialized) {
+    auth.setFirstUserCreated(true);
+    router.push("/login");
+  }
+  const loginMutation = useMutation({
+    mutationFn: login,
+    onSuccess: (result) => {
+      setErrorText("");
+      setCookie("user_token", result.token, {
+        sameSite: true,
+        secure: true,
+        expires: new Date(new Date().getTime() + 60 * 60 * 1000),
+      });
+      router.push("/certificate_requests");
+    },
+    onError: (e: Error) => {
+      setErrorText(e.message);
+    },
+  });
+  const postUserMutation = useMutation({
+    mutationFn: postFirstUser,
+    onSuccess: () => {
+      setErrorText("");
+      auth.setFirstUserCreated(true);
+      loginMutation.mutate({ username: username, password: password1 });
+    },
+    onError: (e: Error) => {
+      setErrorText(e.message);
+    },
+  });
+  const [username, setUsername] = useState<string>("");
+  const [password1, setPassword1] = useState<string>("");
+  const [password2, setPassword2] = useState<string>("");
+  const passwordsMatch = password1 === password2;
+  const password1Error =
+    password1 && !passwordIsValid(password1) ? "Password is not valid" : "";
+  const password2Error =
+    password2 && !passwordsMatch ? "Passwords do not match" : "";
 
-    const [, setErrorText] = useState<string>("")
-    const handleUsernameChange = (event: ChangeEvent<HTMLInputElement>) => { setUsername(event.target.value) }
-    const handlePassword1Change = (event: ChangeEvent<HTMLInputElement>) => { setPassword1(event.target.value) }
-    const handlePassword2Change = (event: ChangeEvent<HTMLInputElement>) => { setPassword2(event.target.value) }
-    return (
-        <>
-            <LoginPageLayout
-                logo={{
-                    src: 'https://assets.ubuntu.com/v1/82818827-CoF_white.svg',
-                    title: 'Notary',
-                    url: '#'
-                }}
-                title="Initialize Notary"
-            >
-                <Form>
-                    <h4>Create the initial admin user</h4>
-                    <Input
-                        id="InputUsername"
-                        label="Username"
-                        type="text"
-                        required={true}
-                        onChange={handleUsernameChange}
-                    />
-                    <PasswordToggle
-                        help="Password must have 8 or more characters, must include at least one capital letter, one lowercase letter, and either a number or a symbol."
-                        id="password1"
-                        label="Password"
-                        onChange={handlePassword1Change}
-                        required={true}
-                        error={password1Error}
-                    />
-                    <PasswordToggle
-                        id="password2"
-                        label="Confirm Password"
-                        onChange={handlePassword2Change}
-                        required={true}
-                        error={password2Error}
-                    />
-                    <Button
-                        appearance="positive"
-                        disabled={!passwordsMatch || !passwordIsValid(password1)}
-                        onClick={(event) => {
-                            event.preventDefault();
-                            if (passwordsMatch && passwordIsValid(password1)) {
-                                postUserMutation.mutate({ username: username, password: password1 });
-                            }
-                        }}
-                    >
-                        Submit
-                    </Button>
-                </Form>
-            </LoginPageLayout>
-        </>
-    )
+  const [, setErrorText] = useState<string>("");
+  const handleUsernameChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setUsername(event.target.value);
+  };
+  const handlePassword1Change = (event: ChangeEvent<HTMLInputElement>) => {
+    setPassword1(event.target.value);
+  };
+  const handlePassword2Change = (event: ChangeEvent<HTMLInputElement>) => {
+    setPassword2(event.target.value);
+  };
+  return (
+    <>
+      <LoginPageLayout
+        logo={{
+          src: "https://assets.ubuntu.com/v1/82818827-CoF_white.svg",
+          title: "Notary",
+          url: "#",
+        }}
+        title="Initialize Notary"
+      >
+        <Form>
+          <h4>Create the initial admin user</h4>
+          <Input
+            id="InputUsername"
+            label="Username"
+            type="text"
+            required={true}
+            onChange={handleUsernameChange}
+          />
+          <PasswordToggle
+            help="Password must have 8 or more characters, must include at least one capital letter, one lowercase letter, and either a number or a symbol."
+            id="password1"
+            label="Password"
+            onChange={handlePassword1Change}
+            required={true}
+            error={password1Error}
+          />
+          <PasswordToggle
+            id="password2"
+            label="Confirm Password"
+            onChange={handlePassword2Change}
+            required={true}
+            error={password2Error}
+          />
+          <Button
+            appearance="positive"
+            disabled={!passwordsMatch || !passwordIsValid(password1)}
+            onClick={(event) => {
+              event.preventDefault();
+              if (passwordsMatch && passwordIsValid(password1)) {
+                postUserMutation.mutate({
+                  username: username,
+                  password: password1,
+                });
+              }
+            }}
+          >
+            Submit
+          </Button>
+        </Form>
+      </LoginPageLayout>
+    </>
+  );
 }

--- a/ui/src/app/(auth)/layout.tsx
+++ b/ui/src/app/(auth)/layout.tsx
@@ -1,9 +1,9 @@
-"use client"
-import '@/globals.scss'
+"use client";
+import "@/globals.scss";
 import { AuthProvider } from "@/hooks/useAuth";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient();
 export default function RootLayout({
   children,
 }: Readonly<{

--- a/ui/src/app/(auth)/login/page.tsx
+++ b/ui/src/app/(auth)/login/page.tsx
@@ -1,92 +1,101 @@
-"use client"
+"use client";
 
-import { getStatus, login } from "@/queries"
-import { useMutation, useQuery } from "@tanstack/react-query"
-import { useState, ChangeEvent } from "react"
-import { useCookies } from "react-cookie"
-import { useRouter } from "next/navigation"
-import { useAuth } from "@/hooks/useAuth"
-import { Input, PasswordToggle, Button, Form, Notification, LoginPageLayout } from "@canonical/react-components";
-
+import { getStatus, login } from "@/queries";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useState, ChangeEvent } from "react";
+import { useCookies } from "react-cookie";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/hooks/useAuth";
+import {
+  Input,
+  PasswordToggle,
+  Button,
+  Form,
+  Notification,
+  LoginPageLayout,
+} from "@canonical/react-components";
 
 export default function LoginPage() {
-    const router = useRouter()
-    const auth = useAuth()
-    const [, setCookie] = useCookies(['user_token']);
-    const statusQuery = useQuery({
-        queryKey: ["status"],
-        queryFn: () => getStatus()
-    })
-    if (!auth.firstUserCreated && (statusQuery.data && !statusQuery.data.initialized)) {
-        router.push("/initialize")
-    }
-    const mutation = useMutation({
-        mutationFn: login,
-        onSuccess: (result) => {
-            setErrorText("")
-            setCookie('user_token', result.token, {
-                sameSite: true,
-                secure: true,
-                expires: new Date(new Date().getTime() + 60 * 60 * 1000),
-            })
-            router.push('/certificate_requests')
-        },
-        onError: (e: Error) => {
-            setErrorText(e.message)
-        }
-    })
+  const router = useRouter();
+  const auth = useAuth();
+  const [, setCookie] = useCookies(["user_token"]);
+  const statusQuery = useQuery({
+    queryKey: ["status"],
+    queryFn: () => getStatus(),
+  });
+  if (
+    !auth.firstUserCreated &&
+    statusQuery.data &&
+    !statusQuery.data.initialized
+  ) {
+    router.push("/initialize");
+  }
+  const mutation = useMutation({
+    mutationFn: login,
+    onSuccess: (result) => {
+      setErrorText("");
+      setCookie("user_token", result.token, {
+        sameSite: true,
+        secure: true,
+        expires: new Date(new Date().getTime() + 60 * 60 * 1000),
+      });
+      router.push("/certificate_requests");
+    },
+    onError: (e: Error) => {
+      setErrorText(e.message);
+    },
+  });
 
-    const [username, setUsername] = useState<string>("")
-    const [password, setPassword] = useState<string>("")
-    const [errorText, setErrorText] = useState<string>("")
-    const handleUsernameChange = (event: ChangeEvent<HTMLInputElement>) => { setUsername(event.target.value) }
-    const handlePasswordChange = (event: ChangeEvent<HTMLInputElement>) => { setPassword(event.target.value) }
-    return (
-        <>
-            <LoginPageLayout
-                logo={{
-                    src: 'https://assets.ubuntu.com/v1/82818827-CoF_white.svg',
-                    title: 'Notary',
-                    url: '#'
-                }}
-                title="Log in"
-            >
-                <Form>
-                    <Input
-                        id="InputUsername"
-                        label="Username"
-                        type="text"
-                        required={true}
-                        onChange={handleUsernameChange}
-                    />
-                    <PasswordToggle
-                        id="InputPassword"
-                        label="Password"
-                        required={true}
-                        onChange={handlePasswordChange}
-                    />
-                    {errorText &&
-                        <Notification
-                            severity="negative"
-                            title="Error"
-                        >
-                            {errorText.split("error: ")}
-                        </Notification>
-                    }
-                    <Button
-                        appearance="positive"
-                        disabled={password.length == 0 || username.length == 0}
-                        onClick={
-                            (event) => {
-                                event.preventDefault();
-                                mutation.mutate({ username: username, password: password })
-                            }
-                        }
-                    >
-                        Log In
-                    </Button>
-                </Form>
-            </LoginPageLayout>
-        </>
-    )
+  const [username, setUsername] = useState<string>("");
+  const [password, setPassword] = useState<string>("");
+  const [errorText, setErrorText] = useState<string>("");
+  const handleUsernameChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setUsername(event.target.value);
+  };
+  const handlePasswordChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setPassword(event.target.value);
+  };
+  return (
+    <>
+      <LoginPageLayout
+        logo={{
+          src: "https://assets.ubuntu.com/v1/82818827-CoF_white.svg",
+          title: "Notary",
+          url: "#",
+        }}
+        title="Log in"
+      >
+        <Form>
+          <Input
+            id="InputUsername"
+            label="Username"
+            type="text"
+            required={true}
+            onChange={handleUsernameChange}
+          />
+          <PasswordToggle
+            id="InputPassword"
+            label="Password"
+            required={true}
+            onChange={handlePasswordChange}
+          />
+          {errorText && (
+            <Notification severity="negative" title="Error">
+              {errorText.split("error: ")}
+            </Notification>
+          )}
+          <Button
+            appearance="positive"
+            disabled={password.length == 0 || username.length == 0}
+            onClick={(event) => {
+              event.preventDefault();
+              mutation.mutate({ username: username, password: password });
+            }}
+          >
+            Log In
+          </Button>
+        </Form>
+      </LoginPageLayout>
+    </>
+  );
 }

--- a/ui/src/app/(auth)/login/page.tsx
+++ b/ui/src/app/(auth)/login/page.tsx
@@ -6,15 +6,14 @@ import { useState, ChangeEvent } from "react"
 import { useCookies } from "react-cookie"
 import { useRouter } from "next/navigation"
 import { useAuth } from "@/hooks/useAuth"
-import { statusResponse } from "@/types"
 import { Input, PasswordToggle, Button, Form, Notification, LoginPageLayout } from "@canonical/react-components";
 
 
 export default function LoginPage() {
     const router = useRouter()
     const auth = useAuth()
-    const [cookies, setCookie, removeCookie] = useCookies(['user_token']);
-    const statusQuery = useQuery<statusResponse, Error>({
+    const [, setCookie] = useCookies(['user_token']);
+    const statusQuery = useQuery({
         queryKey: ["status"],
         queryFn: () => getStatus()
     })
@@ -25,7 +24,7 @@ export default function LoginPage() {
         mutationFn: login,
         onSuccess: (result) => {
             setErrorText("")
-            setCookie('user_token', result?.token, {
+            setCookie('user_token', result.token, {
                 sameSite: true,
                 secure: true,
                 expires: new Date(new Date().getTime() + 60 * 60 * 1000),

--- a/ui/src/app/(notary)/certificate_authorities/asideForm.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/asideForm.tsx
@@ -1,9 +1,9 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCookies } from "react-cookie";
 import { postCA } from "@/queries";
 import { ChangeEvent, useState, Dispatch, SetStateAction } from "react";
 import { Button, Input, Panel, Form, Notification } from "@canonical/react-components";
 import { validationResult, validateCommonName, validateOrganizationName, validateOrganizationalUnit, validateCountryName, validateStateOrProvinceName, validateLocalityName, validateNotAfter } from "@/validators";
+import { useAuth } from "@/hooks/useAuth";
 
 type AsideProps = {
   setAsideOpen: Dispatch<SetStateAction<boolean>>
@@ -11,7 +11,7 @@ type AsideProps = {
 
 export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: AsideProps): JSX.Element {
   const queryClient = useQueryClient();
-  const [cookies] = useCookies(['user_token']);
+  const auth = useAuth();
 
   const [isSelfSigned, setIsSelfSigned] = useState<boolean | null>(null);
 
@@ -36,7 +36,7 @@ export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: Aside
     onSuccess: () => {
       setFormError("");
       setAsideOpen(false);
-      queryClient.invalidateQueries({ queryKey: ['cas'] });
+      void queryClient.invalidateQueries({ queryKey: ['cas'] });
     },
     onError: (e: Error) => {
       setFormError(e.message);
@@ -45,7 +45,7 @@ export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: Aside
 
   const handleSubmit = () => {
     mutation.mutate({
-      authToken: cookies.user_token,
+      authToken: auth.user ? auth.user.authToken : "",
 
       SelfSigned: isSelfSigned ? isSelfSigned : false,
 
@@ -78,7 +78,7 @@ export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: Aside
               type="radio"
               name="ca-type"
               checked={isSelfSigned == true}
-              onChange={(e) => setIsSelfSigned(true)}
+              onChange={() => setIsSelfSigned(true)}
               help="A self-signed certificate authority signs itself and acts as the root certificate for all other types of certificates."
             />
             <Input
@@ -87,7 +87,7 @@ export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: Aside
               type="radio"
               name="ca-type"
               checked={isSelfSigned == false}
-              onChange={(e) => setIsSelfSigned(false)}
+              onChange={() => setIsSelfSigned(false)}
               help="An intermediate certificate authority is signed by a root certificate authority and can sign end certificates."
             />
           </div>

--- a/ui/src/app/(notary)/certificate_authorities/asideForm.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/asideForm.tsx
@@ -1,34 +1,58 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { postCA } from "@/queries";
 import { ChangeEvent, useState, Dispatch, SetStateAction } from "react";
-import { Button, Input, Panel, Form, Notification } from "@canonical/react-components";
-import { validationResult, validateCommonName, validateOrganizationName, validateOrganizationalUnit, validateCountryName, validateStateOrProvinceName, validateLocalityName, validateNotAfter } from "@/validators";
+import {
+  Button,
+  Input,
+  Panel,
+  Form,
+  Notification,
+} from "@canonical/react-components";
+import {
+  validationResult,
+  validateCommonName,
+  validateOrganizationName,
+  validateOrganizationalUnit,
+  validateCountryName,
+  validateStateOrProvinceName,
+  validateLocalityName,
+  validateNotAfter,
+} from "@/validators";
 import { useAuth } from "@/hooks/useAuth";
 
 type AsideProps = {
-  setAsideOpen: Dispatch<SetStateAction<boolean>>
+  setAsideOpen: Dispatch<SetStateAction<boolean>>;
 };
 
-export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: AsideProps): JSX.Element {
+export default function CertificateAuthoritiesAsidePanel({
+  setAsideOpen,
+}: AsideProps): JSX.Element {
   const queryClient = useQueryClient();
   const auth = useAuth();
 
   const [isSelfSigned, setIsSelfSigned] = useState<boolean | null>(null);
 
   const [commonName, setCommonName] = useState<string>("");
-  const [commonNameValidation, setCommonNameValidation] = useState<validationResult>({ error: "", caution: "", success: "" });
+  const [commonNameValidation, setCommonNameValidation] =
+    useState<validationResult>({ error: "", caution: "", success: "" });
   const [organizationName, setOrganizationName] = useState<string>("");
-  const [organizationNameValidation, setOrganizationNameValidation] = useState<validationResult>({ error: "", caution: "", success: "" });
+  const [organizationNameValidation, setOrganizationNameValidation] =
+    useState<validationResult>({ error: "", caution: "", success: "" });
   const [organizationalUnit, setOrganizationalUnit] = useState<string>("");
-  const [organizationalUnitValidation, setOrganizationalUnitValidation] = useState<validationResult>({ error: "", caution: "", success: "" });
+  const [organizationalUnitValidation, setOrganizationalUnitValidation] =
+    useState<validationResult>({ error: "", caution: "", success: "" });
   const [countryName, setCountryName] = useState<string>("");
-  const [countryNameValidation, setCountryNameValidation] = useState<validationResult>({ error: "", caution: "", success: "" });
+  const [countryNameValidation, setCountryNameValidation] =
+    useState<validationResult>({ error: "", caution: "", success: "" });
   const [stateOrProvinceName, setStateOrProvinceName] = useState<string>("");
-  const [stateOrProvinceNameValidation, setStateOrProvinceNameValidation] = useState<validationResult>({ error: "", caution: "", success: "" });
+  const [stateOrProvinceNameValidation, setStateOrProvinceNameValidation] =
+    useState<validationResult>({ error: "", caution: "", success: "" });
   const [localityName, setLocalityName] = useState<string>("");
-  const [localityNameValidation, setLocalityNameValidation] = useState<validationResult>({ error: "", caution: "", success: "" });
+  const [localityNameValidation, setLocalityNameValidation] =
+    useState<validationResult>({ error: "", caution: "", success: "" });
   const [notValidAfter, setNotValidAfter] = useState<string>("");
-  const [notValidAfterValidation, setNotValidAfterValidation] = useState<validationResult>({ error: "", caution: "", success: "" });
+  const [notValidAfterValidation, setNotValidAfterValidation] =
+    useState<validationResult>({ error: "", caution: "", success: "" });
   const [formError, setFormError] = useState<string>("");
 
   const mutation = useMutation({
@@ -36,11 +60,11 @@ export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: Aside
     onSuccess: () => {
       setFormError("");
       setAsideOpen(false);
-      void queryClient.invalidateQueries({ queryKey: ['cas'] });
+      void queryClient.invalidateQueries({ queryKey: ["cas"] });
     },
     onError: (e: Error) => {
       setFormError(e.message);
-    }
+    },
   });
 
   const handleSubmit = () => {
@@ -70,7 +94,7 @@ export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: Aside
       }
     >
       <Form stacked>
-        {isSelfSigned === null &&
+        {isSelfSigned === null && (
           <div className="p-form__group row">
             <Input
               label="Self-Signed"
@@ -91,16 +115,18 @@ export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: Aside
               help="An intermediate certificate authority is signed by a root certificate authority and can sign end certificates."
             />
           </div>
-        }
-        {isSelfSigned !== null &&
+        )}
+        {isSelfSigned !== null && (
           <>
             <div className="p-form__group row">
               <Button hasIcon onClick={() => setIsSelfSigned(null)}>
-                <i className="p-icon--chevron-left" />
-                {' '}
-                <span> Back </span>
+                <i className="p-icon--chevron-left" /> <span> Back </span>
               </Button>
-              <h4>{isSelfSigned ? "Root Certificate Authority" : "Intermediate Certificate Authority"}</h4>
+              <h4>
+                {isSelfSigned
+                  ? "Root Certificate Authority"
+                  : "Intermediate Certificate Authority"}
+              </h4>
               <fieldset>
                 <legend>Subject</legend>
                 <Input
@@ -108,7 +134,10 @@ export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: Aside
                   id="common-name"
                   type="text"
                   value={commonName}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => { setCommonName(e.target.value); setCommonNameValidation(validateCommonName(e.target.value)); }}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                    setCommonName(e.target.value);
+                    setCommonNameValidation(validateCommonName(e.target.value));
+                  }}
                   error={commonNameValidation.error}
                   caution={commonNameValidation.caution}
                   success={commonNameValidation.success}
@@ -119,7 +148,12 @@ export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: Aside
                   id="organization-name"
                   type="text"
                   value={organizationName}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => { setOrganizationName(e.target.value); setOrganizationNameValidation(validateOrganizationName(e.target.value)); }}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                    setOrganizationName(e.target.value);
+                    setOrganizationNameValidation(
+                      validateOrganizationName(e.target.value),
+                    );
+                  }}
                   error={organizationNameValidation.error}
                   caution={organizationNameValidation.caution}
                   success={organizationNameValidation.success}
@@ -130,7 +164,12 @@ export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: Aside
                   id="organizational-unit"
                   type="text"
                   value={organizationalUnit}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => { setOrganizationalUnit(e.target.value); setOrganizationalUnitValidation(validateOrganizationalUnit(e.target.value)); }}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                    setOrganizationalUnit(e.target.value);
+                    setOrganizationalUnitValidation(
+                      validateOrganizationalUnit(e.target.value),
+                    );
+                  }}
                   error={organizationalUnitValidation.error}
                   caution={organizationalUnitValidation.caution}
                   success={organizationalUnitValidation.success}
@@ -141,7 +180,12 @@ export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: Aside
                   id="country-name"
                   type="text"
                   value={countryName}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => { setCountryName(e.target.value); setCountryNameValidation(validateCountryName(e.target.value)); }}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                    setCountryName(e.target.value);
+                    setCountryNameValidation(
+                      validateCountryName(e.target.value),
+                    );
+                  }}
                   error={countryNameValidation.error}
                   caution={countryNameValidation.caution}
                   success={countryNameValidation.success}
@@ -152,7 +196,12 @@ export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: Aside
                   id="state-or-province-name"
                   type="text"
                   value={stateOrProvinceName}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => { setStateOrProvinceName(e.target.value); setStateOrProvinceNameValidation(validateStateOrProvinceName(e.target.value)); }}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                    setStateOrProvinceName(e.target.value);
+                    setStateOrProvinceNameValidation(
+                      validateStateOrProvinceName(e.target.value),
+                    );
+                  }}
                   error={stateOrProvinceNameValidation.error}
                   caution={stateOrProvinceNameValidation.caution}
                   success={stateOrProvinceNameValidation.success}
@@ -163,14 +212,19 @@ export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: Aside
                   id="locality-name"
                   type="text"
                   value={localityName}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => { setLocalityName(e.target.value); setLocalityNameValidation(validateLocalityName(e.target.value)); }}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                    setLocalityName(e.target.value);
+                    setLocalityNameValidation(
+                      validateLocalityName(e.target.value),
+                    );
+                  }}
                   error={localityNameValidation.error}
                   caution={localityNameValidation.caution}
                   success={localityNameValidation.success}
                   stacked
                 />
               </fieldset>
-              {isSelfSigned === true &&
+              {isSelfSigned === true && (
                 <fieldset>
                   <legend>Validity</legend>
                   <Input
@@ -178,29 +232,34 @@ export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: Aside
                     id="not-valid-after"
                     type="datetime-local"
                     value={notValidAfter}
-                    onChange={(e: ChangeEvent<HTMLInputElement>) => { setNotValidAfter(e.target.value); setNotValidAfterValidation(validateNotAfter(e.target.value)); }}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                      setNotValidAfter(e.target.value);
+                      setNotValidAfterValidation(
+                        validateNotAfter(e.target.value),
+                      );
+                    }}
                     error={notValidAfterValidation.error}
                     caution={notValidAfterValidation.caution}
                     success={notValidAfterValidation.success}
                     stacked
-                  >
-                  </Input>
+                  ></Input>
                 </fieldset>
-              }
-              {isSelfSigned === false &&
-                <small>Download the Certificate Signing Request and get it signed by the appropriate authority. Upload the certificate at any moment using the action button.</small>
-              }
+              )}
+              {isSelfSigned === false && (
+                <small>
+                  Download the Certificate Signing Request and get it signed by
+                  the appropriate authority. Upload the certificate at any
+                  moment using the action button.
+                </small>
+              )}
             </div>
             <div className="p-form__group row">
-              {formError &&
-                <Notification
-                  severity="negative"
-                  title="Error"
-                >
+              {formError && (
+                <Notification severity="negative" title="Error">
                   {formError.split("error: ")}
                 </Notification>
-              }
-              {mutation.isPending ?
+              )}
+              {mutation.isPending ? (
                 <Button
                   appearance="positive"
                   name="submit"
@@ -208,18 +267,25 @@ export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: Aside
                   hasIcon
                 >
                   <i className="p-icon--spinner u-animation--spin"></i>
-                </Button> : <Button
+                </Button>
+              ) : (
+                <Button
                   appearance="positive"
                   name="submit"
-                  onClick={(e) => { e.preventDefault(); handleSubmit() }}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    handleSubmit();
+                  }}
                 >
-                  {isSelfSigned === true ? "Create Self Signed CA Certificate" : "Create Intermediate CA CSR"}
+                  {isSelfSigned === true
+                    ? "Create Self Signed CA Certificate"
+                    : "Create Intermediate CA CSR"}
                 </Button>
-              }
+              )}
             </div>
           </>
-        }
+        )}
       </Form>
-    </Panel >
+    </Panel>
   );
 }

--- a/ui/src/app/(notary)/certificate_authorities/components.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/components.tsx
@@ -2,130 +2,130 @@ import { Dispatch, SetStateAction, useState, ChangeEvent, useEffect } from "reac
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { csrMatchesCertificate, splitBundle, validateBundle } from "@/utils"
 import { postCertToCA } from "@/queries"
-import { useCookies } from "react-cookie"
 import { Button, Input, Textarea, Form, Modal, Icon } from "@canonical/react-components";
+import { useAuth } from "@/hooks/useAuth"
 
 interface SubmitCertificateModalProps {
-    id: string
-    csr: string
-    cert: string
-    setFormOpen: Dispatch<SetStateAction<boolean>>
+  id: string
+  csr: string
+  cert: string
+  setFormOpen: Dispatch<SetStateAction<boolean>>
 }
 
 export function SubmitCertificateModal({ id, csr, cert, setFormOpen }: SubmitCertificateModalProps) {
-    const [cookies] = useCookies(['user_token']);
-    const [errorText, setErrorText] = useState<string>("");
-    const [certificatePEMString, setCertificatePEMString] = useState<string>(cert);
-    const [validationErrorText, setValidationErrorText] = useState<string>("");
-    const queryClient = useQueryClient();
+  const auth = useAuth()
+  const [errorText, setErrorText] = useState<string>("");
+  const [certificatePEMString, setCertificatePEMString] = useState<string>(cert);
+  const [validationErrorText, setValidationErrorText] = useState<string>("");
+  const queryClient = useQueryClient();
 
-    const mutation = useMutation({
-        mutationFn: postCertToCA,
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['cas'] });
-            setErrorText("");
-            setFormOpen(false);
-        },
-        onError: (e: Error) => {
-            setErrorText(e.message);
+  const mutation = useMutation({
+    mutationFn: postCertToCA,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['cas'] });
+      setErrorText("");
+      setFormOpen(false);
+    },
+    onError: (e: Error) => {
+      setErrorText(e.message);
+    }
+  });
+
+  const handleTextChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setCertificatePEMString(event.target.value);
+  };
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (e: ProgressEvent<FileReader>) => {
+        if (e.target?.result) {
+          setCertificatePEMString(typeof e.target.result === "string" ? e.target.result : "");
         }
-    });
+      };
+      reader.readAsText(file);
+    }
+  };
 
-    const handleTextChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
-        setCertificatePEMString(event.target.value);
-    };
-
-    const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
-        const file = event.target.files?.[0];
-        if (file) {
-            const reader = new FileReader();
-            reader.onload = (e: ProgressEvent<FileReader>) => {
-                if (e.target?.result) {
-                    setCertificatePEMString(e.target.result.toString());
-                }
-            };
-            reader.readAsText(file);
+  useEffect(() => {
+    const validateCertificate = async () => {
+      try {
+        const certs = splitBundle(certificatePEMString);
+        if (certs.length < 2) {
+          setValidationErrorText("Bundle with 2 certificates required");
+          return;
         }
+        if (!csrMatchesCertificate(csr, certs[0])) {
+          setValidationErrorText("Certificate does not match request");
+          return;
+        }
+        const validationMessage = await validateBundle(certificatePEMString);
+        if (validationMessage !== "") {
+          setValidationErrorText("Bundle validation failed: " + validationMessage);
+          return;
+        }
+      } catch {
+        setValidationErrorText("A certificate is invalid");
+        return;
+      }
+      setValidationErrorText("");
     };
+    void validateCertificate();
+  }, [csr, certificatePEMString]);
 
-    useEffect(() => {
-        const validateCertificate = async () => {
-            try {
-                const certs = splitBundle(certificatePEMString);
-                if (certs.length < 2) {
-                    setValidationErrorText("Bundle with 2 certificates required");
-                    return;
-                }
-                if (!csrMatchesCertificate(csr, certs[0])) {
-                    setValidationErrorText("Certificate does not match request");
-                    return;
-                }
-                const validationMessage = await validateBundle(certificatePEMString);
-                if (validationMessage !== "") {
-                    setValidationErrorText("Bundle validation failed: " + validationMessage);
-                    return;
-                }
-            } catch {
-                setValidationErrorText("A certificate is invalid");
-                return;
-            }
-            setValidationErrorText("");
-        };
-        validateCertificate();
-    }, [csr, certificatePEMString]);
-
-    return (
-        <Modal
-            title="Submit Certificate"
-            buttonRow={
-                <>
-                    <Button
-                        onClick={() => mutation.mutate({ id, authToken: cookies.user_token, certificate_chain: certificatePEMString })}
-                        appearance="positive"
-                        disabled={validationErrorText !== "" || certificatePEMString === ""}
-                    >
-                        Submit
-                    </Button>
-                    <Button onMouseDown={() => setFormOpen(false)}>
-                        Cancel
-                    </Button>
-                </>
-            }
-        >
-            <Form stacked={true}>
-                <div className="p-form__group row">
-                    <Textarea
-                        name="textarea"
-                        id="csr-textarea"
-                        label="Enter or upload the Certificate in PEM format below"
-                        placeholder="-----BEGIN CERTIFICATE-----"
-                        rows={10}
-                        onChange={handleTextChange}
-                        value={certificatePEMString}
-                        error={validationErrorText || errorText}
-                    />
-                </div>
-                <div className="p-form__group row">
-                    <Input
-                        type="file"
-                        name="upload"
-                        accept=".pem,.crt"
-                        onChange={handleFileChange}
-                    />
-                </div>
-            </Form>
-        </Modal>
-    );
+  return (
+    <Modal
+      title="Submit Certificate"
+      buttonRow={
+        <>
+          <Button
+            onClick={() => mutation.mutate({ id, authToken: auth.user ? auth.user.authToken : "", certificate_chain: certificatePEMString })}
+            appearance="positive"
+            disabled={validationErrorText !== "" || certificatePEMString === ""}
+          >
+            Submit
+          </Button>
+          <Button onMouseDown={() => setFormOpen(false)}>
+            Cancel
+          </Button>
+        </>
+      }
+    >
+      <Form stacked={true}>
+        <div className="p-form__group row">
+          <Textarea
+            name="textarea"
+            id="csr-textarea"
+            label="Enter or upload the Certificate in PEM format below"
+            placeholder="-----BEGIN CERTIFICATE-----"
+            rows={10}
+            onChange={handleTextChange}
+            value={certificatePEMString}
+            error={validationErrorText || errorText}
+          />
+        </div>
+        <div className="p-form__group row">
+          <Input
+            type="file"
+            name="upload"
+            accept=".pem,.crt"
+            onChange={handleFileChange}
+          />
+        </div>
+      </Form>
+    </Modal>
+  );
 }
 
 export function SuccessNotification({ successMessage }: { successMessage: string }) {
-    const style = {
-        display: 'inline'
-    }
-    return (
-        <p style={style}>
-            <Icon name="success" />
-            {successMessage}
-        </p>
-    );
+  const style = {
+    display: 'inline'
+  }
+  return (
+    <p style={style}>
+      <Icon name="success" />
+      {successMessage}
+    </p>
+  );
 }

--- a/ui/src/app/(notary)/certificate_authorities/components.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/components.tsx
@@ -1,34 +1,53 @@
-import { Dispatch, SetStateAction, useState, ChangeEvent, useEffect } from "react"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { csrMatchesCertificate, splitBundle, validateBundle } from "@/utils"
-import { postCertToCA } from "@/queries"
-import { Button, Input, Textarea, Form, Modal, Icon } from "@canonical/react-components";
-import { useAuth } from "@/hooks/useAuth"
+import {
+  Dispatch,
+  SetStateAction,
+  useState,
+  ChangeEvent,
+  useEffect,
+} from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { csrMatchesCertificate, splitBundle, validateBundle } from "@/utils";
+import { postCertToCA } from "@/queries";
+import {
+  Button,
+  Input,
+  Textarea,
+  Form,
+  Modal,
+  Icon,
+} from "@canonical/react-components";
+import { useAuth } from "@/hooks/useAuth";
 
 interface SubmitCertificateModalProps {
-  id: string
-  csr: string
-  cert: string
-  setFormOpen: Dispatch<SetStateAction<boolean>>
+  id: string;
+  csr: string;
+  cert: string;
+  setFormOpen: Dispatch<SetStateAction<boolean>>;
 }
 
-export function SubmitCertificateModal({ id, csr, cert, setFormOpen }: SubmitCertificateModalProps) {
-  const auth = useAuth()
+export function SubmitCertificateModal({
+  id,
+  csr,
+  cert,
+  setFormOpen,
+}: SubmitCertificateModalProps) {
+  const auth = useAuth();
   const [errorText, setErrorText] = useState<string>("");
-  const [certificatePEMString, setCertificatePEMString] = useState<string>(cert);
+  const [certificatePEMString, setCertificatePEMString] =
+    useState<string>(cert);
   const [validationErrorText, setValidationErrorText] = useState<string>("");
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: postCertToCA,
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['cas'] });
+      void queryClient.invalidateQueries({ queryKey: ["cas"] });
       setErrorText("");
       setFormOpen(false);
     },
     onError: (e: Error) => {
       setErrorText(e.message);
-    }
+    },
   });
 
   const handleTextChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
@@ -41,7 +60,9 @@ export function SubmitCertificateModal({ id, csr, cert, setFormOpen }: SubmitCer
       const reader = new FileReader();
       reader.onload = (e: ProgressEvent<FileReader>) => {
         if (e.target?.result) {
-          setCertificatePEMString(typeof e.target.result === "string" ? e.target.result : "");
+          setCertificatePEMString(
+            typeof e.target.result === "string" ? e.target.result : "",
+          );
         }
       };
       reader.readAsText(file);
@@ -62,7 +83,9 @@ export function SubmitCertificateModal({ id, csr, cert, setFormOpen }: SubmitCer
         }
         const validationMessage = await validateBundle(certificatePEMString);
         if (validationMessage !== "") {
-          setValidationErrorText("Bundle validation failed: " + validationMessage);
+          setValidationErrorText(
+            "Bundle validation failed: " + validationMessage,
+          );
           return;
         }
       } catch {
@@ -80,15 +103,19 @@ export function SubmitCertificateModal({ id, csr, cert, setFormOpen }: SubmitCer
       buttonRow={
         <>
           <Button
-            onClick={() => mutation.mutate({ id, authToken: auth.user ? auth.user.authToken : "", certificate_chain: certificatePEMString })}
+            onClick={() =>
+              mutation.mutate({
+                id,
+                authToken: auth.user ? auth.user.authToken : "",
+                certificate_chain: certificatePEMString,
+              })
+            }
             appearance="positive"
             disabled={validationErrorText !== "" || certificatePEMString === ""}
           >
             Submit
           </Button>
-          <Button onMouseDown={() => setFormOpen(false)}>
-            Cancel
-          </Button>
+          <Button onMouseDown={() => setFormOpen(false)}>Cancel</Button>
         </>
       }
     >
@@ -118,10 +145,14 @@ export function SubmitCertificateModal({ id, csr, cert, setFormOpen }: SubmitCer
   );
 }
 
-export function SuccessNotification({ successMessage }: { successMessage: string }) {
+export function SuccessNotification({
+  successMessage,
+}: {
+  successMessage: string;
+}) {
   const style = {
-    display: 'inline'
-  }
+    display: "inline",
+  };
   return (
     <p style={style}>
       <Icon name="success" />

--- a/ui/src/app/(notary)/certificate_authorities/page.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/page.tsx
@@ -3,7 +3,7 @@
 import { useQuery } from "@tanstack/react-query"
 import { CertificateAuthoritiesTable } from "./table"
 import { getCertificateAuthorities } from "@/queries"
-import { CertificateAuthorityEntry, CSREntry } from "@/types"
+import { CertificateAuthorityEntry } from "@/types"
 import { useCookies } from "react-cookie"
 import { useRouter } from "next/navigation"
 import Loading from "@/components/loading"
@@ -14,20 +14,22 @@ import CertificateAuthoritiesAsidePanel from "./asideForm"
 import NotaryAppNavigationBars from "@/components/NotaryAppNavigationBars"
 import { retryUnlessUnauthorized } from "@/utils"
 import NotaryAppStatus from "@/components/NotaryAppStatus"
+import { useAuth } from "@/hooks/useAuth"
 
 
 export default function CertificateRequestsPanel() {
   const router = useRouter()
+  const auth = useAuth()
   const [asideOpen, setAsideOpen] = useState<boolean>(false)
-  const [cookies, setCookie, removeCookie] = useCookies(['user_token']);
+  const [cookies, , removeCookie] = useCookies(['user_token']);
 
   if (!cookies.user_token) {
     router.push("/login")
   }
 
   const query = useQuery<CertificateAuthorityEntry[], Error>({
-    queryKey: ['cas', cookies.user_token],
-    queryFn: () => getCertificateAuthorities({ authToken: cookies.user_token }),
+    queryKey: ['cas', auth.user ? auth.user.authToken : ""],
+    queryFn: () => getCertificateAuthorities({ authToken: auth.user ? auth.user.authToken : "" }),
     retry: retryUnlessUnauthorized,
   })
   if (query.status == "pending") { return <Loading /> }

--- a/ui/src/app/(notary)/certificate_authorities/page.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/page.tsx
@@ -1,45 +1,49 @@
-"use client"
+"use client";
 
-import { useQuery } from "@tanstack/react-query"
-import { CertificateAuthoritiesTable } from "./table"
-import { getCertificateAuthorities } from "@/queries"
-import { CertificateAuthorityEntry } from "@/types"
-import { useCookies } from "react-cookie"
-import { useRouter } from "next/navigation"
-import Loading from "@/components/loading"
-import Error from "@/components/error"
-import { useState } from "react"
-import { AppAside, Application, AppMain } from "@canonical/react-components"
-import CertificateAuthoritiesAsidePanel from "./asideForm"
-import NotaryAppNavigationBars from "@/components/NotaryAppNavigationBars"
-import { retryUnlessUnauthorized } from "@/utils"
-import NotaryAppStatus from "@/components/NotaryAppStatus"
-import { useAuth } from "@/hooks/useAuth"
-
+import { useQuery } from "@tanstack/react-query";
+import { CertificateAuthoritiesTable } from "./table";
+import { getCertificateAuthorities } from "@/queries";
+import { CertificateAuthorityEntry } from "@/types";
+import { useCookies } from "react-cookie";
+import { useRouter } from "next/navigation";
+import Loading from "@/components/loading";
+import Error from "@/components/error";
+import { useState } from "react";
+import { AppAside, Application, AppMain } from "@canonical/react-components";
+import CertificateAuthoritiesAsidePanel from "./asideForm";
+import NotaryAppNavigationBars from "@/components/NotaryAppNavigationBars";
+import { retryUnlessUnauthorized } from "@/utils";
+import NotaryAppStatus from "@/components/NotaryAppStatus";
+import { useAuth } from "@/hooks/useAuth";
 
 export default function CertificateRequestsPanel() {
-  const router = useRouter()
-  const auth = useAuth()
-  const [asideOpen, setAsideOpen] = useState<boolean>(false)
-  const [cookies, , removeCookie] = useCookies(['user_token']);
+  const router = useRouter();
+  const auth = useAuth();
+  const [asideOpen, setAsideOpen] = useState<boolean>(false);
+  const [cookies, , removeCookie] = useCookies(["user_token"]);
 
   if (!cookies.user_token) {
-    router.push("/login")
+    router.push("/login");
   }
 
   const query = useQuery<CertificateAuthorityEntry[], Error>({
-    queryKey: ['cas', auth.user ? auth.user.authToken : ""],
-    queryFn: () => getCertificateAuthorities({ authToken: auth.user ? auth.user.authToken : "" }),
+    queryKey: ["cas", auth.user ? auth.user.authToken : ""],
+    queryFn: () =>
+      getCertificateAuthorities({
+        authToken: auth.user ? auth.user.authToken : "",
+      }),
     retry: retryUnlessUnauthorized,
-  })
-  if (query.status == "pending") { return <Loading /> }
+  });
+  if (query.status == "pending") {
+    return <Loading />;
+  }
   if (query.status == "error") {
     if (query.error.message.includes("401")) {
-      removeCookie("user_token")
+      removeCookie("user_token");
     }
-    return <Error msg={query.error.message} />
+    return <Error msg={query.error.message} />;
   }
-  const cas = Array.from(query.data ? query.data : [])
+  const cas = Array.from(query.data ? query.data : []);
   return (
     <Application>
       <NotaryAppNavigationBars />
@@ -51,5 +55,5 @@ export default function CertificateRequestsPanel() {
       </AppMain>
       <NotaryAppStatus />
     </Application>
-  )
+  );
 }

--- a/ui/src/app/(notary)/certificate_authorities/table.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/table.tsx
@@ -1,9 +1,8 @@
-import { useState, Dispatch, SetStateAction, useReducer, useRef } from "react";
-import { CertificateAuthorityEntry } from "@/types";
+import { useState, Dispatch, SetStateAction } from "react";
+import { CertificateAuthorityEntry, CertificateSigningRequest } from "@/types";
 import { Button, MainTable, Panel, EmptyState, ContextualMenu } from "@canonical/react-components";
 import { deleteCA, makeCALegacy, revokeCA, signCA } from "@/queries"
 import { extractCSR, extractCert, splitBundle } from "@/utils";
-import { useQueryClient } from "@tanstack/react-query"
 import { SubmitCertificateModal, SuccessNotification } from "./components"
 import { useAuth } from "@/hooks/useAuth";
 import { NotaryConfirmationModalData, NotaryConfirmationModal } from "@/components/NotaryConfirmationModal";
@@ -16,26 +15,26 @@ type TableProps = {
 
 export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TableProps) {
   const auth = useAuth();
-  const queryClient = useQueryClient();
   const [certificateFormOpen, setCertificateFormOpen] = useState<boolean>(false);
-  const [confirmationModalData, setConfirmationModalData] = useState<NotaryConfirmationModalData | null>(null);
+  // eslint-disable-next-line
+  const [confirmationModalData, setConfirmationModalData] = useState<NotaryConfirmationModalData<any> | null>(null);
   const [selectedCA, setSelectedCA] = useState<CertificateAuthorityEntry | null>(null);
   const [showCACSRContent, setShowCACSRContent] = useState<number | null>(null);
   const [showCACertificateContent, setShowCACertificateContent] = useState<number | null>(null);
   const [successNotificationId, setSuccessNotificationId] = useState<number | null>(null);
 
   const handleCopy = (csr: string, id: number) => {
-    navigator.clipboard.writeText(csr).then(() => {
+    void navigator.clipboard.writeText(csr).then(() => {
       setSuccessNotificationId(id);
       setTimeout(() => setSuccessNotificationId(null), 2500);
     });
   };
 
-  const handleDownload = (csr: string, id: number, csrObj: any) => {
+  const handleDownload = (csr: string, id: number, csrObj: CertificateSigningRequest) => {
     const blob = new Blob([csr], { type: 'text/plain' });
     const link = document.createElement('a');
     link.href = URL.createObjectURL(blob);
-    link.download = `csr-${csrObj.commonName || id}.pem`;
+    link.download = `csr-${csrObj.commonName?.toLowerCase() || id}.pem`;
     link.click();
     URL.revokeObjectURL(link.href);
   };
@@ -113,7 +112,7 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
     return "rgba(14, 132, 32, 0.35)";
   };
 
-  const getFieldDisplay = (label: string, field: string | undefined, compareField?: string | undefined) => {
+  const getFieldDisplay = (label: string, field: string | undefined, compareField?: string) => {
     const isMismatched = compareField !== undefined && compareField !== field;
     return field ? (
       <p style={{ marginBottom: "4px" }}>

--- a/ui/src/app/(notary)/certificate_authorities/table.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/table.tsx
@@ -1,27 +1,45 @@
 import { useState, Dispatch, SetStateAction } from "react";
 import { CertificateAuthorityEntry, CertificateSigningRequest } from "@/types";
-import { Button, MainTable, Panel, EmptyState, ContextualMenu } from "@canonical/react-components";
-import { deleteCA, makeCALegacy, revokeCA, signCA } from "@/queries"
+import {
+  Button,
+  MainTable,
+  Panel,
+  EmptyState,
+  ContextualMenu,
+} from "@canonical/react-components";
+import { deleteCA, makeCALegacy, revokeCA, signCA } from "@/queries";
 import { extractCSR, extractCert, splitBundle } from "@/utils";
-import { SubmitCertificateModal, SuccessNotification } from "./components"
+import { SubmitCertificateModal, SuccessNotification } from "./components";
 import { useAuth } from "@/hooks/useAuth";
-import { NotaryConfirmationModalData, NotaryConfirmationModal } from "@/components/NotaryConfirmationModal";
-
+import {
+  NotaryConfirmationModalData,
+  NotaryConfirmationModal,
+} from "@/components/NotaryConfirmationModal";
 
 type TableProps = {
   cas: CertificateAuthorityEntry[];
-  setAsideOpen: Dispatch<SetStateAction<boolean>>
+  setAsideOpen: Dispatch<SetStateAction<boolean>>;
 };
 
-export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TableProps) {
+export function CertificateAuthoritiesTable({
+  cas: rows,
+  setAsideOpen,
+}: TableProps) {
   const auth = useAuth();
-  const [certificateFormOpen, setCertificateFormOpen] = useState<boolean>(false);
+  const [certificateFormOpen, setCertificateFormOpen] =
+    useState<boolean>(false);
   // eslint-disable-next-line
-  const [confirmationModalData, setConfirmationModalData] = useState<NotaryConfirmationModalData<any> | null>(null);
-  const [selectedCA, setSelectedCA] = useState<CertificateAuthorityEntry | null>(null);
+  const [confirmationModalData, setConfirmationModalData] =
+    useState<NotaryConfirmationModalData<any> | null>(null);
+  const [selectedCA, setSelectedCA] =
+    useState<CertificateAuthorityEntry | null>(null);
   const [showCACSRContent, setShowCACSRContent] = useState<number | null>(null);
-  const [showCACertificateContent, setShowCACertificateContent] = useState<number | null>(null);
-  const [successNotificationId, setSuccessNotificationId] = useState<number | null>(null);
+  const [showCACertificateContent, setShowCACertificateContent] = useState<
+    number | null
+  >(null);
+  const [successNotificationId, setSuccessNotificationId] = useState<
+    number | null
+  >(null);
 
   const handleCopy = (csr: string, id: number) => {
     void navigator.clipboard.writeText(csr).then(() => {
@@ -30,9 +48,13 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
     });
   };
 
-  const handleDownload = (csr: string, id: number, csrObj: CertificateSigningRequest) => {
-    const blob = new Blob([csr], { type: 'text/plain' });
-    const link = document.createElement('a');
+  const handleDownload = (
+    csr: string,
+    id: number,
+    csrObj: CertificateSigningRequest,
+  ) => {
+    const blob = new Blob([csr], { type: "text/plain" });
+    const link = document.createElement("a");
     link.href = URL.createObjectURL(blob);
     link.download = `csr-${csrObj.commonName?.toLowerCase() || id}.pem`;
     link.click();
@@ -42,11 +64,16 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
   const handleSign = (id: number, override: number | null = null) => {
     setConfirmationModalData({
       queryFn: signCA,
-      queryParams: { id: id.toString(), authToken: auth.user?.authToken || "", certificate_authority_id: override ? override : auth.activeCA?.id },
+      queryParams: {
+        id: id.toString(),
+        authToken: auth.user?.authToken || "",
+        certificate_authority_id: override ? override : auth.activeCA?.id,
+      },
       queryKey: "cas",
       closeFn: () => setConfirmationModalData(null),
       buttonConfirmText: "Sign",
-      warningText: "Signing a CSR will create a new certificate and replace the old one. This action cannot be undone.",
+      warningText:
+        "Signing a CSR will create a new certificate and replace the old one. This action cannot be undone.",
     });
   };
 
@@ -60,7 +87,8 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
       queryKey: "cas",
       closeFn: () => setConfirmationModalData(null),
       buttonConfirmText: "Revoke",
-      warningText: "Revoking a CA Certificate will prevent signing CSR's and issuing a new CRL with this CA. This action cannot be undone.",
+      warningText:
+        "Revoking a CA Certificate will prevent signing CSR's and issuing a new CRL with this CA. This action cannot be undone.",
     });
   };
 
@@ -74,9 +102,10 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
       queryKey: "cas",
       closeFn: () => setConfirmationModalData(null),
       buttonConfirmText: "Continue",
-      warningText: "Making a CA Certificate Legacy will prevent signing CSR's with or renewing the CA certificate, but will not revoke any signed certificates. This action cannot be undone.",
+      warningText:
+        "Making a CA Certificate Legacy will prevent signing CSR's with or renewing the CA certificate, but will not revoke any signed certificates. This action cannot be undone.",
     });
-  }
+  };
 
   const handleDelete = (id: number) => {
     if (id === auth.activeCA?.id) {
@@ -87,13 +116,14 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
       queryParams: { id: id.toString(), authToken: auth.user?.authToken || "" },
       closeFn: () => setConfirmationModalData(null),
       queryKey: "cas",
-      warningText: "Deleting a Certificate Authority means the private key and the subject details of this CA will be removed. Deleting the CA does not revoke this certificate, and does not revoke any certificates this CA has signed. This action cannot be undone.",
+      warningText:
+        "Deleting a Certificate Authority means the private key and the subject details of this CA will be removed. Deleting the CA does not revoke this certificate, and does not revoke any certificates this CA has signed. This action cannot be undone.",
       buttonConfirmText: "Delete",
     });
   };
 
-  const handleExpand = (id: number, type: 'CSR' | 'Cert') => {
-    if (type === 'CSR') {
+  const handleExpand = (id: number, type: "CSR" | "Cert") => {
+    if (type === "CSR") {
       setShowCACSRContent(id === showCACSRContent ? null : id);
       setShowCACertificateContent(null);
     } else {
@@ -103,7 +133,7 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
   };
 
   const getExpiryColor = (notAfter?: string): string => {
-    if (!notAfter) return 'inherit';
+    if (!notAfter) return "inherit";
     const expiryDate = new Date(notAfter);
     const now = new Date();
     const timeDifference = expiryDate.getTime() - now.getTime();
@@ -112,12 +142,18 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
     return "rgba(14, 132, 32, 0.35)";
   };
 
-  const getFieldDisplay = (label: string, field: string | undefined, compareField?: string) => {
+  const getFieldDisplay = (
+    label: string,
+    field: string | undefined,
+    compareField?: string,
+  ) => {
     const isMismatched = compareField !== undefined && compareField !== field;
     return field ? (
       <p style={{ marginBottom: "4px" }}>
         <b>{label}:</b>{" "}
-        <span style={{ color: isMismatched ? "rgba(199, 22, 43, 1)" : "inherit" }}>
+        <span
+          style={{ color: isMismatched ? "rgba(199, 22, 43, 1)" : "inherit" }}
+        >
           {field}
         </span>
       </p>
@@ -145,7 +181,11 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
         { content: caEntry.id.toString() },
         { content: isSelfSigned ? "Self Signed" : "Intermediate" },
         { content: csrObj.commonName || "N/A" },
-        { content: caEntry.status + (auth.activeCA?.id === caEntry.id ? " (selected)" : "") },
+        {
+          content:
+            caEntry.status +
+            (auth.activeCA?.id === caEntry.id ? " (selected)" : ""),
+        },
         {
           content: certObj?.notAfter || "",
           style: { backgroundColor: getExpiryColor(certObj?.notAfter) },
@@ -153,92 +193,111 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
         {
           content: (
             <>
-              {successNotificationId === caEntry.id && <SuccessNotification successMessage="CSR copied to clipboard" />}
-              <ContextualMenu
-                hasToggleIcon
-                position="right"
-              >
-                {!isSelfSigned &&
+              {successNotificationId === caEntry.id && (
+                <SuccessNotification successMessage="CSR copied to clipboard" />
+              )}
+              <ContextualMenu hasToggleIcon position="right">
+                {!isSelfSigned && (
                   <span className="p-contextual-menu__group">
                     <Button
                       className="p-contextual-menu__link"
-                      onMouseDown={() => handleExpand(caEntry.id, 'CSR')}>
-                      {isCSRContentVisible ? "Hide CSR Content" : "Show CSR Content"}
+                      onMouseDown={() => handleExpand(caEntry.id, "CSR")}
+                    >
+                      {isCSRContentVisible
+                        ? "Hide CSR Content"
+                        : "Show CSR Content"}
                     </Button>
                     <Button
                       className="p-contextual-menu__link"
-                      onMouseDown={() => handleCopy(caEntry.csr, caEntry.id)}>
+                      onMouseDown={() => handleCopy(caEntry.csr, caEntry.id)}
+                    >
                       Copy CSR to Clipboard
                     </Button>
                     <Button
                       className="p-contextual-menu__link"
-                      onMouseDown={() => handleDownload(caEntry.csr, caEntry.id, csrObj)}>
+                      onMouseDown={() =>
+                        handleDownload(caEntry.csr, caEntry.id, csrObj)
+                      }
+                    >
                       Download CSR
                     </Button>
                   </span>
-                }
+                )}
                 <span className="p-contextual-menu__group">
                   <Button
                     className="p-contextual-menu__link"
                     disabled={caEntry.status == "pending"}
-                    onMouseDown={() => handleExpand(caEntry.id, 'Cert')}>
-                    {isCertContentVisible ? "Hide Certificate Content" : "Show Certificate Content"}
+                    onMouseDown={() => handleExpand(caEntry.id, "Cert")}
+                  >
+                    {isCertContentVisible
+                      ? "Hide Certificate Content"
+                      : "Show Certificate Content"}
                   </Button>
-                  {!isSelfSigned &&
+                  {!isSelfSigned && (
                     <Button
                       className="p-contextual-menu__link"
                       disabled={auth.activeCA == null}
-                      onMouseDown={() => handleSign(caEntry.id)}>
+                      onMouseDown={() => handleSign(caEntry.id)}
+                    >
                       {caEntry.status === "active" ? "Re-sign CSR" : "Sign CSR"}
                     </Button>
-                  }
-                  {isSelfSigned &&
+                  )}
+                  {isSelfSigned && (
                     <Button
                       className="p-contextual-menu__link"
-                      onMouseDown={() => handleSign(caEntry.id, caEntry.id)}>
+                      onMouseDown={() => handleSign(caEntry.id, caEntry.id)}
+                    >
                       Renew Certificate
                     </Button>
-                  }
-                  {!isSelfSigned &&
+                  )}
+                  {!isSelfSigned && (
                     <Button
                       className="p-contextual-menu__link"
                       onMouseDown={() => {
                         setCertificateFormOpen(true);
                         setSelectedCA(caEntry);
-                      }}>
+                      }}
+                    >
                       Upload New Certificate
                     </Button>
-                  }
-                  {!isSelfSigned &&
+                  )}
+                  {!isSelfSigned && (
                     <Button
                       className="p-contextual-menu__link"
                       disabled={caEntry.status == "pending"}
-                      onMouseDown={() => handleRevoke(caEntry.id)}>
+                      onMouseDown={() => handleRevoke(caEntry.id)}
+                    >
                       Revoke Certificate
                     </Button>
-                  }
+                  )}
                 </span>
                 <span className="p-contextual-menu__group">
-                  {caEntry.status === "active" &&
+                  {caEntry.status === "active" && (
                     <Button
                       className="p-contextual-menu__link"
-                      disabled={caEntry.status != "active" || auth.activeCA?.id === caEntry.id}
+                      disabled={
+                        caEntry.status != "active" ||
+                        auth.activeCA?.id === caEntry.id
+                      }
                       onMouseDown={() => {
                         auth.setActiveCA(caEntry);
-                      }}>
+                      }}
+                    >
                       Set as default for signing CSRs
                     </Button>
-                  }
-                  {caEntry.status === "active" &&
+                  )}
+                  {caEntry.status === "active" && (
                     <Button
                       className="p-contextual-menu__link"
-                      onMouseDown={() => handleMakeLegacy(caEntry.id)}>
+                      onMouseDown={() => handleMakeLegacy(caEntry.id)}
+                    >
                       Make CA Legacy
                     </Button>
-                  }
+                  )}
                   <Button
                     className="p-contextual-menu__link"
-                    onMouseDown={() => handleDelete(caEntry.id)}>
+                    onMouseDown={() => handleDelete(caEntry.id)}
+                  >
                     Delete Certificate Authority
                   </Button>
                 </span>
@@ -251,38 +310,62 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
       ],
       expanded: isCSRContentVisible || isCertContentVisible,
       expandedContent: (
-        <div >
+        <div>
           {isCSRContentVisible && (
-            <div >
+            <div>
               <h4>Certificate Request Content</h4>
               {getFieldDisplay("Common Name", csrObj.commonName)}
-              {getFieldDisplay("Subject Alternative Name DNS", csrObj.sansDns?.join(', '))}
-              {getFieldDisplay("Subject Alternative Name IP addresses", csrObj.sansIp?.join(', '))}
+              {getFieldDisplay(
+                "Subject Alternative Name DNS",
+                csrObj.sansDns?.join(", "),
+              )}
+              {getFieldDisplay(
+                "Subject Alternative Name IP addresses",
+                csrObj.sansIp?.join(", "),
+              )}
               {getFieldDisplay("Country", csrObj.country)}
               {getFieldDisplay("State or Province", csrObj.stateOrProvince)}
               {getFieldDisplay("Locality", csrObj.locality)}
               {getFieldDisplay("Organization", csrObj.organization)}
-              {getFieldDisplay("Organizational Unit", csrObj.OrganizationalUnitName)}
+              {getFieldDisplay(
+                "Organizational Unit",
+                csrObj.OrganizationalUnitName,
+              )}
               {getFieldDisplay("Email Address", csrObj.emailAddress)}
-              <p><b>Certificate request for a certificate authority</b>: {csrObj.is_ca ? "Yes" : "No"}</p>
+              <p>
+                <b>Certificate request for a certificate authority</b>:{" "}
+                {csrObj.is_ca ? "Yes" : "No"}
+              </p>
             </div>
           )}
           {isCertContentVisible && certObj && (
-            <div >
+            <div>
               <h4>Certificate Content</h4>
               {getFieldDisplay("Common Name", certObj.commonName)}
-              {getFieldDisplay("Subject Alternative Name DNS", certObj.sansDns?.join(', '))}
-              {getFieldDisplay("Subject Alternative Name IP addresses", certObj.sansIp?.join(', '))}
+              {getFieldDisplay(
+                "Subject Alternative Name DNS",
+                certObj.sansDns?.join(", "),
+              )}
+              {getFieldDisplay(
+                "Subject Alternative Name IP addresses",
+                certObj.sansIp?.join(", "),
+              )}
               {getFieldDisplay("Country", certObj.country)}
               {getFieldDisplay("State or Province", certObj.stateOrProvince)}
               {getFieldDisplay("Locality", certObj.locality)}
               {getFieldDisplay("Organization", certObj.organization)}
-              {getFieldDisplay("Organizational Unit", certObj.OrganizationalUnitName)}
+              {getFieldDisplay(
+                "Organizational Unit",
+                certObj.OrganizationalUnitName,
+              )}
               {getFieldDisplay("Email Address", certObj.emailAddress)}
               {getFieldDisplay("Start of validity", certObj.notBefore)}
               {getFieldDisplay("Expiry Time", certObj.notAfter)}
               {getFieldDisplay("Issuer Common Name", certObj.issuerCommonName)}
-              <p><b>Certificate for a certificate authority</b>: {certObj.is_ca ? "Yes" : "No"}</p>
+              <p>
+                <b>Certificate for a certificate authority</b>:{" "}
+                {certObj.is_ca ? "Yes" : "No"}
+              </p>
             </div>
           )}
         </div>
@@ -294,11 +377,13 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
       stickyHeader
       title="Certificate Authorities"
       className="u-fixed-width"
-      controls={rows.length > 0 && (
-        <Button appearance="positive" onClick={() => setAsideOpen(true)}>
-          Add New CA
-        </Button>
-      )}
+      controls={
+        rows.length > 0 && (
+          <Button appearance="positive" onClick={() => setAsideOpen(true)}>
+            Add New CA
+          </Button>
+        )
+      }
     >
       <MainTable
         emptyStateMsg={<CAEmptyState setAsideOpen={setAsideOpen} />}
@@ -327,8 +412,8 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
           },
           {
             content: "Actions",
-            className: "u-align--right has-overflow"
-          }
+            className: "u-align--right has-overflow",
+          },
         ]}
         rows={carows}
       />
@@ -347,19 +432,22 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
   );
 }
 
-function CAEmptyState({ setAsideOpen }: { setAsideOpen: Dispatch<SetStateAction<boolean>> }) {
+function CAEmptyState({
+  setAsideOpen,
+}: {
+  setAsideOpen: Dispatch<SetStateAction<boolean>>;
+}) {
   return (
-    <EmptyState
-      image={""}
-      title="No Certificate Authorities available yet."
-    >
+    <EmptyState image={""} title="No Certificate Authorities available yet.">
       <p>
-        There are no Certificate Authorities in Notary. Create your first one to start signing certificates!
+        There are no Certificate Authorities in Notary. Create your first one to
+        start signing certificates!
       </p>
       <Button
         appearance="positive"
         aria-label="add-ca-button"
-        onClick={() => setAsideOpen(true)}>
+        onClick={() => setAsideOpen(true)}
+      >
         Add New Certificate Authority
       </Button>
     </EmptyState>

--- a/ui/src/app/(notary)/certificate_authorities/table.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/table.tsx
@@ -28,8 +28,8 @@ export function CertificateAuthoritiesTable({
   const auth = useAuth();
   const [certificateFormOpen, setCertificateFormOpen] =
     useState<boolean>(false);
-  // eslint-disable-next-line
   const [confirmationModalData, setConfirmationModalData] =
+    // eslint-disable-next-line
     useState<NotaryConfirmationModalData<any> | null>(null);
   const [selectedCA, setSelectedCA] =
     useState<CertificateAuthorityEntry | null>(null);

--- a/ui/src/app/(notary)/certificate_requests/asideForm.tsx
+++ b/ui/src/app/(notary)/certificate_requests/asideForm.tsx
@@ -1,16 +1,16 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { csrIsValid } from "@/utils";
-import { useCookies } from "react-cookie";
 import { postCSR } from "@/queries";
 import { ChangeEvent, useState, useEffect, Dispatch, SetStateAction } from "react";
 import { Textarea, Button, Input, Panel, Form } from "@canonical/react-components";
+import { useAuth } from "@/hooks/useAuth";
 
 type AsideProps = {
     setAsideOpen: Dispatch<SetStateAction<boolean>>
 };
 
-export default function CertificateRequestsAsidePanel({setAsideOpen}: AsideProps): JSX.Element {
-    const [cookies] = useCookies(['user_token']);
+export default function CertificateRequestsAsidePanel({ setAsideOpen }: AsideProps): JSX.Element {
+    const auth = useAuth()
     const [errorText, setErrorText] = useState<string>("");
     const [CSRPEMString, setCSRPEMString] = useState<string>("");
     const queryClient = useQueryClient();
@@ -20,7 +20,7 @@ export default function CertificateRequestsAsidePanel({setAsideOpen}: AsideProps
         onSuccess: () => {
             setErrorText("");
             setAsideOpen(false);
-            queryClient.invalidateQueries({ queryKey: ['csrs'] });
+            void queryClient.invalidateQueries({ queryKey: ['csrs'] });
         },
         onError: (e: Error) => {
             setErrorText(e.message);
@@ -45,7 +45,7 @@ export default function CertificateRequestsAsidePanel({setAsideOpen}: AsideProps
             const reader = new FileReader();
             reader.onload = (e: ProgressEvent<FileReader>) => {
                 if (e.target?.result) {
-                    setCSRPEMString(e.target.result.toString());
+                    setCSRPEMString(typeof e.target.result === "string" ? e.target.result : "");
                 }
             };
             reader.readAsText(file);
@@ -53,7 +53,7 @@ export default function CertificateRequestsAsidePanel({setAsideOpen}: AsideProps
     };
 
     const handleSubmit = () => {
-        mutation.mutate({ authToken: cookies.user_token, csr: CSRPEMString });
+        mutation.mutate({ authToken: auth.user ? auth.user.authToken : "", csr: CSRPEMString });
     };
 
     return (

--- a/ui/src/app/(notary)/certificate_requests/asideForm.tsx
+++ b/ui/src/app/(notary)/certificate_requests/asideForm.tsx
@@ -1,102 +1,121 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { csrIsValid } from "@/utils";
 import { postCSR } from "@/queries";
-import { ChangeEvent, useState, useEffect, Dispatch, SetStateAction } from "react";
-import { Textarea, Button, Input, Panel, Form } from "@canonical/react-components";
+import {
+  ChangeEvent,
+  useState,
+  useEffect,
+  Dispatch,
+  SetStateAction,
+} from "react";
+import {
+  Textarea,
+  Button,
+  Input,
+  Panel,
+  Form,
+} from "@canonical/react-components";
 import { useAuth } from "@/hooks/useAuth";
 
 type AsideProps = {
-    setAsideOpen: Dispatch<SetStateAction<boolean>>
+  setAsideOpen: Dispatch<SetStateAction<boolean>>;
 };
 
-export default function CertificateRequestsAsidePanel({ setAsideOpen }: AsideProps): JSX.Element {
-    const auth = useAuth()
-    const [errorText, setErrorText] = useState<string>("");
-    const [CSRPEMString, setCSRPEMString] = useState<string>("");
-    const queryClient = useQueryClient();
+export default function CertificateRequestsAsidePanel({
+  setAsideOpen,
+}: AsideProps): JSX.Element {
+  const auth = useAuth();
+  const [errorText, setErrorText] = useState<string>("");
+  const [CSRPEMString, setCSRPEMString] = useState<string>("");
+  const queryClient = useQueryClient();
 
-    const mutation = useMutation({
-        mutationFn: postCSR,
-        onSuccess: () => {
-            setErrorText("");
-            setAsideOpen(false);
-            void queryClient.invalidateQueries({ queryKey: ['csrs'] });
-        },
-        onError: (e: Error) => {
-            setErrorText(e.message);
+  const mutation = useMutation({
+    mutationFn: postCSR,
+    onSuccess: () => {
+      setErrorText("");
+      setAsideOpen(false);
+      void queryClient.invalidateQueries({ queryKey: ["csrs"] });
+    },
+    onError: (e: Error) => {
+      setErrorText(e.message);
+    },
+  });
+
+  useEffect(() => {
+    if (CSRPEMString && !csrIsValid(CSRPEMString)) {
+      setErrorText("Invalid CSR format");
+    } else {
+      setErrorText("");
+    }
+  }, [CSRPEMString]);
+
+  const handleTextChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setCSRPEMString(event.target.value);
+  };
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (e: ProgressEvent<FileReader>) => {
+        if (e.target?.result) {
+          setCSRPEMString(
+            typeof e.target.result === "string" ? e.target.result : "",
+          );
         }
+      };
+      reader.readAsText(file);
+    }
+  };
+
+  const handleSubmit = () => {
+    mutation.mutate({
+      authToken: auth.user ? auth.user.authToken : "",
+      csr: CSRPEMString,
     });
+  };
 
-    useEffect(() => {
-        if (CSRPEMString && !csrIsValid(CSRPEMString)) {
-            setErrorText("Invalid CSR format");
-        } else {
-            setErrorText("");
-        }
-    }, [CSRPEMString]);
-
-    const handleTextChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
-        setCSRPEMString(event.target.value);
-    };
-
-    const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
-        const file = event.target.files?.[0];
-        if (file) {
-            const reader = new FileReader();
-            reader.onload = (e: ProgressEvent<FileReader>) => {
-                if (e.target?.result) {
-                    setCSRPEMString(typeof e.target.result === "string" ? e.target.result : "");
-                }
-            };
-            reader.readAsText(file);
-        }
-    };
-
-    const handleSubmit = () => {
-        mutation.mutate({ authToken: auth.user ? auth.user.authToken : "", csr: CSRPEMString });
-    };
-
-    return (
-        <Panel
-            title="Add a New Certificate Request"
-            controls={
-                <Button onClick={() => setAsideOpen(false)} hasIcon>
-                    <i className="p-icon--close" />
-                </Button>
-            }
-        >
-            <Form stacked={true}>
-                <div className="p-form__group row">
-                    <Textarea
-                        name="textarea"
-                        id="csr-textarea"
-                        label="Enter or upload the CSR in PEM format below"
-                        placeholder="-----BEGIN CERTIFICATE REQUEST-----"
-                        rows={10}
-                        onChange={handleTextChange}
-                        value={CSRPEMString}
-                        error={errorText}
-                    />
-                </div>
-                <div className="p-form__group row">
-                    <Input
-                        type="file"
-                        name="upload"
-                        accept=".pem,.csr"
-                        onChange={handleFileChange}
-                    />
-                </div>
-                <div className="p-form__group row">
-                    <Button
-                        appearance="positive"
-                        name="submit"
-                        disabled={!csrIsValid(CSRPEMString)}
-                        onClick={handleSubmit}
-                    >
-                        Submit
-                    </Button>
-                </div>
-            </Form>
-        </Panel>
-    );
+  return (
+    <Panel
+      title="Add a New Certificate Request"
+      controls={
+        <Button onClick={() => setAsideOpen(false)} hasIcon>
+          <i className="p-icon--close" />
+        </Button>
+      }
+    >
+      <Form stacked={true}>
+        <div className="p-form__group row">
+          <Textarea
+            name="textarea"
+            id="csr-textarea"
+            label="Enter or upload the CSR in PEM format below"
+            placeholder="-----BEGIN CERTIFICATE REQUEST-----"
+            rows={10}
+            onChange={handleTextChange}
+            value={CSRPEMString}
+            error={errorText}
+          />
+        </div>
+        <div className="p-form__group row">
+          <Input
+            type="file"
+            name="upload"
+            accept=".pem,.csr"
+            onChange={handleFileChange}
+          />
+        </div>
+        <div className="p-form__group row">
+          <Button
+            appearance="positive"
+            name="submit"
+            disabled={!csrIsValid(CSRPEMString)}
+            onClick={handleSubmit}
+          >
+            Submit
+          </Button>
+        </div>
+      </Form>
+    </Panel>
+  );
 }

--- a/ui/src/app/(notary)/certificate_requests/components.tsx
+++ b/ui/src/app/(notary)/certificate_requests/components.tsx
@@ -2,8 +2,8 @@ import { Dispatch, SetStateAction, useState, ChangeEvent, useEffect } from "reac
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { csrMatchesCertificate, splitBundle, validateBundle } from "@/utils"
 import { postCertToID } from "@/queries"
-import { useCookies } from "react-cookie"
 import { Button, Input, Textarea, Form, Modal, Icon } from "@canonical/react-components";
+import { useAuth } from "@/hooks/useAuth"
 
 interface SubmitCertificateModalProps {
     id: string
@@ -13,7 +13,7 @@ interface SubmitCertificateModalProps {
 }
 
 export function SubmitCertificateModal({ id, csr, cert, setFormOpen }: SubmitCertificateModalProps) {
-    const [cookies] = useCookies(['user_token']);
+    const auth = useAuth()
     const [errorText, setErrorText] = useState<string>("");
     const [certificatePEMString, setCertificatePEMString] = useState<string>(cert);
     const [validationErrorText, setValidationErrorText] = useState<string>("");
@@ -22,7 +22,7 @@ export function SubmitCertificateModal({ id, csr, cert, setFormOpen }: SubmitCer
     const mutation = useMutation({
         mutationFn: postCertToID,
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['csrs'] });
+            void queryClient.invalidateQueries({ queryKey: ['csrs'] });
             setErrorText("");
             setFormOpen(false);
         },
@@ -41,7 +41,7 @@ export function SubmitCertificateModal({ id, csr, cert, setFormOpen }: SubmitCer
             const reader = new FileReader();
             reader.onload = (e: ProgressEvent<FileReader>) => {
                 if (e.target?.result) {
-                    setCertificatePEMString(e.target.result.toString());
+                    setCertificatePEMString(typeof e.target.result === "string" ? e.target.result : "");
                 }
             };
             reader.readAsText(file);
@@ -71,7 +71,7 @@ export function SubmitCertificateModal({ id, csr, cert, setFormOpen }: SubmitCer
             }
             setValidationErrorText("");
         };
-        validateCertificate();
+        void validateCertificate();
     }, [csr, certificatePEMString]);
 
     return (
@@ -80,7 +80,7 @@ export function SubmitCertificateModal({ id, csr, cert, setFormOpen }: SubmitCer
             buttonRow={
                 <>
                     <Button
-                        onClick={() => mutation.mutate({ id, authToken: cookies.user_token, cert: certificatePEMString })}
+                        onClick={() => mutation.mutate({ id, authToken: auth.user ? auth.user.authToken : "", cert: certificatePEMString })}
                         appearance="positive"
                         disabled={validationErrorText !== "" || certificatePEMString === ""}
                     >

--- a/ui/src/app/(notary)/certificate_requests/components.tsx
+++ b/ui/src/app/(notary)/certificate_requests/components.tsx
@@ -1,131 +1,162 @@
-import { Dispatch, SetStateAction, useState, ChangeEvent, useEffect } from "react"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { csrMatchesCertificate, splitBundle, validateBundle } from "@/utils"
-import { postCertToID } from "@/queries"
-import { Button, Input, Textarea, Form, Modal, Icon } from "@canonical/react-components";
-import { useAuth } from "@/hooks/useAuth"
+import {
+  Dispatch,
+  SetStateAction,
+  useState,
+  ChangeEvent,
+  useEffect,
+} from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { csrMatchesCertificate, splitBundle, validateBundle } from "@/utils";
+import { postCertToID } from "@/queries";
+import {
+  Button,
+  Input,
+  Textarea,
+  Form,
+  Modal,
+  Icon,
+} from "@canonical/react-components";
+import { useAuth } from "@/hooks/useAuth";
 
 interface SubmitCertificateModalProps {
-    id: string
-    csr: string
-    cert: string
-    setFormOpen: Dispatch<SetStateAction<boolean>>
+  id: string;
+  csr: string;
+  cert: string;
+  setFormOpen: Dispatch<SetStateAction<boolean>>;
 }
 
-export function SubmitCertificateModal({ id, csr, cert, setFormOpen }: SubmitCertificateModalProps) {
-    const auth = useAuth()
-    const [errorText, setErrorText] = useState<string>("");
-    const [certificatePEMString, setCertificatePEMString] = useState<string>(cert);
-    const [validationErrorText, setValidationErrorText] = useState<string>("");
-    const queryClient = useQueryClient();
+export function SubmitCertificateModal({
+  id,
+  csr,
+  cert,
+  setFormOpen,
+}: SubmitCertificateModalProps) {
+  const auth = useAuth();
+  const [errorText, setErrorText] = useState<string>("");
+  const [certificatePEMString, setCertificatePEMString] =
+    useState<string>(cert);
+  const [validationErrorText, setValidationErrorText] = useState<string>("");
+  const queryClient = useQueryClient();
 
-    const mutation = useMutation({
-        mutationFn: postCertToID,
-        onSuccess: () => {
-            void queryClient.invalidateQueries({ queryKey: ['csrs'] });
-            setErrorText("");
-            setFormOpen(false);
-        },
-        onError: (e: Error) => {
-            setErrorText(e.message);
+  const mutation = useMutation({
+    mutationFn: postCertToID,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["csrs"] });
+      setErrorText("");
+      setFormOpen(false);
+    },
+    onError: (e: Error) => {
+      setErrorText(e.message);
+    },
+  });
+
+  const handleTextChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setCertificatePEMString(event.target.value);
+  };
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (e: ProgressEvent<FileReader>) => {
+        if (e.target?.result) {
+          setCertificatePEMString(
+            typeof e.target.result === "string" ? e.target.result : "",
+          );
         }
-    });
-
-    const handleTextChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
-        setCertificatePEMString(event.target.value);
-    };
-
-    const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
-        const file = event.target.files?.[0];
-        if (file) {
-            const reader = new FileReader();
-            reader.onload = (e: ProgressEvent<FileReader>) => {
-                if (e.target?.result) {
-                    setCertificatePEMString(typeof e.target.result === "string" ? e.target.result : "");
-                }
-            };
-            reader.readAsText(file);
-        }
-    };
-
-    useEffect(() => {
-        const validateCertificate = async () => {
-            try {
-                const certs = splitBundle(certificatePEMString);
-                if (certs.length < 2) {
-                    setValidationErrorText("Bundle with 2 certificates required");
-                    return;
-                }
-                if (!csrMatchesCertificate(csr, certs[0])) {
-                    setValidationErrorText("Certificate does not match request");
-                    return;
-                }
-                const validationMessage = await validateBundle(certificatePEMString);
-                if (validationMessage !== "") {
-                    setValidationErrorText("Bundle validation failed: " + validationMessage);
-                    return;
-                }
-            } catch {
-                setValidationErrorText("A certificate is invalid");
-                return;
-            }
-            setValidationErrorText("");
-        };
-        void validateCertificate();
-    }, [csr, certificatePEMString]);
-
-    return (
-        <Modal
-            title="Submit Certificate"
-            buttonRow={
-                <>
-                    <Button
-                        onClick={() => mutation.mutate({ id, authToken: auth.user ? auth.user.authToken : "", cert: certificatePEMString })}
-                        appearance="positive"
-                        disabled={validationErrorText !== "" || certificatePEMString === ""}
-                    >
-                        Submit
-                    </Button>
-                    <Button onMouseDown={() => setFormOpen(false)}>
-                        Cancel
-                    </Button>
-                </>
-            }
-        >
-            <Form stacked={true}>
-                <div className="p-form__group row">
-                    <Textarea
-                        name="textarea"
-                        id="csr-textarea"
-                        label="Enter or upload the Certificate in PEM format below"
-                        placeholder="-----BEGIN CERTIFICATE-----"
-                        rows={10}
-                        onChange={handleTextChange}
-                        value={certificatePEMString}
-                        error={validationErrorText || errorText}
-                    />
-                </div>
-                <div className="p-form__group row">
-                    <Input
-                        type="file"
-                        name="upload"
-                        accept=".pem,.crt"
-                        onChange={handleFileChange}
-                    />
-                </div>
-            </Form>
-        </Modal>
-    );
-}
-
-export function SuccessNotification({ successMessage }: { successMessage: string }) {
-    const style = {
-        display: 'inline'
+      };
+      reader.readAsText(file);
     }
-    return (
-        <p style={style}>
-            <Icon name="success" />
-            {successMessage}
-        </p>
-    );
+  };
+
+  useEffect(() => {
+    const validateCertificate = async () => {
+      try {
+        const certs = splitBundle(certificatePEMString);
+        if (certs.length < 2) {
+          setValidationErrorText("Bundle with 2 certificates required");
+          return;
+        }
+        if (!csrMatchesCertificate(csr, certs[0])) {
+          setValidationErrorText("Certificate does not match request");
+          return;
+        }
+        const validationMessage = await validateBundle(certificatePEMString);
+        if (validationMessage !== "") {
+          setValidationErrorText(
+            "Bundle validation failed: " + validationMessage,
+          );
+          return;
+        }
+      } catch {
+        setValidationErrorText("A certificate is invalid");
+        return;
+      }
+      setValidationErrorText("");
+    };
+    void validateCertificate();
+  }, [csr, certificatePEMString]);
+
+  return (
+    <Modal
+      title="Submit Certificate"
+      buttonRow={
+        <>
+          <Button
+            onClick={() =>
+              mutation.mutate({
+                id,
+                authToken: auth.user ? auth.user.authToken : "",
+                cert: certificatePEMString,
+              })
+            }
+            appearance="positive"
+            disabled={validationErrorText !== "" || certificatePEMString === ""}
+          >
+            Submit
+          </Button>
+          <Button onMouseDown={() => setFormOpen(false)}>Cancel</Button>
+        </>
+      }
+    >
+      <Form stacked={true}>
+        <div className="p-form__group row">
+          <Textarea
+            name="textarea"
+            id="csr-textarea"
+            label="Enter or upload the Certificate in PEM format below"
+            placeholder="-----BEGIN CERTIFICATE-----"
+            rows={10}
+            onChange={handleTextChange}
+            value={certificatePEMString}
+            error={validationErrorText || errorText}
+          />
+        </div>
+        <div className="p-form__group row">
+          <Input
+            type="file"
+            name="upload"
+            accept=".pem,.crt"
+            onChange={handleFileChange}
+          />
+        </div>
+      </Form>
+    </Modal>
+  );
+}
+
+export function SuccessNotification({
+  successMessage,
+}: {
+  successMessage: string;
+}) {
+  const style = {
+    display: "inline",
+  };
+  return (
+    <p style={style}>
+      <Icon name="success" />
+      {successMessage}
+    </p>
+  );
 }

--- a/ui/src/app/(notary)/certificate_requests/page.tsx
+++ b/ui/src/app/(notary)/certificate_requests/page.tsx
@@ -1,44 +1,48 @@
-"use client"
+"use client";
 
-import { useQuery } from "@tanstack/react-query"
-import { CertificateRequestsTable } from "./table"
-import { getCertificateRequests } from "@/queries"
-import { CSREntry } from "@/types"
-import { useCookies } from "react-cookie"
-import { useRouter } from "next/navigation"
-import Loading from "@/components/loading"
-import Error from "@/components/error"
-import { useState } from "react"
-import { AppAside, Application, AppMain } from "@canonical/react-components"
-import CertificateRequestsAsidePanel from "./asideForm"
-import NotaryAppNavigationBars from "@/components/NotaryAppNavigationBars"
-import { retryUnlessUnauthorized } from "@/utils"
-import NotaryAppStatus from "@/components/NotaryAppStatus"
-
+import { useQuery } from "@tanstack/react-query";
+import { CertificateRequestsTable } from "./table";
+import { getCertificateRequests } from "@/queries";
+import { CSREntry } from "@/types";
+import { useCookies } from "react-cookie";
+import { useRouter } from "next/navigation";
+import Loading from "@/components/loading";
+import Error from "@/components/error";
+import { useState } from "react";
+import { AppAside, Application, AppMain } from "@canonical/react-components";
+import CertificateRequestsAsidePanel from "./asideForm";
+import NotaryAppNavigationBars from "@/components/NotaryAppNavigationBars";
+import { retryUnlessUnauthorized } from "@/utils";
+import NotaryAppStatus from "@/components/NotaryAppStatus";
 
 export default function CertificateRequestsPanel() {
-  const router = useRouter()
-  const [asideOpen, setAsideOpen] = useState<boolean>(false)
-  const [cookies, , removeCookie] = useCookies(['user_token']);
+  const router = useRouter();
+  const [asideOpen, setAsideOpen] = useState<boolean>(false);
+  const [cookies, , removeCookie] = useCookies(["user_token"]);
 
   if (!cookies.user_token) {
-    router.push("/login")
+    router.push("/login");
   }
 
   const query = useQuery<CSREntry[], Error>({
-    queryKey: ['csrs', cookies.user_token],
+    queryKey: ["csrs", cookies.user_token],
     // eslint-disable-next-line
-    queryFn: () => getCertificateRequests({ authToken: cookies.user_token ? cookies.user_token : "" }),
+    queryFn: () =>
+      getCertificateRequests({
+        authToken: cookies.user_token ? cookies.user_token : "",
+      }),
     retry: retryUnlessUnauthorized,
-  })
-  if (query.status == "pending") { return <Loading /> }
+  });
+  if (query.status == "pending") {
+    return <Loading />;
+  }
   if (query.status == "error") {
     if (query.error.message.includes("401")) {
-      removeCookie("user_token")
+      removeCookie("user_token");
     }
-    return <Error msg={query.error.message} />
+    return <Error msg={query.error.message} />;
   }
-  const csrs = Array.from(query.data ? query.data : [])
+  const csrs = Array.from(query.data ? query.data : []);
   return (
     <Application>
       <NotaryAppNavigationBars />
@@ -50,5 +54,5 @@ export default function CertificateRequestsPanel() {
       </AppMain>
       <NotaryAppStatus />
     </Application>
-  )
+  );
 }

--- a/ui/src/app/(notary)/certificate_requests/page.tsx
+++ b/ui/src/app/(notary)/certificate_requests/page.tsx
@@ -19,7 +19,7 @@ import NotaryAppStatus from "@/components/NotaryAppStatus"
 export default function CertificateRequestsPanel() {
   const router = useRouter()
   const [asideOpen, setAsideOpen] = useState<boolean>(false)
-  const [cookies, setCookie, removeCookie] = useCookies(['user_token']);
+  const [cookies, , removeCookie] = useCookies(['user_token']);
 
   if (!cookies.user_token) {
     router.push("/login")
@@ -27,7 +27,8 @@ export default function CertificateRequestsPanel() {
 
   const query = useQuery<CSREntry[], Error>({
     queryKey: ['csrs', cookies.user_token],
-    queryFn: () => getCertificateRequests({ authToken: cookies.user_token }),
+    // eslint-disable-next-line
+    queryFn: () => getCertificateRequests({ authToken: cookies.user_token ? cookies.user_token : "" }),
     retry: retryUnlessUnauthorized,
   })
   if (query.status == "pending") { return <Loading /> }

--- a/ui/src/app/(notary)/certificate_requests/page.tsx
+++ b/ui/src/app/(notary)/certificate_requests/page.tsx
@@ -26,9 +26,9 @@ export default function CertificateRequestsPanel() {
 
   const query = useQuery<CSREntry[], Error>({
     queryKey: ["csrs", cookies.user_token],
-    // eslint-disable-next-line
     queryFn: () =>
       getCertificateRequests({
+        // eslint-disable-next-line
         authToken: cookies.user_token ? cookies.user_token : "",
       }),
     retry: retryUnlessUnauthorized,

--- a/ui/src/app/(notary)/certificate_requests/table.test.tsx
+++ b/ui/src/app/(notary)/certificate_requests/table.test.tsx
@@ -1,13 +1,13 @@
-import { expect, test } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import { CertificateRequestsTable } from './table'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { CSREntry } from '@/types'
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CertificateRequestsTable } from "./table";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { CSREntry } from "@/types";
 
 const rows: CSREntry[] = [
-    {
-        'id': 1,
-        'csr': `-----BEGIN CERTIFICATE REQUEST-----
+  {
+    id: 1,
+    csr: `-----BEGIN CERTIFICATE REQUEST-----
 MIICszCCAZsCAQAwFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3
 DQEBAQUAA4IBDwAwggEKAoIBAQDC5KgrADpuOUPwSh0YLmpWF66VTcciIGC2HcGn
 oJknL7pm5q9qhfWGIdvKKlIA6cBB32jPd0QcYDsx7+AvzEvBuO7mq7v2Q1sPU4Q+
@@ -24,12 +24,12 @@ Y/uPl4g3jpGqLCKTASWJDGnZLroLICOzYTVs5P3oj+VueSUwYhGK5tBnS2x5FHID
 uMNMgwl0fxGMQZjrlXyCBhXBm1k6PmwcJGJF5LQ31c+5aTTMFU7SyZhlymctB8mS
 y+ErBQsRpcQho6Ok+HTXQQUcx7WNcwI=
 -----END CERTIFICATE REQUEST-----`,
-        'certificate_chain': "",
-        'status': "Outstanding",
-    },
-    {
-        'id': 2,
-        'csr': `-----BEGIN CERTIFICATE REQUEST-----
+    certificate_chain: "",
+    status: "Outstanding",
+  },
+  {
+    id: 2,
+    csr: `-----BEGIN CERTIFICATE REQUEST-----
 MIIDGjCCAgICAQAwajEVMBMGA1UEAwwMZXhlbXBsYXIuY29tMQswCQYDVQQGEwJV
 UzESMBAGA1UECAwJTG91aXNpYW5hMRQwEgYDVQQHDAtOZXcgT3JsZWFuczEaMBgG
 A1UECgwRQ2VydGlmaWNhdGUgVG9vbHMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
@@ -48,12 +48,12 @@ tK9qb8EE92MoWboo4m4bcX74y+eUo3xBev6ZZwdScy8OHLhA/MMI8EElpeYt+Hc2
 WsDOAOH6qKQKQg3BO/xmRoohC6GL4CuhP7HYGi7+wziNhNZQa4GtE/k9DyIXVtJy
 yuf2PnfXCKnaIWRJNoEqDCZRVMfA5BFSwTPITqyo
 -----END CERTIFICATE REQUEST-----`,
-        'certificate_chain': "",
-        'status': "Rejected"
-    },
-    {
-        'id': 3,
-        'csr': `-----BEGIN CERTIFICATE REQUEST-----
+    certificate_chain: "",
+    status: "Rejected",
+  },
+  {
+    id: 3,
+    csr: `-----BEGIN CERTIFICATE REQUEST-----
 MIIC5zCCAc8CAQAwRzEWMBQGA1UEAwwNMTAuMTUyLjE4My41MzEtMCsGA1UELQwk
 MzlhY2UxOTUtZGM1YS00MzJiLTgwOTAtYWZlNmFiNGI0OWNmMIIBIjANBgkqhkiG
 9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjM5Wz+HRtDveRzeDkEDM4ornIaefe8d8nmFi
@@ -71,7 +71,7 @@ cAQXk3fvTWuikHiCHqqdSdjDYj/8cyiwCrQWpV245VSbOE0WesWoEnSdFXVUfE1+
 RSKeTRuuJMcdGqBkDnDI22myj0bjt7q8eqBIjTiLQLnAFnQYpcCrhc8dKU9IJlv1
 H9Hay4ZO9LRew3pEtlx2WrExw/gpUcWM8rTI
 -----END CERTIFICATE REQUEST-----`,
-        'certificate_chain': `-----BEGIN CERTIFICATE-----
+    certificate_chain: `-----BEGIN CERTIFICATE-----
 MIIDrDCCApSgAwIBAgIURKr+jf7hj60SyAryIeN++9wDdtkwDQYJKoZIhvcNAQEL
 BQAwOTELMAkGA1UEBhMCVVMxKjAoBgNVBAMMIXNlbGYtc2lnbmVkLWNlcnRpZmlj
 YXRlcy1vcGVyYXRvcjAeFw0yNDAzMjcxMjQ4MDRaFw0yNTAzMjcxMjQ4MDRaMEcx
@@ -93,17 +93,17 @@ gCX3nqYpp70oZIFDrhmYwE5ij5KXlHD4/1IOfNUKCDmQDgGPLI1tVtwQLjeRq7Hg
 XVelpl/LXTQawmJyvDaVT/Q9P+WqoDiMjrqF6Sy7DzNeeccWVqvqX5TVS6Ky56iS
 Mvo/+PAJHkBciR5Xn+Wg2a+7vrZvT6CBoRSOTozlLSM=
 -----END CERTIFICATE-----`,
-        'status': 'Active'
-    },
-]
+    status: "Active",
+  },
+];
 
-const queryClient = new QueryClient()
-test('CertificateRequestsPage', () => {
-    render(
-        <QueryClientProvider client={queryClient}>
-            < CertificateRequestsTable csrs={rows} setAsideOpen={() => {}}/>
-        </QueryClientProvider>
-    )
-    const commonNames = screen.getAllByText('example.com');
-    expect(commonNames.length).toBeGreaterThan(0);
-})
+const queryClient = new QueryClient();
+test("CertificateRequestsPage", () => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <CertificateRequestsTable csrs={rows} setAsideOpen={() => {}} />
+    </QueryClientProvider>,
+  );
+  const commonNames = screen.getAllByText("example.com");
+  expect(commonNames.length).toBeGreaterThan(0);
+});

--- a/ui/src/app/(notary)/certificate_requests/table.tsx
+++ b/ui/src/app/(notary)/certificate_requests/table.tsx
@@ -1,5 +1,5 @@
 import { useState, Dispatch, SetStateAction } from "react";
-import { CSREntry } from "@/types";
+import { CertificateSigningRequest, CSREntry } from "@/types";
 import { Button, MainTable, Panel, EmptyState, ContextualMenu } from "@canonical/react-components";
 import { deleteCSR, rejectCSR, revokeCertificate, signCSR } from "@/queries"
 import { extractCSR, extractCert, splitBundle } from "@/utils";
@@ -15,24 +15,25 @@ type TableProps = {
 export function CertificateRequestsTable({ csrs: rows, setAsideOpen }: TableProps) {
   const auth = useAuth()
   const [certificateFormOpen, setCertificateFormOpen] = useState<boolean>(false);
-  const [confirmationModalData, setConfirmationModalData] = useState<NotaryConfirmationModalData | null>(null);
+  // eslint-disable-next-line
+  const [confirmationModalData, setConfirmationModalData] = useState<NotaryConfirmationModalData<any> | null>(null);
   const [selectedCSR, setSelectedCSR] = useState<CSREntry | null>(null);
   const [showCSRContent, setShowCSRContent] = useState<number | null>(null);
   const [showCertContent, setShowCertContent] = useState<number | null>(null);
   const [successNotificationId, setSuccessNotificationId] = useState<number | null>(null);
 
   const handleCopy = (csr: string, id: number) => {
-    navigator.clipboard.writeText(csr).then(() => {
+    void navigator.clipboard.writeText(csr).then(() => {
       setSuccessNotificationId(id);
       setTimeout(() => setSuccessNotificationId(null), 2500);
     });
   };
 
-  const handleDownload = (csr: string, id: number, csrObj: any) => {
+  const handleDownload = (csr: string, id: number, csrObj: CertificateSigningRequest) => {
     const blob = new Blob([csr], { type: 'text/plain' });
     const link = document.createElement('a');
     link.href = URL.createObjectURL(blob);
-    link.download = `csr-${csrObj.commonName || id}.pem`;
+    link.download = `csr-${csrObj.commonName?.toLowerCase() || id}.pem`;
     link.click();
     URL.revokeObjectURL(link.href);
   };
@@ -107,7 +108,7 @@ export function CertificateRequestsTable({ csrs: rows, setAsideOpen }: TableProp
     return "rgba(14, 132, 32, 0.35)";
   };
 
-  const getFieldDisplay = (label: string, field: string | undefined, compareField?: string | undefined) => {
+  const getFieldDisplay = (label: string, field: string | undefined, compareField?: string) => {
     const isMismatched = compareField !== undefined && compareField !== field;
     return field ? (
       <p style={{ marginBottom: "4px" }}>

--- a/ui/src/app/(notary)/certificate_requests/table.tsx
+++ b/ui/src/app/(notary)/certificate_requests/table.tsx
@@ -28,8 +28,8 @@ export function CertificateRequestsTable({
   const auth = useAuth();
   const [certificateFormOpen, setCertificateFormOpen] =
     useState<boolean>(false);
-  // eslint-disable-next-line
   const [confirmationModalData, setConfirmationModalData] =
+    // eslint-disable-next-line
     useState<NotaryConfirmationModalData<any> | null>(null);
   const [selectedCSR, setSelectedCSR] = useState<CSREntry | null>(null);
   const [showCSRContent, setShowCSRContent] = useState<number | null>(null);

--- a/ui/src/app/(notary)/certificate_requests/table.tsx
+++ b/ui/src/app/(notary)/certificate_requests/table.tsx
@@ -1,26 +1,42 @@
 import { useState, Dispatch, SetStateAction } from "react";
 import { CertificateSigningRequest, CSREntry } from "@/types";
-import { Button, MainTable, Panel, EmptyState, ContextualMenu } from "@canonical/react-components";
-import { deleteCSR, rejectCSR, revokeCertificate, signCSR } from "@/queries"
+import {
+  Button,
+  MainTable,
+  Panel,
+  EmptyState,
+  ContextualMenu,
+} from "@canonical/react-components";
+import { deleteCSR, rejectCSR, revokeCertificate, signCSR } from "@/queries";
 import { extractCSR, extractCert, splitBundle } from "@/utils";
-import { SubmitCertificateModal, SuccessNotification } from "./components"
-import { NotaryConfirmationModal, NotaryConfirmationModalData } from "@/components/NotaryConfirmationModal";
+import { SubmitCertificateModal, SuccessNotification } from "./components";
+import {
+  NotaryConfirmationModal,
+  NotaryConfirmationModalData,
+} from "@/components/NotaryConfirmationModal";
 import { useAuth } from "@/hooks/useAuth";
 
 type TableProps = {
   csrs: CSREntry[];
-  setAsideOpen: Dispatch<SetStateAction<boolean>>
+  setAsideOpen: Dispatch<SetStateAction<boolean>>;
 };
 
-export function CertificateRequestsTable({ csrs: rows, setAsideOpen }: TableProps) {
-  const auth = useAuth()
-  const [certificateFormOpen, setCertificateFormOpen] = useState<boolean>(false);
+export function CertificateRequestsTable({
+  csrs: rows,
+  setAsideOpen,
+}: TableProps) {
+  const auth = useAuth();
+  const [certificateFormOpen, setCertificateFormOpen] =
+    useState<boolean>(false);
   // eslint-disable-next-line
-  const [confirmationModalData, setConfirmationModalData] = useState<NotaryConfirmationModalData<any> | null>(null);
+  const [confirmationModalData, setConfirmationModalData] =
+    useState<NotaryConfirmationModalData<any> | null>(null);
   const [selectedCSR, setSelectedCSR] = useState<CSREntry | null>(null);
   const [showCSRContent, setShowCSRContent] = useState<number | null>(null);
   const [showCertContent, setShowCertContent] = useState<number | null>(null);
-  const [successNotificationId, setSuccessNotificationId] = useState<number | null>(null);
+  const [successNotificationId, setSuccessNotificationId] = useState<
+    number | null
+  >(null);
 
   const handleCopy = (csr: string, id: number) => {
     void navigator.clipboard.writeText(csr).then(() => {
@@ -29,9 +45,13 @@ export function CertificateRequestsTable({ csrs: rows, setAsideOpen }: TableProp
     });
   };
 
-  const handleDownload = (csr: string, id: number, csrObj: CertificateSigningRequest) => {
-    const blob = new Blob([csr], { type: 'text/plain' });
-    const link = document.createElement('a');
+  const handleDownload = (
+    csr: string,
+    id: number,
+    csrObj: CertificateSigningRequest,
+  ) => {
+    const blob = new Blob([csr], { type: "text/plain" });
+    const link = document.createElement("a");
     link.href = URL.createObjectURL(blob);
     link.download = `csr-${csrObj.commonName?.toLowerCase() || id}.pem`;
     link.click();
@@ -47,21 +67,26 @@ export function CertificateRequestsTable({ csrs: rows, setAsideOpen }: TableProp
     const certObj = clientCertificate ? extractCert(clientCertificate) : null;
     setConfirmationModalData({
       queryFn: signCSR,
-      queryParams: { id: id.toString(), authToken: auth.user?.authToken, certificate_authority_id: auth.activeCA.id },
+      queryParams: {
+        id: id.toString(),
+        authToken: auth.user?.authToken,
+        certificate_authority_id: auth.activeCA.id,
+      },
       closeFn: () => setConfirmationModalData(null),
-      queryKey: 'csrs',
+      queryKey: "csrs",
       warningText: `Signing a Certificate Request means the CSR will be signed and a certificate will be generated. This CSR will be signed by "${certObj?.commonName}". This action cannot be undone.`,
-      buttonConfirmText: "Sign"
-    })
-  }
+      buttonConfirmText: "Sign",
+    });
+  };
 
   const handleReject = (id: number) => {
     setConfirmationModalData({
       queryFn: rejectCSR,
       queryParams: { id: id.toString(), authToken: auth.user?.authToken },
       closeFn: () => setConfirmationModalData(null),
-      queryKey: 'csrs',
-      warningText: "Rejecting a Certificate Request means the CSR will remain in this application, but its status will be moved to rejected and the associated certificate will be deleted if there is any. This action cannot be undone.",
+      queryKey: "csrs",
+      warningText:
+        "Rejecting a Certificate Request means the CSR will remain in this application, but its status will be moved to rejected and the associated certificate will be deleted if there is any. This action cannot be undone.",
       buttonConfirmText: "Reject",
     });
   };
@@ -71,8 +96,9 @@ export function CertificateRequestsTable({ csrs: rows, setAsideOpen }: TableProp
       queryFn: deleteCSR,
       queryParams: { id: id.toString(), authToken: auth.user?.authToken },
       closeFn: () => setConfirmationModalData(null),
-      queryKey: 'csrs',
-      warningText: "Deleting a Certificate Request means this row will be completely removed from the application. This action cannot be undone.",
+      queryKey: "csrs",
+      warningText:
+        "Deleting a Certificate Request means this row will be completely removed from the application. This action cannot be undone.",
       buttonConfirmText: "Delete",
     });
   };
@@ -82,14 +108,15 @@ export function CertificateRequestsTable({ csrs: rows, setAsideOpen }: TableProp
       queryFn: revokeCertificate,
       queryParams: { id: id.toString(), authToken: auth.user?.authToken },
       closeFn: () => setConfirmationModalData(null),
-      queryKey: 'csrs',
-      warningText: "Revoking a Certificate will delete it from the table. This action cannot be undone.",
+      queryKey: "csrs",
+      warningText:
+        "Revoking a Certificate will delete it from the table. This action cannot be undone.",
       buttonConfirmText: "Revoke",
     });
   };
 
-  const handleExpand = (id: number, type: 'CSR' | 'Cert') => {
-    if (type === 'CSR') {
+  const handleExpand = (id: number, type: "CSR" | "Cert") => {
+    if (type === "CSR") {
       setShowCSRContent(id === showCSRContent ? null : id);
       setShowCertContent(null);
     } else {
@@ -99,7 +126,7 @@ export function CertificateRequestsTable({ csrs: rows, setAsideOpen }: TableProp
   };
 
   const getExpiryColor = (notAfter?: string): string => {
-    if (!notAfter) return 'inherit';
+    if (!notAfter) return "inherit";
     const expiryDate = new Date(notAfter);
     const now = new Date();
     const timeDifference = expiryDate.getTime() - now.getTime();
@@ -108,12 +135,18 @@ export function CertificateRequestsTable({ csrs: rows, setAsideOpen }: TableProp
     return "rgba(14, 132, 32, 0.35)";
   };
 
-  const getFieldDisplay = (label: string, field: string | undefined, compareField?: string) => {
+  const getFieldDisplay = (
+    label: string,
+    field: string | undefined,
+    compareField?: string,
+  ) => {
     const isMismatched = compareField !== undefined && compareField !== field;
     return field ? (
       <p style={{ marginBottom: "4px" }}>
         <b>{label}:</b>{" "}
-        <span style={{ color: isMismatched ? "rgba(199, 22, 43, 1)" : "inherit" }}>
+        <span
+          style={{ color: isMismatched ? "rgba(199, 22, 43, 1)" : "inherit" }}
+        >
           {field}
         </span>
       </p>
@@ -147,25 +180,29 @@ export function CertificateRequestsTable({ csrs: rows, setAsideOpen }: TableProp
         {
           content: (
             <>
-              {successNotificationId === id && <SuccessNotification successMessage="CSR copied to clipboard" />}
-              <ContextualMenu
-                hasToggleIcon
-                position="right"
-              >
+              {successNotificationId === id && (
+                <SuccessNotification successMessage="CSR copied to clipboard" />
+              )}
+              <ContextualMenu hasToggleIcon position="right">
                 <span className="p-contextual-menu__group">
                   <Button
                     className="p-contextual-menu__link"
-                    onMouseDown={() => handleExpand(id, 'CSR')}>
-                    {isCSRContentVisible ? "Hide CSR Content" : "Show CSR Content"}
+                    onMouseDown={() => handleExpand(id, "CSR")}
+                  >
+                    {isCSRContentVisible
+                      ? "Hide CSR Content"
+                      : "Show CSR Content"}
                   </Button>
                   <Button
                     className="p-contextual-menu__link"
-                    onMouseDown={() => handleCopy(csr, id)}>
+                    onMouseDown={() => handleCopy(csr, id)}
+                  >
                     Copy CSR to Clipboard
                   </Button>
                   <Button
                     className="p-contextual-menu__link"
-                    onMouseDown={() => handleDownload(csr, id, csrObj)}>
+                    onMouseDown={() => handleDownload(csr, id, csrObj)}
+                  >
                     Download CSR
                   </Button>
                 </span>
@@ -173,13 +210,17 @@ export function CertificateRequestsTable({ csrs: rows, setAsideOpen }: TableProp
                   <Button
                     className="p-contextual-menu__link"
                     disabled={csr_status != "Active"}
-                    onMouseDown={() => handleExpand(id, 'Cert')}>
-                    {isCertContentVisible ? "Hide Certificate Content" : "Show Certificate Content"}
+                    onMouseDown={() => handleExpand(id, "Cert")}
+                  >
+                    {isCertContentVisible
+                      ? "Hide Certificate Content"
+                      : "Show Certificate Content"}
                   </Button>
                   <Button
                     className="p-contextual-menu__link"
                     disabled={!auth.activeCA}
-                    onMouseDown={() => handleSign(id)}>
+                    onMouseDown={() => handleSign(id)}
+                  >
                     Sign CSR
                   </Button>
                   <Button
@@ -187,13 +228,15 @@ export function CertificateRequestsTable({ csrs: rows, setAsideOpen }: TableProp
                     onMouseDown={() => {
                       setCertificateFormOpen(true);
                       setSelectedCSR(csrEntry);
-                    }}>
+                    }}
+                  >
                     Upload New Certificate
                   </Button>
                   <Button
                     className="p-contextual-menu__link"
                     disabled={csr_status != "Active"}
-                    onMouseDown={() => handleRevoke(id)}>
+                    onMouseDown={() => handleRevoke(id)}
+                  >
                     Revoke Certificate
                   </Button>
                 </span>
@@ -201,12 +244,14 @@ export function CertificateRequestsTable({ csrs: rows, setAsideOpen }: TableProp
                   <Button
                     className="p-contextual-menu__link"
                     disabled={csr_status == "Rejected"}
-                    onMouseDown={() => handleReject(id)}>
+                    onMouseDown={() => handleReject(id)}
+                  >
                     Reject Certificate Request
                   </Button>
                   <Button
                     className="p-contextual-menu__link"
-                    onMouseDown={() => handleDelete(id)}>
+                    onMouseDown={() => handleDelete(id)}
+                  >
                     Delete Certificate Request
                   </Button>
                 </span>
@@ -219,38 +264,62 @@ export function CertificateRequestsTable({ csrs: rows, setAsideOpen }: TableProp
       ],
       expanded: isCSRContentVisible || isCertContentVisible,
       expandedContent: (
-        <div >
+        <div>
           {isCSRContentVisible && (
-            <div >
+            <div>
               <h4>Certificate Request Content</h4>
               {getFieldDisplay("Common Name", csrObj.commonName)}
-              {getFieldDisplay("Subject Alternative Name DNS", csrObj.sansDns?.join(', '))}
-              {getFieldDisplay("Subject Alternative Name IP addresses", csrObj.sansIp?.join(', '))}
+              {getFieldDisplay(
+                "Subject Alternative Name DNS",
+                csrObj.sansDns?.join(", "),
+              )}
+              {getFieldDisplay(
+                "Subject Alternative Name IP addresses",
+                csrObj.sansIp?.join(", "),
+              )}
               {getFieldDisplay("Country", csrObj.country)}
               {getFieldDisplay("State or Province", csrObj.stateOrProvince)}
               {getFieldDisplay("Locality", csrObj.locality)}
               {getFieldDisplay("Organization", csrObj.organization)}
-              {getFieldDisplay("Organizational Unit", csrObj.OrganizationalUnitName)}
+              {getFieldDisplay(
+                "Organizational Unit",
+                csrObj.OrganizationalUnitName,
+              )}
               {getFieldDisplay("Email Address", csrObj.emailAddress)}
-              <p><b>Certificate request for a certificate authority</b>: {csrObj.is_ca ? "Yes" : "No"}</p>
+              <p>
+                <b>Certificate request for a certificate authority</b>:{" "}
+                {csrObj.is_ca ? "Yes" : "No"}
+              </p>
             </div>
           )}
           {isCertContentVisible && certObj && (
-            <div >
+            <div>
               <h4>Certificate Content</h4>
               {getFieldDisplay("Common Name", certObj.commonName)}
-              {getFieldDisplay("Subject Alternative Name DNS", certObj.sansDns?.join(', '))}
-              {getFieldDisplay("Subject Alternative Name IP addresses", certObj.sansIp?.join(', '))}
+              {getFieldDisplay(
+                "Subject Alternative Name DNS",
+                certObj.sansDns?.join(", "),
+              )}
+              {getFieldDisplay(
+                "Subject Alternative Name IP addresses",
+                certObj.sansIp?.join(", "),
+              )}
               {getFieldDisplay("Country", certObj.country)}
               {getFieldDisplay("State or Province", certObj.stateOrProvince)}
               {getFieldDisplay("Locality", certObj.locality)}
               {getFieldDisplay("Organization", certObj.organization)}
-              {getFieldDisplay("Organizational Unit", certObj.OrganizationalUnitName)}
+              {getFieldDisplay(
+                "Organizational Unit",
+                certObj.OrganizationalUnitName,
+              )}
               {getFieldDisplay("Email Address", certObj.emailAddress)}
               {getFieldDisplay("Start of validity", certObj.notBefore)}
               {getFieldDisplay("Expiry Time", certObj.notAfter)}
               {getFieldDisplay("Issuer Common Name", certObj.issuerCommonName)}
-              <p><b>Certificate for a certificate authority</b>: {certObj.is_ca ? "Yes" : "No"}</p>
+              <p>
+                <b>Certificate for a certificate authority</b>:{" "}
+                {certObj.is_ca ? "Yes" : "No"}
+              </p>
             </div>
           )}
         </div>
@@ -262,11 +331,13 @@ export function CertificateRequestsTable({ csrs: rows, setAsideOpen }: TableProp
       stickyHeader
       title="Certificate Requests"
       className="u-fixed-width"
-      controls={rows.length > 0 && (
-        <Button appearance="positive" onClick={() => setAsideOpen(true)}>
-          Add New Certificate Request
-        </Button>
-      )}
+      controls={
+        rows.length > 0 && (
+          <Button appearance="positive" onClick={() => setAsideOpen(true)}>
+            Add New Certificate Request
+          </Button>
+        )
+      }
     >
       <MainTable
         emptyStateMsg={<CSREmptyState setAsideOpen={setAsideOpen} />}
@@ -291,12 +362,14 @@ export function CertificateRequestsTable({ csrs: rows, setAsideOpen }: TableProp
           },
           {
             content: "Actions",
-            className: "u-align--right has-overflow"
-          }
+            className: "u-align--right has-overflow",
+          },
         ]}
         rows={csrrows}
       />
-      {confirmationModalData && <NotaryConfirmationModal {...confirmationModalData} />}
+      {confirmationModalData && (
+        <NotaryConfirmationModal {...confirmationModalData} />
+      )}
       {certificateFormOpen && selectedCSR && (
         <SubmitCertificateModal
           id={selectedCSR.id.toString()}
@@ -309,19 +382,22 @@ export function CertificateRequestsTable({ csrs: rows, setAsideOpen }: TableProp
   );
 }
 
-function CSREmptyState({ setAsideOpen }: { setAsideOpen: Dispatch<SetStateAction<boolean>> }) {
+function CSREmptyState({
+  setAsideOpen,
+}: {
+  setAsideOpen: Dispatch<SetStateAction<boolean>>;
+}) {
   return (
-    <EmptyState
-      image={""}
-      title="No CSRs available yet."
-    >
+    <EmptyState image={""} title="No CSRs available yet.">
       <p>
-        There are no Certificate Requests in Notary. Request your first certificate!
+        There are no Certificate Requests in Notary. Request your first
+        certificate!
       </p>
       <Button
         appearance="positive"
         aria-label="add-csr-button"
-        onClick={() => setAsideOpen(true)}>
+        onClick={() => setAsideOpen(true)}
+      >
         Add New CSR
       </Button>
     </EmptyState>

--- a/ui/src/app/(notary)/layout.tsx
+++ b/ui/src/app/(notary)/layout.tsx
@@ -1,9 +1,9 @@
-"use client"
-import '@/globals.scss'
+"use client";
+import "@/globals.scss";
 import { AuthProvider } from "@/hooks/useAuth";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient();
 export default function RootLayout({
   children,
 }: Readonly<{

--- a/ui/src/app/(notary)/users/asideForm.tsx
+++ b/ui/src/app/(notary)/users/asideForm.tsx
@@ -4,10 +4,11 @@ import { changePassword, postUser } from "@/queries";
 import { ChangeEvent, Dispatch, SetStateAction, useState } from "react";
 import { useAuth } from "@/hooks/useAuth";
 import { Panel, Button, Input, PasswordToggle, Form } from "@canonical/react-components";
+import { AsideFormData } from "@/types";
 
 type AsideProps = {
   setAsideOpen: Dispatch<SetStateAction<boolean>>
-  formData: any
+  formData: AsideFormData
 };
 
 export default function UsersPageAsidePanel(asideProps: AsideProps) {
@@ -34,7 +35,7 @@ function AddNewUserForm(asideProps: AsideProps) {
   const mutation = useMutation({
     mutationFn: postUser,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['users'] })
+      void queryClient.invalidateQueries({ queryKey: ['users'] })
       setErrorText("")
       asideProps.setAsideOpen(false)
     },
@@ -49,7 +50,7 @@ function AddNewUserForm(asideProps: AsideProps) {
   const password1Error = password1 && !passwordIsValid(password1) ? "Password is not valid" : ""
   const password2Error = password2 && !passwordsMatch ? "Passwords do not match" : ""
 
-  const [errorText, setErrorText] = useState<string>("")
+  const [, setErrorText] = useState<string>("")
   const handleUsernameChange = (event: ChangeEvent<HTMLInputElement>) => { setUsername(event.target.value) }
   const handlePassword1Change = (event: ChangeEvent<HTMLInputElement>) => { setPassword1(event.target.value) }
   const handlePassword2Change = (event: ChangeEvent<HTMLInputElement>) => { setPassword2(event.target.value) }
@@ -96,7 +97,7 @@ function ChangePasswordForm(asideProps: AsideProps) {
   const mutation = useMutation({
     mutationFn: changePassword,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['users'] })
+      void queryClient.invalidateQueries({ queryKey: ['users'] })
       setErrorText("")
       asideProps.setAsideOpen(false)
     },
@@ -110,7 +111,7 @@ function ChangePasswordForm(asideProps: AsideProps) {
   const password1Error = password1 && !passwordIsValid(password1) ? "Password is not valid" : ""
   const password2Error = password2 && !passwordsMatch ? "Passwords do not match" : ""
 
-  const [errorText, setErrorText] = useState<string>("")
+  const [, setErrorText] = useState<string>("")
   const handlePassword1Change = (event: ChangeEvent<HTMLInputElement>) => { setPassword1(event.target.value) }
   const handlePassword2Change = (event: ChangeEvent<HTMLInputElement>) => { setPassword2(event.target.value) }
   return (
@@ -120,7 +121,7 @@ function ChangePasswordForm(asideProps: AsideProps) {
           id="InputUsername"
           label="Username"
           type="text"
-          value={asideProps.formData["user"]["username"]}
+          value={asideProps.formData.user?.username}
           disabled={true}
         />
         <PasswordToggle
@@ -141,7 +142,7 @@ function ChangePasswordForm(asideProps: AsideProps) {
         <Button
           appearance="positive"
           disabled={!passwordsMatch || !passwordIsValid(password1)}
-          onClick={(event) => { event.preventDefault(); mutation.mutate({ authToken: (auth.user ? auth.user.authToken : ""), id: asideProps.formData["user"]["id"], password: password1 }) }}
+          onClick={(event) => { event.preventDefault(); mutation.mutate({ authToken: (auth.user ? auth.user.authToken : ""), id: asideProps.formData.user ? asideProps.formData.user.id : "0", password: password1 }) }}
         >
           Submit
         </Button>

--- a/ui/src/app/(notary)/users/asideForm.tsx
+++ b/ui/src/app/(notary)/users/asideForm.tsx
@@ -3,12 +3,18 @@ import { passwordIsValid } from "@/utils";
 import { changePassword, postUser } from "@/queries";
 import { ChangeEvent, Dispatch, SetStateAction, useState } from "react";
 import { useAuth } from "@/hooks/useAuth";
-import { Panel, Button, Input, PasswordToggle, Form } from "@canonical/react-components";
+import {
+  Panel,
+  Button,
+  Input,
+  PasswordToggle,
+  Form,
+} from "@canonical/react-components";
 import { AsideFormData } from "@/types";
 
 type AsideProps = {
-  setAsideOpen: Dispatch<SetStateAction<boolean>>
-  formData: AsideFormData
+  setAsideOpen: Dispatch<SetStateAction<boolean>>;
+  formData: AsideFormData;
 };
 
 export default function UsersPageAsidePanel(asideProps: AsideProps) {
@@ -16,44 +22,54 @@ export default function UsersPageAsidePanel(asideProps: AsideProps) {
     <Panel
       title={asideProps.formData.formTitle}
       controls={
-        <Button
-          onClick={() => asideProps.setAsideOpen(false)}
-          hasIcon>
+        <Button onClick={() => asideProps.setAsideOpen(false)} hasIcon>
           <i className="p-icon--close" />
         </Button>
-      }>
-      {asideProps.formData.formTitle == "Add a New User" && <AddNewUserForm {...asideProps} />}
-      {asideProps.formData.formTitle == "Change User Password" && <ChangePasswordForm {...asideProps} />}
+      }
+    >
+      {asideProps.formData.formTitle == "Add a New User" && (
+        <AddNewUserForm {...asideProps} />
+      )}
+      {asideProps.formData.formTitle == "Change User Password" && (
+        <ChangePasswordForm {...asideProps} />
+      )}
     </Panel>
-  )
+  );
 }
 
-
 function AddNewUserForm(asideProps: AsideProps) {
-  const auth = useAuth()
-  const queryClient = useQueryClient()
+  const auth = useAuth();
+  const queryClient = useQueryClient();
   const mutation = useMutation({
     mutationFn: postUser,
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['users'] })
-      setErrorText("")
-      asideProps.setAsideOpen(false)
+      void queryClient.invalidateQueries({ queryKey: ["users"] });
+      setErrorText("");
+      asideProps.setAsideOpen(false);
     },
     onError: (e: Error) => {
-      setErrorText(e.message)
-    }
-  })
-  const [username, setUsername] = useState<string>("")
-  const [password1, setPassword1] = useState<string>("")
-  const [password2, setPassword2] = useState<string>("")
-  const passwordsMatch = password1 === password2
-  const password1Error = password1 && !passwordIsValid(password1) ? "Password is not valid" : ""
-  const password2Error = password2 && !passwordsMatch ? "Passwords do not match" : ""
+      setErrorText(e.message);
+    },
+  });
+  const [username, setUsername] = useState<string>("");
+  const [password1, setPassword1] = useState<string>("");
+  const [password2, setPassword2] = useState<string>("");
+  const passwordsMatch = password1 === password2;
+  const password1Error =
+    password1 && !passwordIsValid(password1) ? "Password is not valid" : "";
+  const password2Error =
+    password2 && !passwordsMatch ? "Passwords do not match" : "";
 
-  const [, setErrorText] = useState<string>("")
-  const handleUsernameChange = (event: ChangeEvent<HTMLInputElement>) => { setUsername(event.target.value) }
-  const handlePassword1Change = (event: ChangeEvent<HTMLInputElement>) => { setPassword1(event.target.value) }
-  const handlePassword2Change = (event: ChangeEvent<HTMLInputElement>) => { setPassword2(event.target.value) }
+  const [, setErrorText] = useState<string>("");
+  const handleUsernameChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setUsername(event.target.value);
+  };
+  const handlePassword1Change = (event: ChangeEvent<HTMLInputElement>) => {
+    setPassword1(event.target.value);
+  };
+  const handlePassword2Change = (event: ChangeEvent<HTMLInputElement>) => {
+    setPassword2(event.target.value);
+  };
   return (
     <Form>
       <div className="p-form__group row">
@@ -82,38 +98,51 @@ function AddNewUserForm(asideProps: AsideProps) {
         <Button
           appearance="positive"
           disabled={!passwordsMatch || !passwordIsValid(password1)}
-          onClick={(event) => { event.preventDefault(); mutation.mutate({ authToken: (auth.user ? auth.user.authToken : ""), username: username, password: password1 }) }}
+          onClick={(event) => {
+            event.preventDefault();
+            mutation.mutate({
+              authToken: auth.user ? auth.user.authToken : "",
+              username: username,
+              password: password1,
+            });
+          }}
         >
           Submit
         </Button>
       </div>
     </Form>
-  )
+  );
 }
 
 function ChangePasswordForm(asideProps: AsideProps) {
-  const auth = useAuth()
-  const queryClient = useQueryClient()
+  const auth = useAuth();
+  const queryClient = useQueryClient();
   const mutation = useMutation({
     mutationFn: changePassword,
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['users'] })
-      setErrorText("")
-      asideProps.setAsideOpen(false)
+      void queryClient.invalidateQueries({ queryKey: ["users"] });
+      setErrorText("");
+      asideProps.setAsideOpen(false);
     },
     onError: (e: Error) => {
-      setErrorText(e.message)
-    }
-  })
-  const [password1, setPassword1] = useState<string>("")
-  const [password2, setPassword2] = useState<string>("")
-  const passwordsMatch = password1 === password2
-  const password1Error = password1 && !passwordIsValid(password1) ? "Password is not valid" : ""
-  const password2Error = password2 && !passwordsMatch ? "Passwords do not match" : ""
+      setErrorText(e.message);
+    },
+  });
+  const [password1, setPassword1] = useState<string>("");
+  const [password2, setPassword2] = useState<string>("");
+  const passwordsMatch = password1 === password2;
+  const password1Error =
+    password1 && !passwordIsValid(password1) ? "Password is not valid" : "";
+  const password2Error =
+    password2 && !passwordsMatch ? "Passwords do not match" : "";
 
-  const [, setErrorText] = useState<string>("")
-  const handlePassword1Change = (event: ChangeEvent<HTMLInputElement>) => { setPassword1(event.target.value) }
-  const handlePassword2Change = (event: ChangeEvent<HTMLInputElement>) => { setPassword2(event.target.value) }
+  const [, setErrorText] = useState<string>("");
+  const handlePassword1Change = (event: ChangeEvent<HTMLInputElement>) => {
+    setPassword1(event.target.value);
+  };
+  const handlePassword2Change = (event: ChangeEvent<HTMLInputElement>) => {
+    setPassword2(event.target.value);
+  };
   return (
     <Form>
       <div className="p-form__group row">
@@ -142,11 +171,18 @@ function ChangePasswordForm(asideProps: AsideProps) {
         <Button
           appearance="positive"
           disabled={!passwordsMatch || !passwordIsValid(password1)}
-          onClick={(event) => { event.preventDefault(); mutation.mutate({ authToken: (auth.user ? auth.user.authToken : ""), id: asideProps.formData.user ? asideProps.formData.user.id : "0", password: password1 }) }}
+          onClick={(event) => {
+            event.preventDefault();
+            mutation.mutate({
+              authToken: auth.user ? auth.user.authToken : "",
+              id: asideProps.formData.user ? asideProps.formData.user.id : "0",
+              password: password1,
+            });
+          }}
         >
           Submit
         </Button>
       </div>
     </Form>
-  )
+  );
 }

--- a/ui/src/app/(notary)/users/components.tsx
+++ b/ui/src/app/(notary)/users/components.tsx
@@ -48,7 +48,7 @@ export function ChangePasswordModal({ id, username, setChangePasswordModalVisibl
     const mutation = useMutation({
         mutationFn: changePassword,
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['users'] })
+            void queryClient.invalidateQueries({ queryKey: ['users'] })
             setErrorText("")
         },
         onError: (e: Error) => {
@@ -61,7 +61,7 @@ export function ChangePasswordModal({ id, username, setChangePasswordModalVisibl
     const password1Error = password1 && !passwordIsValid(password1) ? "Password is not valid" : ""
     const password2Error = password2 && !passwordsMatch ? "Passwords do not match" : ""
 
-    const [errorText, setErrorText] = useState<string>("")
+    const [, setErrorText] = useState<string>("")
     const handlePassword1Change = (event: ChangeEvent<HTMLInputElement>) => { setPassword1(event.target.value) }
     const handlePassword2Change = (event: ChangeEvent<HTMLInputElement>) => { setPassword2(event.target.value) }
     return (

--- a/ui/src/app/(notary)/users/components.tsx
+++ b/ui/src/app/(notary)/users/components.tsx
@@ -1,108 +1,155 @@
-import { Dispatch, SetStateAction, useState, ChangeEvent, createContext } from "react"
-import { useAuth } from "@/hooks/useAuth"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { changePassword } from "@/queries"
-import { passwordIsValid } from "@/utils"
-import { ConfirmationModal, Modal, Button, Input, PasswordToggle, Form } from "@canonical/react-components";
+import {
+  Dispatch,
+  SetStateAction,
+  useState,
+  ChangeEvent,
+  createContext,
+} from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { changePassword } from "@/queries";
+import { passwordIsValid } from "@/utils";
+import {
+  ConfirmationModal,
+  Modal,
+  Button,
+  Input,
+  PasswordToggle,
+  Form,
+} from "@canonical/react-components";
 
 export type ConfirmationModalData = {
-    onMouseDownFunc: () => void
-    warningText: string
-} | null
+  onMouseDownFunc: () => void;
+  warningText: string;
+} | null;
 
 interface ConfirmationModalProps {
-    modalData: ConfirmationModalData
-    setModalData: Dispatch<SetStateAction<ConfirmationModalData>>
+  modalData: ConfirmationModalData;
+  setModalData: Dispatch<SetStateAction<ConfirmationModalData>>;
 }
 
 export type ChangePasswordModalData = {
-    id: string
-    username: string
-} | null
+  id: string;
+  username: string;
+} | null;
 
 interface ChangePasswordModalProps {
-    modalData: ChangePasswordModalData
-    setModalData: Dispatch<SetStateAction<ChangePasswordModalData>>
+  modalData: ChangePasswordModalData;
+  setModalData: Dispatch<SetStateAction<ChangePasswordModalData>>;
 }
 
-export const ChangePasswordModalContext = createContext<ChangePasswordModalProps>({
+export const ChangePasswordModalContext =
+  createContext<ChangePasswordModalProps>({
     modalData: null,
-    setModalData: () => { }
-})
+    setModalData: () => {},
+  });
 
-export function UsersConfirmationModal({ modalData, setModalData }: ConfirmationModalProps) {
-    const confirmQuery = () => {
-        modalData?.onMouseDownFunc()
-        setModalData(null)
-    }
-    return (
-        <ConfirmationModal title="Confirm Action" confirmButtonLabel="Delete" onConfirm={confirmQuery} close={() => setModalData(null)}>
-            <p>{modalData?.warningText}</p>
-        </ConfirmationModal>
-    )
+export function UsersConfirmationModal({
+  modalData,
+  setModalData,
+}: ConfirmationModalProps) {
+  const confirmQuery = () => {
+    modalData?.onMouseDownFunc();
+    setModalData(null);
+  };
+  return (
+    <ConfirmationModal
+      title="Confirm Action"
+      confirmButtonLabel="Delete"
+      onConfirm={confirmQuery}
+      close={() => setModalData(null)}
+    >
+      <p>{modalData?.warningText}</p>
+    </ConfirmationModal>
+  );
 }
 
-export function ChangePasswordModal({ id, username, setChangePasswordModalVisible }: { id: string, username: string, setChangePasswordModalVisible: Dispatch<SetStateAction<boolean>> }) {
-    const auth = useAuth()
-    const queryClient = useQueryClient()
-    const mutation = useMutation({
-        mutationFn: changePassword,
-        onSuccess: () => {
-            void queryClient.invalidateQueries({ queryKey: ['users'] })
-            setErrorText("")
-        },
-        onError: (e: Error) => {
-            setErrorText(e.message)
-        }
-    })
-    const [password1, setPassword1] = useState<string>("")
-    const [password2, setPassword2] = useState<string>("")
-    const passwordsMatch = password1 === password2
-    const password1Error = password1 && !passwordIsValid(password1) ? "Password is not valid" : ""
-    const password2Error = password2 && !passwordsMatch ? "Passwords do not match" : ""
+export function ChangePasswordModal({
+  id,
+  username,
+  setChangePasswordModalVisible,
+}: {
+  id: string;
+  username: string;
+  setChangePasswordModalVisible: Dispatch<SetStateAction<boolean>>;
+}) {
+  const auth = useAuth();
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: changePassword,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["users"] });
+      setErrorText("");
+    },
+    onError: (e: Error) => {
+      setErrorText(e.message);
+    },
+  });
+  const [password1, setPassword1] = useState<string>("");
+  const [password2, setPassword2] = useState<string>("");
+  const passwordsMatch = password1 === password2;
+  const password1Error =
+    password1 && !passwordIsValid(password1) ? "Password is not valid" : "";
+  const password2Error =
+    password2 && !passwordsMatch ? "Passwords do not match" : "";
 
-    const [, setErrorText] = useState<string>("")
-    const handlePassword1Change = (event: ChangeEvent<HTMLInputElement>) => { setPassword1(event.target.value) }
-    const handlePassword2Change = (event: ChangeEvent<HTMLInputElement>) => { setPassword2(event.target.value) }
-    return (
-        <Modal
-            title="Change Password"
-            buttonRow={<>
-                <Button onClick={() => setChangePasswordModalVisible(false)}>
-                    Cancel
-                </Button>
-                <Button
-                    appearance="positive"
-                    disabled={!passwordsMatch || !passwordIsValid(password1)}
-                    onClick={(event) => { event.preventDefault(); mutation.mutate({ authToken: (auth.user ? auth.user.authToken : ""), id: id, password: password1 }) }}>
-                    Submit
-                </Button>
-            </>}>
-            <Form>
-                <Input
-                    id="InputUsername"
-                    label="Username"
-                    type="text"
-                    required={true}
-                    disabled={true}
-                    value={username}
-                />
-                <PasswordToggle
-                    help="Password must have 8 or more characters, must include at least one capital letter, one lowercase letter, and either a number or a symbol."
-                    id="password1"
-                    label="New Password"
-                    required={true}
-                    onChange={handlePassword1Change}
-                    error={password1Error}
-                />
-                <PasswordToggle
-                    id="password2"
-                    label="Confirm New Password"
-                    required={true}
-                    onChange={handlePassword2Change}
-                    error={password2Error}
-                />
-            </Form>
-        </Modal >
-    )
+  const [, setErrorText] = useState<string>("");
+  const handlePassword1Change = (event: ChangeEvent<HTMLInputElement>) => {
+    setPassword1(event.target.value);
+  };
+  const handlePassword2Change = (event: ChangeEvent<HTMLInputElement>) => {
+    setPassword2(event.target.value);
+  };
+  return (
+    <Modal
+      title="Change Password"
+      buttonRow={
+        <>
+          <Button onClick={() => setChangePasswordModalVisible(false)}>
+            Cancel
+          </Button>
+          <Button
+            appearance="positive"
+            disabled={!passwordsMatch || !passwordIsValid(password1)}
+            onClick={(event) => {
+              event.preventDefault();
+              mutation.mutate({
+                authToken: auth.user ? auth.user.authToken : "",
+                id: id,
+                password: password1,
+              });
+            }}
+          >
+            Submit
+          </Button>
+        </>
+      }
+    >
+      <Form>
+        <Input
+          id="InputUsername"
+          label="Username"
+          type="text"
+          required={true}
+          disabled={true}
+          value={username}
+        />
+        <PasswordToggle
+          help="Password must have 8 or more characters, must include at least one capital letter, one lowercase letter, and either a number or a symbol."
+          id="password1"
+          label="New Password"
+          required={true}
+          onChange={handlePassword1Change}
+          error={password1Error}
+        />
+        <PasswordToggle
+          id="password2"
+          label="Confirm New Password"
+          required={true}
+          onChange={handlePassword2Change}
+          error={password2Error}
+        />
+      </Form>
+    </Modal>
+  );
 }

--- a/ui/src/app/(notary)/users/page.tsx
+++ b/ui/src/app/(notary)/users/page.tsx
@@ -29,8 +29,8 @@ export default function Users() {
   }
   const query = useQuery<UserEntry[], Error>({
     queryKey: ["users", cookies.user_token],
-    // eslint-disable-next-line
     queryFn: () =>
+      // eslint-disable-next-line
       ListUsers({ authToken: cookies.user_token ? cookies.user_token : "" }),
     retry: retryUnlessUnauthorized,
   });

--- a/ui/src/app/(notary)/users/page.tsx
+++ b/ui/src/app/(notary)/users/page.tsx
@@ -1,44 +1,49 @@
-"use client"
+"use client";
 
-import { useQuery } from "@tanstack/react-query"
-import { ListUsers } from "@/queries"
-import { AsideFormData, UserEntry } from "@/types"
-import { useCookies } from "react-cookie"
-import { useRouter } from "next/navigation"
-import { UsersTable } from "./table"
-import Loading from "@/components/loading"
-import Error from "@/components/error"
-import { retryUnlessUnauthorized } from "@/utils"
-import { AppMain } from "@canonical/react-components"
-import { AppAside } from "@canonical/react-components"
-import NotaryAppNavigationBars from "@/components/NotaryAppNavigationBars"
-import { Application } from "@canonical/react-components"
-import NotaryAppStatus from "@/components/NotaryAppStatus"
-import { useState } from "react"
-import UsersPageAsidePanel from "./asideForm"
+import { useQuery } from "@tanstack/react-query";
+import { ListUsers } from "@/queries";
+import { AsideFormData, UserEntry } from "@/types";
+import { useCookies } from "react-cookie";
+import { useRouter } from "next/navigation";
+import { UsersTable } from "./table";
+import Loading from "@/components/loading";
+import Error from "@/components/error";
+import { retryUnlessUnauthorized } from "@/utils";
+import { AppMain } from "@canonical/react-components";
+import { AppAside } from "@canonical/react-components";
+import NotaryAppNavigationBars from "@/components/NotaryAppNavigationBars";
+import { Application } from "@canonical/react-components";
+import NotaryAppStatus from "@/components/NotaryAppStatus";
+import { useState } from "react";
+import UsersPageAsidePanel from "./asideForm";
 
 export default function Users() {
-  const router = useRouter()
-  const [asideOpen, setAsideOpen] = useState<boolean>(false)
-  const [formData, setFormData] = useState<AsideFormData>({ formTitle: "Add a New User" })
-  const [cookies, , removeCookie] = useCookies(['user_token']);
+  const router = useRouter();
+  const [asideOpen, setAsideOpen] = useState<boolean>(false);
+  const [formData, setFormData] = useState<AsideFormData>({
+    formTitle: "Add a New User",
+  });
+  const [cookies, , removeCookie] = useCookies(["user_token"]);
   if (!cookies.user_token) {
-    router.push("/login")
+    router.push("/login");
   }
   const query = useQuery<UserEntry[], Error>({
-    queryKey: ['users', cookies.user_token],
+    queryKey: ["users", cookies.user_token],
     // eslint-disable-next-line
-    queryFn: () => ListUsers({ authToken: cookies.user_token ? cookies.user_token : "" }),
+    queryFn: () =>
+      ListUsers({ authToken: cookies.user_token ? cookies.user_token : "" }),
     retry: retryUnlessUnauthorized,
-  })
-  if (query.status == "pending") { return <Loading /> }
+  });
+  if (query.status == "pending") {
+    return <Loading />;
+  }
   if (query.status == "error") {
     if (query.error.message.includes("401")) {
-      removeCookie("user_token")
+      removeCookie("user_token");
     }
-    return <Error msg={query.error.message} />
+    return <Error msg={query.error.message} />;
   }
-  const users = Array.from(query.data ? query.data : [])
+  const users = Array.from(query.data ? query.data : []);
   return (
     <Application>
       <NotaryAppNavigationBars />
@@ -46,9 +51,13 @@ export default function Users() {
         <UsersPageAsidePanel setAsideOpen={setAsideOpen} formData={formData} />
       </AppAside>
       <AppMain>
-        <UsersTable users={users} setAsideOpen={setAsideOpen} setFormData={setFormData} />
+        <UsersTable
+          users={users}
+          setAsideOpen={setAsideOpen}
+          setFormData={setFormData}
+        />
       </AppMain>
       <NotaryAppStatus />
     </Application>
-  )
+  );
 }

--- a/ui/src/app/(notary)/users/page.tsx
+++ b/ui/src/app/(notary)/users/page.tsx
@@ -20,14 +20,15 @@ import UsersPageAsidePanel from "./asideForm"
 export default function Users() {
   const router = useRouter()
   const [asideOpen, setAsideOpen] = useState<boolean>(false)
-  const [formData, setFormData] = useState<AsideFormData>({ formTitle: "Add a New User", formData: null })
-  const [cookies, setCookie, removeCookie] = useCookies(['user_token']);
+  const [formData, setFormData] = useState<AsideFormData>({ formTitle: "Add a New User" })
+  const [cookies, , removeCookie] = useCookies(['user_token']);
   if (!cookies.user_token) {
     router.push("/login")
   }
   const query = useQuery<UserEntry[], Error>({
     queryKey: ['users', cookies.user_token],
-    queryFn: () => ListUsers({ authToken: cookies.user_token }),
+    // eslint-disable-next-line
+    queryFn: () => ListUsers({ authToken: cookies.user_token ? cookies.user_token : "" }),
     retry: retryUnlessUnauthorized,
   })
   if (query.status == "pending") { return <Loading /> }

--- a/ui/src/app/(notary)/users/table.tsx
+++ b/ui/src/app/(notary)/users/table.tsx
@@ -1,102 +1,136 @@
-import { useState, Dispatch, SetStateAction } from "react"
-import { AsideFormData, UserEntry } from "@/types"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { Button, ContextualMenu, MainTable, Panel } from "@canonical/react-components";
-import { ConfirmationModalData, UsersConfirmationModal, ChangePasswordModalData, ChangePasswordModal } from "./components"
-import { useAuth } from "@/hooks/useAuth"
-import { deleteUser } from "@/queries"
+import { useState, Dispatch, SetStateAction } from "react";
+import { AsideFormData, UserEntry } from "@/types";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Button,
+  ContextualMenu,
+  MainTable,
+  Panel,
+} from "@canonical/react-components";
+import {
+  ConfirmationModalData,
+  UsersConfirmationModal,
+  ChangePasswordModalData,
+  ChangePasswordModal,
+} from "./components";
+import { useAuth } from "@/hooks/useAuth";
+import { deleteUser } from "@/queries";
 
 type TableProps = {
-    users: UserEntry[]
-    setAsideOpen: Dispatch<SetStateAction<boolean>>
-    setFormData: Dispatch<SetStateAction<AsideFormData>>
-}
+  users: UserEntry[];
+  setAsideOpen: Dispatch<SetStateAction<boolean>>;
+  setFormData: Dispatch<SetStateAction<AsideFormData>>;
+};
 
 export function UsersTable({ users, setAsideOpen, setFormData }: TableProps) {
-    const auth = useAuth()
-    const [confirmationModalData, setConfirmationModalData] = useState<ConfirmationModalData>(null)
-    const [changePasswordModalData, setChangePasswordModalData] = useState<ChangePasswordModalData>(null)
-    const queryClient = useQueryClient()
-    const deleteMutation = useMutation({
-        mutationFn: deleteUser,
-        onSuccess: () => queryClient.invalidateQueries({ queryKey: ['users'] })
-    })
-    const handleDelete = (id: string, username: string) => {
-        setConfirmationModalData({
-            warningText: `Deleting user: "${username}". This action cannot be undone.`,
-            onMouseDownFunc: () => {
-                const authToken = auth.user ? auth.user.authToken : "";
-                deleteMutation.mutate({ id: id, authToken });
-            }
-        });
-    };
-    const handleChangePassword = (id: string, username: string) => {
-        setChangePasswordModalData({ "id": id, "username": username })
-    }
+  const auth = useAuth();
+  const [confirmationModalData, setConfirmationModalData] =
+    useState<ConfirmationModalData>(null);
+  const [changePasswordModalData, setChangePasswordModalData] =
+    useState<ChangePasswordModalData>(null);
+  const queryClient = useQueryClient();
+  const deleteMutation = useMutation({
+    mutationFn: deleteUser,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["users"] }),
+  });
+  const handleDelete = (id: string, username: string) => {
+    setConfirmationModalData({
+      warningText: `Deleting user: "${username}". This action cannot be undone.`,
+      onMouseDownFunc: () => {
+        const authToken = auth.user ? auth.user.authToken : "";
+        deleteMutation.mutate({ id: id, authToken });
+      },
+    });
+  };
+  const handleChangePassword = (id: string, username: string) => {
+    setChangePasswordModalData({ id: id, username: username });
+  };
 
-    return (
-        <Panel
-            stickyHeader
-            title="Users"
-            className="u-fixed-width"
-            controls={users.length > 0 &&
-                <Button appearance="positive" onClick={() => { setFormData({ formTitle: "Add a New User" }); setAsideOpen(true) }}>Create New User</Button>
-            }
-        >
-            <div >
-                <MainTable
-                    headers={[{
-                        content: "ID"
-                    }, {
-                        content: "Username"
-                    }, {
-                        content: "Actions",
-                        className: "u-align--right has-overflow"
-                    }]}
-                    rows={users.map(user => ({
-                        columns: [
-                            {
-                                content: user.id.toString(),
-                            },
-                            {
-                                content: user.username,
-                            },
-                            {
-                                content: (
-                                    <ContextualMenu
-                                        links={[{
-                                            children: "Delete User",
-                                            disabled: user.id === 1,
-                                            onClick: () => handleDelete(user.id.toString(), user.username)
-                                        }, {
-                                            children: "Change Password",
-                                            onClick: () => handleChangePassword(user.id.toString(), user.username)
-                                        }]}
-                                        hasToggleIcon
-                                        position="right"
-                                        style={{ height: "40px" }}
-                                    />
-                                ),
-                                className: "u-align--right",
-                                hasOverflow: true
-                            }
-                        ]
-                    }))}
-                />
-            </div>
-            {confirmationModalData && (
-                <UsersConfirmationModal
-                    modalData={confirmationModalData}
-                    setModalData={setConfirmationModalData}
-                />
-            )}
-            {changePasswordModalData && (
-                <ChangePasswordModal
-                    id={changePasswordModalData.id}
-                    username={changePasswordModalData.username}
-                    setChangePasswordModalVisible={() => setChangePasswordModalData(null)}
-                />
-            )}
-        </Panel>
-    )
+  return (
+    <Panel
+      stickyHeader
+      title="Users"
+      className="u-fixed-width"
+      controls={
+        users.length > 0 && (
+          <Button
+            appearance="positive"
+            onClick={() => {
+              setFormData({ formTitle: "Add a New User" });
+              setAsideOpen(true);
+            }}
+          >
+            Create New User
+          </Button>
+        )
+      }
+    >
+      <div>
+        <MainTable
+          headers={[
+            {
+              content: "ID",
+            },
+            {
+              content: "Username",
+            },
+            {
+              content: "Actions",
+              className: "u-align--right has-overflow",
+            },
+          ]}
+          rows={users.map((user) => ({
+            columns: [
+              {
+                content: user.id.toString(),
+              },
+              {
+                content: user.username,
+              },
+              {
+                content: (
+                  <ContextualMenu
+                    links={[
+                      {
+                        children: "Delete User",
+                        disabled: user.id === 1,
+                        onClick: () =>
+                          handleDelete(user.id.toString(), user.username),
+                      },
+                      {
+                        children: "Change Password",
+                        onClick: () =>
+                          handleChangePassword(
+                            user.id.toString(),
+                            user.username,
+                          ),
+                      },
+                    ]}
+                    hasToggleIcon
+                    position="right"
+                    style={{ height: "40px" }}
+                  />
+                ),
+                className: "u-align--right",
+                hasOverflow: true,
+              },
+            ],
+          }))}
+        />
+      </div>
+      {confirmationModalData && (
+        <UsersConfirmationModal
+          modalData={confirmationModalData}
+          setModalData={setConfirmationModalData}
+        />
+      )}
+      {changePasswordModalData && (
+        <ChangePasswordModal
+          id={changePasswordModalData.id}
+          username={changePasswordModalData.username}
+          setChangePasswordModalVisible={() => setChangePasswordModalData(null)}
+        />
+      )}
+    </Panel>
+  );
 }

--- a/ui/src/app/(notary)/users/table.tsx
+++ b/ui/src/app/(notary)/users/table.tsx
@@ -40,7 +40,7 @@ export function UsersTable({ users, setAsideOpen, setFormData }: TableProps) {
             title="Users"
             className="u-fixed-width"
             controls={users.length > 0 &&
-                <Button appearance="positive" onClick={() => { setFormData({ formTitle: "Add a New User", formData: null }); setAsideOpen(true) }}>Create New User</Button>
+                <Button appearance="positive" onClick={() => { setFormData({ formTitle: "Add a New User" }); setAsideOpen(true) }}>Create New User</Button>
             }
         >
             <div >

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import '@/globals.scss'
+import "@/globals.scss";
 
 export const metadata: Metadata = {
   title: "Notary",

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -1,7 +1,7 @@
-"use client"
-import { useRouter } from "next/navigation"
+"use client";
+import { useRouter } from "next/navigation";
 
 export default function FrontPage() {
-    const router = useRouter()
-    router.push("/certificate_requests")
+  const router = useRouter();
+  router.push("/certificate_requests");
 }

--- a/ui/src/components/NotaryAppNavigationBars.tsx
+++ b/ui/src/components/NotaryAppNavigationBars.tsx
@@ -1,12 +1,12 @@
 "use client"
 
-import { SetStateAction, Dispatch, useState, useContext } from "react"
+import { SetStateAction, Dispatch, useState } from "react"
 import Image from "next/image";
 import { useAuth } from "@/hooks/useAuth";
 import { usePathname } from "next/navigation";
 import { AppNavigation } from "@canonical/react-components";
 import { AppNavigationBar } from "@canonical/react-components";
-import { ChangePasswordModal, ChangePasswordModalContext, ChangePasswordModalData } from "@/app/(notary)/users/components";
+import { ChangePasswordModal } from "@/app/(notary)/users/components";
 import { useCookies } from "react-cookie";
 
 type SidebarProps = {
@@ -18,7 +18,7 @@ type SidebarProps = {
 export function SideBar({ sidebarVisible, setSidebarVisible, setChangePasswordModalVisible }: SidebarProps) {
   const auth = useAuth()
   const path = usePathname()
-  const [cookies, setCookie, removeCookie] = useCookies(['user_token']);
+  const [, , removeCookie] = useCookies(['user_token']);
   const [menuOpen, setMenuOpen] = useState<boolean>(false)
 
   return (

--- a/ui/src/components/NotaryAppNavigationBars.tsx
+++ b/ui/src/components/NotaryAppNavigationBars.tsx
@@ -1,6 +1,6 @@
-"use client"
+"use client";
 
-import { SetStateAction, Dispatch, useState } from "react"
+import { SetStateAction, Dispatch, useState } from "react";
 import Image from "next/image";
 import { useAuth } from "@/hooks/useAuth";
 import { usePathname } from "next/navigation";
@@ -10,26 +10,46 @@ import { ChangePasswordModal } from "@/app/(notary)/users/components";
 import { useCookies } from "react-cookie";
 
 type SidebarProps = {
-  sidebarVisible: boolean,
-  setSidebarVisible: Dispatch<SetStateAction<boolean>>,
-  setChangePasswordModalVisible: Dispatch<SetStateAction<boolean>>
-}
+  sidebarVisible: boolean;
+  setSidebarVisible: Dispatch<SetStateAction<boolean>>;
+  setChangePasswordModalVisible: Dispatch<SetStateAction<boolean>>;
+};
 
-export function SideBar({ sidebarVisible, setSidebarVisible, setChangePasswordModalVisible }: SidebarProps) {
-  const auth = useAuth()
-  const path = usePathname()
-  const [, , removeCookie] = useCookies(['user_token']);
-  const [menuOpen, setMenuOpen] = useState<boolean>(false)
+export function SideBar({
+  sidebarVisible,
+  setSidebarVisible,
+  setChangePasswordModalVisible,
+}: SidebarProps) {
+  const auth = useAuth();
+  const path = usePathname();
+  const [, , removeCookie] = useCookies(["user_token"]);
+  const [menuOpen, setMenuOpen] = useState<boolean>(false);
 
   return (
-    <header className={sidebarVisible ? "l-navigation" : "l-navigation is-collapsed"} >
+    <header
+      className={sidebarVisible ? "l-navigation" : "l-navigation is-collapsed"}
+    >
       <div className="l-navigation__drawer">
         <div className="p-panel is-dark">
           <div className="p-panel__header is-sticky">
             <Logo />
             <div className="p-panel__controls u-hide--large">
-              <button onClick={() => { setSidebarVisible(false) }} className="p-button--base is-dark has-icon u-no-margin u-hide--medium"><i className="is-light p-icon--close"></i></button>
-              <button onClick={() => { setSidebarVisible(false) }} className="p-button--base is-dark has-icon u-no-margin u-hide--small"><i className="is-light p-icon--pin"></i></button>
+              <button
+                onClick={() => {
+                  setSidebarVisible(false);
+                }}
+                className="p-button--base is-dark has-icon u-no-margin u-hide--medium"
+              >
+                <i className="is-light p-icon--close"></i>
+              </button>
+              <button
+                onClick={() => {
+                  setSidebarVisible(false);
+                }}
+                className="p-button--base is-dark has-icon u-no-margin u-hide--small"
+              >
+                <i className="is-light p-icon--pin"></i>
+              </button>
             </div>
           </div>
           <div className="p-panel__content">
@@ -37,62 +57,129 @@ export function SideBar({ sidebarVisible, setSidebarVisible, setChangePasswordMo
               <nav aria-label="Main">
                 <ul className="p-side-navigation__list">
                   <li className="p-side-navigation__item">
-                    <a className="p-side-navigation__link" href="/certificate_requests" aria-current={path.startsWith("/certificate_requests") ? "page" : "false"} style={{ cursor: "pointer" }}>
+                    <a
+                      className="p-side-navigation__link"
+                      href="/certificate_requests"
+                      aria-current={
+                        path.startsWith("/certificate_requests")
+                          ? "page"
+                          : "false"
+                      }
+                      style={{ cursor: "pointer" }}
+                    >
                       <i className="p-icon--security is-light p-side-navigation__icon"></i>
                       <span className="p-side-navigation__label">
-                        <span className="p-side-navigation__label">Certificate Requests</span>
+                        <span className="p-side-navigation__label">
+                          Certificate Requests
+                        </span>
                       </span>
                     </a>
                   </li>
-                  {auth.user?.permissions == 1 &&
+                  {auth.user?.permissions == 1 && (
                     <li className="p-side-navigation__item">
-                      <a className="p-side-navigation__link" href="/certificate_authorities" aria-current={path.startsWith("/certificate_authorities") ? "page" : "false"} style={{ cursor: "pointer" }}>
+                      <a
+                        className="p-side-navigation__link"
+                        href="/certificate_authorities"
+                        aria-current={
+                          path.startsWith("/certificate_authorities")
+                            ? "page"
+                            : "false"
+                        }
+                        style={{ cursor: "pointer" }}
+                      >
                         <i className="p-icon--copy-to-clipboard is-light p-side-navigation__icon"></i>
                         <span className="p-side-navigation__label">
-                          <span className="p-side-navigation__label">Certificate Authorities</span>
+                          <span className="p-side-navigation__label">
+                            Certificate Authorities
+                          </span>
                         </span>
                       </a>
                     </li>
-                  }
-                  {auth.user?.permissions == 1 &&
+                  )}
+                  {auth.user?.permissions == 1 && (
                     <li className="p-side-navigation__item">
-                      <a className="p-side-navigation__link" href="/users" aria-current={path.startsWith("/users") ? "page" : "false"} style={{ cursor: "pointer" }}>
+                      <a
+                        className="p-side-navigation__link"
+                        href="/users"
+                        aria-current={
+                          path.startsWith("/users") ? "page" : "false"
+                        }
+                        style={{ cursor: "pointer" }}
+                      >
                         <i className="p-icon--user is-light p-side-navigation__icon"></i>
                         <span className="p-side-navigation__label">
-                          <span className="p-side-navigation__label">Users</span>
+                          <span className="p-side-navigation__label">
+                            Users
+                          </span>
                         </span>
                       </a>
                     </li>
-                  }
+                  )}
                 </ul>
-                <ul className="p-side-navigation__list" style={{ bottom: "64px", position: "absolute", width: "100%" }}>
-                  <li className="p-side-navigation__item" >
+                <ul
+                  className="p-side-navigation__list"
+                  style={{
+                    bottom: "64px",
+                    position: "absolute",
+                    width: "100%",
+                  }}
+                >
+                  <li className="p-side-navigation__item">
                     <>
-                      {
-                        auth.user ?
-                          <div className="p-side-navigation__link p-contextual-menu__toggle" onClick={() => setMenuOpen(!menuOpen)} aria-current={menuOpen} style={{ cursor: "pointer" }}>
-                            <i className="p-icon--user is-light p-side-navigation__icon"></i>
+                      {auth.user ? (
+                        <div
+                          className="p-side-navigation__link p-contextual-menu__toggle"
+                          onClick={() => setMenuOpen(!menuOpen)}
+                          aria-current={menuOpen}
+                          style={{ cursor: "pointer" }}
+                        >
+                          <i className="p-icon--user is-light p-side-navigation__icon"></i>
+                          <span className="p-side-navigation__label">
                             <span className="p-side-navigation__label">
-                              <span className="p-side-navigation__label">{auth.user.username}</span>
+                              {auth.user.username}
                             </span>
-                            <div className="p-side-navigation__status">
-                              <i className="p-icon--menu"></i>
-                              <span className="p-contextual-menu__dropdown" id="menu-3" aria-hidden={!menuOpen} style={{ bottom: "40px" }}>
-                                <span className="p-contextual-menu__group">
-                                  <button className="p-contextual-menu__link" onMouseDown={() => setChangePasswordModalVisible(true)}>Change Password</button>
-                                  <button className="p-contextual-menu__link" onMouseDown={() => removeCookie("user_token")}>Log Out</button>
-                                </span>
+                          </span>
+                          <div className="p-side-navigation__status">
+                            <i className="p-icon--menu"></i>
+                            <span
+                              className="p-contextual-menu__dropdown"
+                              id="menu-3"
+                              aria-hidden={!menuOpen}
+                              style={{ bottom: "40px" }}
+                            >
+                              <span className="p-contextual-menu__group">
+                                <button
+                                  className="p-contextual-menu__link"
+                                  onMouseDown={() =>
+                                    setChangePasswordModalVisible(true)
+                                  }
+                                >
+                                  Change Password
+                                </button>
+                                <button
+                                  className="p-contextual-menu__link"
+                                  onMouseDown={() => removeCookie("user_token")}
+                                >
+                                  Log Out
+                                </button>
                               </span>
-                            </div>
-                          </div>
-                          :
-                          <a className="p-side-navigation__link" href="/login" aria-current="false">
-                            <i className="p-icon--user is-light p-side-navigation__icon"></i>
-                            <span className="p-side-navigation__label">
-                              <span className="p-side-navigation__label">Login</span>
                             </span>
-                          </a>
-                      }
+                          </div>
+                        </div>
+                      ) : (
+                        <a
+                          className="p-side-navigation__link"
+                          href="/login"
+                          aria-current="false"
+                        >
+                          <i className="p-icon--user is-light p-side-navigation__icon"></i>
+                          <span className="p-side-navigation__label">
+                            <span className="p-side-navigation__label">
+                              Login
+                            </span>
+                          </span>
+                        </a>
+                      )}
                     </>
                   </li>
                 </ul>
@@ -101,23 +188,34 @@ export function SideBar({ sidebarVisible, setSidebarVisible, setChangePasswordMo
           </div>
         </div>
       </div>
-    </header >
-  )
+    </header>
+  );
 }
 
-export function TopBar({ setSidebarVisible }: { setSidebarVisible: Dispatch<SetStateAction<boolean>> }) {
+export function TopBar({
+  setSidebarVisible,
+}: {
+  setSidebarVisible: Dispatch<SetStateAction<boolean>>;
+}) {
   return (
     <div className="l-navigation-bar">
       <div className="p-panel is-dark">
         <div className="p-panel__header">
           <Logo />
           <div className="p-panel__controls">
-            <span className="p-panel__toggle" onClick={() => { setSidebarVisible(true) }}>Menu</span>
+            <span
+              className="p-panel__toggle"
+              onClick={() => {
+                setSidebarVisible(true);
+              }}
+            >
+              Menu
+            </span>
           </div>
         </div>
       </div>
     </div>
-  )
+  );
 }
 
 export function Logo() {
@@ -134,22 +232,33 @@ export function Logo() {
       </div>
       <span className="logo-text p-heading--4">Notary</span>
     </div>
-  )
+  );
 }
 
 export default function NotaryAppNavigationBars() {
-  const auth = useAuth()
-  const [sidebarVisible, setSidebarVisible] = useState<boolean>(true)
-  const [changePasswordModalVisible, setChangePasswordModalVisible] = useState<boolean>(false)
+  const auth = useAuth();
+  const [sidebarVisible, setSidebarVisible] = useState<boolean>(true);
+  const [changePasswordModalVisible, setChangePasswordModalVisible] =
+    useState<boolean>(false);
   return (
     <>
       <AppNavigation>
-        <SideBar sidebarVisible={sidebarVisible} setSidebarVisible={setSidebarVisible} setChangePasswordModalVisible={setChangePasswordModalVisible} />
+        <SideBar
+          sidebarVisible={sidebarVisible}
+          setSidebarVisible={setSidebarVisible}
+          setChangePasswordModalVisible={setChangePasswordModalVisible}
+        />
       </AppNavigation>
       <AppNavigationBar>
         <TopBar setSidebarVisible={setSidebarVisible} />
       </AppNavigationBar>
-      {changePasswordModalVisible && auth.user && <ChangePasswordModal id={auth.user.id.toString()} username={auth.user.username} setChangePasswordModalVisible={setChangePasswordModalVisible} />}
+      {changePasswordModalVisible && auth.user && (
+        <ChangePasswordModal
+          id={auth.user.id.toString()}
+          username={auth.user.username}
+          setChangePasswordModalVisible={setChangePasswordModalVisible}
+        />
+      )}
     </>
-  )
+  );
 }

--- a/ui/src/components/NotaryAppStatus.tsx
+++ b/ui/src/components/NotaryAppStatus.tsx
@@ -7,5 +7,5 @@ export default function NotaryAppStatus() {
         Version {process.env.VERSION}
       </span>
     </AppStatus>
-  )
+  );
 }

--- a/ui/src/components/NotaryConfirmationModal.tsx
+++ b/ui/src/components/NotaryConfirmationModal.tsx
@@ -4,22 +4,23 @@ import { ConfirmationModal, Notification } from "@canonical/react-components";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
-export type NotaryConfirmationModalData = {
-  queryFn: (params: any) => Promise<any>
-  queryParams: any
+export type NotaryConfirmationModalData<T> = {
+  queryFn: (params: T) => Promise<T>
+  queryParams: T
   closeFn: () => void
   queryKey: string
   warningText: string
   buttonConfirmText: string
 }
 
-export function NotaryConfirmationModal(data: NotaryConfirmationModalData) {
+// eslint-disable-next-line
+export function NotaryConfirmationModal(data: NotaryConfirmationModalData<any>) {
   const [errorText, setErrorText] = useState<string>("");
   const queryClient = useQueryClient();
   const mutation = useMutation({
     mutationFn: data.queryFn,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [data.queryKey] });
+      void queryClient.invalidateQueries({ queryKey: [data.queryKey] });
       setErrorText("");
       data.closeFn();
     },

--- a/ui/src/components/NotaryConfirmationModal.tsx
+++ b/ui/src/components/NotaryConfirmationModal.tsx
@@ -1,20 +1,22 @@
-"use client"
+"use client";
 
 import { ConfirmationModal, Notification } from "@canonical/react-components";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
 export type NotaryConfirmationModalData<T> = {
-  queryFn: (params: T) => Promise<T>
-  queryParams: T
-  closeFn: () => void
-  queryKey: string
-  warningText: string
-  buttonConfirmText: string
-}
+  queryFn: (params: T) => Promise<T>;
+  queryParams: T;
+  closeFn: () => void;
+  queryKey: string;
+  warningText: string;
+  buttonConfirmText: string;
+};
 
 // eslint-disable-next-line
-export function NotaryConfirmationModal(data: NotaryConfirmationModalData<any>) {
+export function NotaryConfirmationModal(
+  data: NotaryConfirmationModalData<any>,
+) {
   const [errorText, setErrorText] = useState<string>("");
   const queryClient = useQueryClient();
   const mutation = useMutation({
@@ -26,21 +28,21 @@ export function NotaryConfirmationModal(data: NotaryConfirmationModalData<any>) 
     },
     onError: (e: Error) => {
       setErrorText(e.message);
-    }
+    },
   });
   return (
-    < ConfirmationModal
+    <ConfirmationModal
       title="Confirm Action"
       confirmButtonLabel="Confirm"
       onConfirm={() => mutation.mutate(data.queryParams)}
       close={() => data.closeFn()}
     >
       <p>{data.warningText}</p>
-      {errorText !== "" &&
+      {errorText !== "" && (
         <Notification severity="negative" title="Error">
           {errorText}
         </Notification>
-      }
-    </ConfirmationModal >
-  )
+      )}
+    </ConfirmationModal>
+  );
 }

--- a/ui/src/components/NotaryConfirmationModal.tsx
+++ b/ui/src/components/NotaryConfirmationModal.tsx
@@ -13,8 +13,8 @@ export type NotaryConfirmationModalData<T> = {
   buttonConfirmText: string;
 };
 
-// eslint-disable-next-line
 export function NotaryConfirmationModal(
+  // eslint-disable-next-line
   data: NotaryConfirmationModalData<any>,
 ) {
   const [errorText, setErrorText] = useState<string>("");

--- a/ui/src/components/error.tsx
+++ b/ui/src/components/error.tsx
@@ -1,11 +1,11 @@
-"use client"
+"use client";
 import { Strip } from "@canonical/react-components";
 
 export default function Error({ msg }: { msg: string }) {
   return (
-    <Strip >
+    <Strip>
       <p className="p-heading--5">An error occured trying to load content</p>
       <p>{msg}</p>
     </Strip>
-  )
+  );
 }

--- a/ui/src/components/loading.tsx
+++ b/ui/src/components/loading.tsx
@@ -1,10 +1,10 @@
-"use client"
+"use client";
 import { Strip, Spinner } from "@canonical/react-components";
 
 export default function Loading() {
   return (
-    <Strip >
+    <Strip>
       <Spinner text="Loading..." />
     </Strip>
-  )
+  );
 }

--- a/ui/src/globals.scss
+++ b/ui/src/globals.scss
@@ -1,5 +1,5 @@
 // Import the framework
-@import 'node_modules/vanilla-framework';
+@import "node_modules/vanilla-framework";
 
 // Include all of Vanilla Framework
 @include vanilla;
@@ -10,52 +10,52 @@
 
 // Override visibility settings
 #csr-table {
-    overflow: visible;
+  overflow: visible;
 }
 
 .p-panel__content {
-    overflow: visible;
+  overflow: visible;
 }
 
 // Add Extra logo CSS
 .logo {
-    .logo-tag {
-        background-color: #e95420;
-        height: 2.2rem;
-        position: absolute;
-        top: 0;
-        width: 1.313rem;
-    }
+  .logo-tag {
+    background-color: #e95420;
+    height: 2.2rem;
+    position: absolute;
+    top: 0;
+    width: 1.313rem;
+  }
 
-    .logo-image {
-        bottom: 0.125rem;
-        height: 1rem;
-        left: 50%;
-        position: absolute;
-        transform: translate(-50%, 0);
-        width: 1rem;
-    }
+  .logo-image {
+    bottom: 0.125rem;
+    height: 1rem;
+    left: 50%;
+    position: absolute;
+    transform: translate(-50%, 0);
+    width: 1rem;
+  }
 
-    .logo-text {
-        color: #fff;
-        display: inline-block;
-        font-size: 1.3rem;
-        font-weight: 300;
-        line-height: 1rem;
-        margin-top: 0.5rem;
-        padding-left: 1.5rem;
-    }
+  .logo-text {
+    color: #fff;
+    display: inline-block;
+    font-size: 1.3rem;
+    font-weight: 300;
+    line-height: 1rem;
+    margin-top: 0.5rem;
+    padding-left: 1.5rem;
+  }
 }
 
 .certificate-info {
-    margin: 0;
-    padding: 0;
+  margin: 0;
+  padding: 0;
 }
 
 .certificate-info h4 {
-    margin: 4px 0;
+  margin: 4px 0;
 }
 
 .certificate-info p {
-    margin: 4px 0;
+  margin: 4px 0;
 }

--- a/ui/src/hooks/useAuth.tsx
+++ b/ui/src/hooks/useAuth.tsx
@@ -17,7 +17,7 @@ type AuthContextType = {
 const AuthContext = createContext<AuthContextType>({ user: null, firstUserCreated: false, setFirstUserCreated: () => { }, activeCA: null, setActiveCA: () => { } });
 
 export const AuthProvider = ({ children }: Readonly<{ children: React.ReactNode }>) => {
-    const [cookies, setCookie, removeCookie] = useCookies(['user_token']);
+    const [cookies,] = useCookies(['user_token']);
     const [user, setUser] = useState<User | null>(null);
     const [firstUserCreated, setFirstUserCreated] = useState<boolean>(false)
     const [activeCAState, setActiveCAState] = useState<CertificateAuthorityEntry | null>(null);
@@ -29,13 +29,13 @@ export const AuthProvider = ({ children }: Readonly<{ children: React.ReactNode 
     }, [])
 
     useEffect(() => {
-        let storedActiveCA = localStorage.getItem("activeCA")
-        setActiveCAState(storedActiveCA ? JSON.parse(storedActiveCA) : null)
+        const storedActiveCA = localStorage.getItem("activeCA")
+        setActiveCAState(storedActiveCA ? JSON.parse(storedActiveCA) as CertificateAuthorityEntry : null)
 
-        const token = cookies.user_token;
+        const token = cookies.user_token as string;
         if (token) {
-            let userObject = jwtDecode(cookies.user_token) as User
-            userObject.authToken = cookies.user_token
+            const userObject = jwtDecode<User>(token)
+            userObject.authToken = token
             setUser(userObject);
             setFirstUserCreated(true)
         } else {

--- a/ui/src/hooks/useAuth.tsx
+++ b/ui/src/hooks/useAuth.tsx
@@ -1,54 +1,83 @@
-"use client"
+"use client";
 
-import { createContext, useContext, useState, useEffect, Dispatch, SetStateAction, useCallback } from 'react';
-import { User, CertificateAuthorityEntry } from '../types';
-import { useCookies } from 'react-cookie';
-import { jwtDecode } from 'jwt-decode';
-import { useRouter } from 'next/navigation';
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  Dispatch,
+  SetStateAction,
+  useCallback,
+} from "react";
+import { User, CertificateAuthorityEntry } from "../types";
+import { useCookies } from "react-cookie";
+import { jwtDecode } from "jwt-decode";
+import { useRouter } from "next/navigation";
 
 type AuthContextType = {
-    user: User | null
-    firstUserCreated: boolean
-    setFirstUserCreated: Dispatch<SetStateAction<boolean>>
-    activeCA: CertificateAuthorityEntry | null
-    setActiveCA: (value: CertificateAuthorityEntry | null) => void
-}
+  user: User | null;
+  firstUserCreated: boolean;
+  setFirstUserCreated: Dispatch<SetStateAction<boolean>>;
+  activeCA: CertificateAuthorityEntry | null;
+  setActiveCA: (value: CertificateAuthorityEntry | null) => void;
+};
 
-const AuthContext = createContext<AuthContextType>({ user: null, firstUserCreated: false, setFirstUserCreated: () => { }, activeCA: null, setActiveCA: () => { } });
+const AuthContext = createContext<AuthContextType>({
+  user: null,
+  firstUserCreated: false,
+  setFirstUserCreated: () => {},
+  activeCA: null,
+  setActiveCA: () => {},
+});
 
-export const AuthProvider = ({ children }: Readonly<{ children: React.ReactNode }>) => {
-    const [cookies,] = useCookies(['user_token']);
-    const [user, setUser] = useState<User | null>(null);
-    const [firstUserCreated, setFirstUserCreated] = useState<boolean>(false)
-    const [activeCAState, setActiveCAState] = useState<CertificateAuthorityEntry | null>(null);
-    const router = useRouter();
+export const AuthProvider = ({
+  children,
+}: Readonly<{ children: React.ReactNode }>) => {
+  const [cookies] = useCookies(["user_token"]);
+  const [user, setUser] = useState<User | null>(null);
+  const [firstUserCreated, setFirstUserCreated] = useState<boolean>(false);
+  const [activeCAState, setActiveCAState] =
+    useState<CertificateAuthorityEntry | null>(null);
+  const router = useRouter();
 
-    const setActiveCA = useCallback((value: CertificateAuthorityEntry | null) => {
-        setActiveCAState(value)
-        localStorage.setItem("activeCA", JSON.stringify(value))
-    }, [])
+  const setActiveCA = useCallback((value: CertificateAuthorityEntry | null) => {
+    setActiveCAState(value);
+    localStorage.setItem("activeCA", JSON.stringify(value));
+  }, []);
 
-    useEffect(() => {
-        const storedActiveCA = localStorage.getItem("activeCA")
-        setActiveCAState(storedActiveCA ? JSON.parse(storedActiveCA) as CertificateAuthorityEntry : null)
-
-        const token = cookies.user_token as string;
-        if (token) {
-            const userObject = jwtDecode<User>(token)
-            userObject.authToken = token
-            setUser(userObject);
-            setFirstUserCreated(true)
-        } else {
-            setUser(null)
-            router.push('/login');
-        }
-    }, [cookies.user_token, router]);
-
-    return (
-        <AuthContext.Provider value={{ user, firstUserCreated, setFirstUserCreated, activeCA: activeCAState, setActiveCA }}>
-            {children}
-        </AuthContext.Provider >
+  useEffect(() => {
+    const storedActiveCA = localStorage.getItem("activeCA");
+    setActiveCAState(
+      storedActiveCA
+        ? (JSON.parse(storedActiveCA) as CertificateAuthorityEntry)
+        : null,
     );
+
+    const token = cookies.user_token as string;
+    if (token) {
+      const userObject = jwtDecode<User>(token);
+      userObject.authToken = token;
+      setUser(userObject);
+      setFirstUserCreated(true);
+    } else {
+      setUser(null);
+      router.push("/login");
+    }
+  }, [cookies.user_token, router]);
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        firstUserCreated,
+        setFirstUserCreated,
+        activeCA: activeCAState,
+        setActiveCA,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
 };
 
 export const useAuth = () => useContext(AuthContext);

--- a/ui/src/queries.ts
+++ b/ui/src/queries.ts
@@ -1,392 +1,496 @@
 // FIXME: Update the response and param types to match the actual API response when they are standardized
 /* eslint-disable */
 
-import { CertificateAuthorityEntry, CSREntry, UserEntry } from "@/types"
-import { HTTPStatus } from "@/utils"
+import { CertificateAuthorityEntry, CSREntry, UserEntry } from "@/types";
+import { HTTPStatus } from "@/utils";
 
 export type RequiredCSRParams = {
-  id: string
-  authToken: string
-  csr?: string
-  cert?: string
-}
+  id: string;
+  authToken: string;
+  csr?: string;
+  cert?: string;
+};
 
 export type RequiredCAParams = {
-  id: string
-  authToken: string
-}
+  id: string;
+  authToken: string;
+};
 
 export type Response<T> = {
-  result: T
-  error: string
-}
+  result: T;
+  error: string;
+};
 
 type GETStatus = {
-  initialized: boolean
-  version: string
-}
+  initialized: boolean;
+  version: string;
+};
 
 export async function getStatus(): Promise<GETStatus> {
-  const response = await fetch("/status")
-  const respData = await response.json() as Response<GETStatus>
+  const response = await fetch("/status");
+  const respData = (await response.json()) as Response<GETStatus>;
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
 }
 
-export async function getCertificateRequests(params: { authToken: string }): Promise<CSREntry[]> {
+export async function getCertificateRequests(params: {
+  authToken: string;
+}): Promise<CSREntry[]> {
   const response = await fetch("/api/v1/certificate_requests", {
-    headers: { "Authorization": "Bearer " + params.authToken }
-  })
+    headers: { Authorization: "Bearer " + params.authToken },
+  });
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  console.log(respData)
-  return respData.result
+  console.log(respData);
+  return respData.result;
 }
 
-export async function postCSR(params: { authToken: string, csr: string }) {
+export async function postCSR(params: { authToken: string; csr: string }) {
   if (!params.csr) {
-    throw new Error('CSR not provided')
+    throw new Error("CSR not provided");
   }
   const reqParams = {
-    "csr": params.csr.trim()
-  }
+    csr: params.csr.trim(),
+  };
   const response = await fetch("/api/v1/certificate_requests", {
-    method: 'post',
+    method: "post",
     headers: {
-      'Content-Type': 'text/plain',
-      'Authorization': "Bearer " + params.authToken
+      "Content-Type": "text/plain",
+      Authorization: "Bearer " + params.authToken,
     },
-    body: JSON.stringify(reqParams)
-  })
+    body: JSON.stringify(reqParams),
+  });
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
 }
 
 export async function postCertToID(params: RequiredCSRParams) {
   if (!params.cert) {
-    throw new Error('Certificate not provided')
+    throw new Error("Certificate not provided");
   }
   const reqParams = {
-    "certificate": params.cert.trim()
-  }
-  const response = await fetch("/api/v1/certificate_requests/" + params.id + "/certificate", {
-    method: 'post',
-    headers: {
-      'Content-Type': 'text/plain',
-      'Authorization': "Bearer " + params.authToken
+    certificate: params.cert.trim(),
+  };
+  const response = await fetch(
+    "/api/v1/certificate_requests/" + params.id + "/certificate",
+    {
+      method: "post",
+      headers: {
+        "Content-Type": "text/plain",
+        Authorization: "Bearer " + params.authToken,
+      },
+      body: JSON.stringify(reqParams),
     },
-    body: JSON.stringify(reqParams)
-  })
+  );
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
 }
 
 export async function deleteCSR(params: RequiredCSRParams) {
   const response = await fetch("/api/v1/certificate_requests/" + params.id, {
-    method: 'delete',
+    method: "delete",
     headers: {
-      'Authorization': "Bearer " + params.authToken
-    }
-  })
+      Authorization: "Bearer " + params.authToken,
+    },
+  });
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
 }
 
-export async function signCSR(params: RequiredCSRParams & { certificate_authority_id: number }) {
+export async function signCSR(
+  params: RequiredCSRParams & { certificate_authority_id: number },
+) {
   if (!params.certificate_authority_id) {
-    throw new Error('Certificate not provided')
+    throw new Error("Certificate not provided");
   }
   const reqParams = {
-    "certificate_authority_id": params.certificate_authority_id.toString()
-  }
-  const response = await fetch("/api/v1/certificate_requests/" + params.id + "/sign", {
-    method: 'post',
-    headers: {
-      'Authorization': "Bearer " + params.authToken,
-      'Content-Type': 'application/json',
+    certificate_authority_id: params.certificate_authority_id.toString(),
+  };
+  const response = await fetch(
+    "/api/v1/certificate_requests/" + params.id + "/sign",
+    {
+      method: "post",
+      headers: {
+        Authorization: "Bearer " + params.authToken,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(reqParams),
     },
-    body: JSON.stringify(reqParams)
-  })
+  );
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
 }
 
 export async function rejectCSR(params: RequiredCSRParams) {
-  const response = await fetch("/api/v1/certificate_requests/" + params.id + "/reject", {
-    method: 'post',
-    headers: {
-      'Authorization': "Bearer " + params.authToken
-    }
-  })
+  const response = await fetch(
+    "/api/v1/certificate_requests/" + params.id + "/reject",
+    {
+      method: "post",
+      headers: {
+        Authorization: "Bearer " + params.authToken,
+      },
+    },
+  );
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
 }
 
 export async function revokeCertificate(params: RequiredCSRParams) {
-  const response = await fetch("/api/v1/certificate_requests/" + params.id + "/certificate/revoke", {
-    method: 'post',
-    headers: {
-      'Authorization': 'Bearer ' + params.authToken
-    }
-  })
+  const response = await fetch(
+    "/api/v1/certificate_requests/" + params.id + "/certificate/revoke",
+    {
+      method: "post",
+      headers: {
+        Authorization: "Bearer " + params.authToken,
+      },
+    },
+  );
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
 }
 
-export async function login(userForm: { username: string, password: string }): Promise<{ token: string }> {
+export async function login(userForm: {
+  username: string;
+  password: string;
+}): Promise<{ token: string }> {
   const response = await fetch("/login", {
     method: "POST",
 
-    body: JSON.stringify({ "username": userForm.username, "password": userForm.password })
-  })
+    body: JSON.stringify({
+      username: userForm.username,
+      password: userForm.password,
+    }),
+  });
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
 }
 
-export async function changeSelfPassword(changePasswordForm: { authToken: string, password: string }) {
+export async function changeSelfPassword(changePasswordForm: {
+  authToken: string;
+  password: string;
+}) {
   const response = await fetch("/api/v1/accounts/me/change_password", {
     method: "POST",
     headers: {
-      'Authorization': 'Bearer ' + changePasswordForm.authToken
+      Authorization: "Bearer " + changePasswordForm.authToken,
     },
-    body: JSON.stringify({ "password": changePasswordForm.password })
-  })
+    body: JSON.stringify({ password: changePasswordForm.password }),
+  });
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
 }
 
-export async function changePassword(changePasswordForm: { authToken: string, id: string, password: string }) {
-  const response = await fetch("/api/v1/accounts/" + changePasswordForm.id + "/change_password", {
-    method: "POST",
-    headers: {
-      'Authorization': 'Bearer ' + changePasswordForm.authToken
+export async function changePassword(changePasswordForm: {
+  authToken: string;
+  id: string;
+  password: string;
+}) {
+  const response = await fetch(
+    "/api/v1/accounts/" + changePasswordForm.id + "/change_password",
+    {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer " + changePasswordForm.authToken,
+      },
+      body: JSON.stringify({ password: changePasswordForm.password }),
     },
-    body: JSON.stringify({ "password": changePasswordForm.password })
-  })
+  );
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
 }
 
-export async function ListUsers(params: { authToken: string }): Promise<UserEntry[]> {
+export async function ListUsers(params: {
+  authToken: string;
+}): Promise<UserEntry[]> {
   const response = await fetch("/api/v1/accounts", {
-    headers: { "Authorization": "Bearer " + params.authToken }
-  })
+    headers: { Authorization: "Bearer " + params.authToken },
+  });
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
 }
 
-export async function deleteUser(params: { authToken: string, id: string }) {
+export async function deleteUser(params: { authToken: string; id: string }) {
   const response = await fetch("/api/v1/accounts/" + params.id, {
-    method: 'delete',
+    method: "delete",
     headers: {
-      'Authorization': "Bearer " + params.authToken
-    }
-  })
+      Authorization: "Bearer " + params.authToken,
+    },
+  });
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
 }
 
-export async function postFirstUser(userForm: { username: string, password: string }) {
-  const response = await fetch("/api/v1/accounts", {
-    method: "POST",
-    body: JSON.stringify({ "username": userForm.username, "password": userForm.password })
-  })
-  const respData = await response.json();
-  if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
-  }
-  return respData.result
-}
-
-export async function postUser(userForm: { authToken: string, username: string, password: string }) {
+export async function postFirstUser(userForm: {
+  username: string;
+  password: string;
+}) {
   const response = await fetch("/api/v1/accounts", {
     method: "POST",
     body: JSON.stringify({
-      "username": userForm.username, "password": userForm.password
+      username: userForm.username,
+      password: userForm.password,
     }),
-    headers: {
-      'Authorization': "Bearer " + userForm.authToken
-    }
-  })
+  });
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
 }
 
-export async function getCertificateAuthorities(params: { authToken: string }): Promise<CertificateAuthorityEntry[]> {
-  const response = await fetch("/api/v1/certificate_authorities", {
-    headers: { "Authorization": "Bearer " + params.authToken }
-  })
+export async function postUser(userForm: {
+  authToken: string;
+  username: string;
+  password: string;
+}) {
+  const response = await fetch("/api/v1/accounts", {
+    method: "POST",
+    body: JSON.stringify({
+      username: userForm.username,
+      password: userForm.password,
+    }),
+    headers: {
+      Authorization: "Bearer " + userForm.authToken,
+    },
+  });
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
+}
+
+export async function getCertificateAuthorities(params: {
+  authToken: string;
+}): Promise<CertificateAuthorityEntry[]> {
+  const response = await fetch("/api/v1/certificate_authorities", {
+    headers: { Authorization: "Bearer " + params.authToken },
+  });
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
+  }
+  return respData.result;
 }
 
 export async function postCA(params: {
-  authToken: string,
+  authToken: string;
 
-  SelfSigned: boolean,
-  CommonName: string,
-  CountryName: string,
-  StateOrProvinceName: string,
-  LocalityName: string,
-  OrganizationName: string,
-  OrganizationalUnit: string,
-  NotValidAfter: string,
-
+  SelfSigned: boolean;
+  CommonName: string;
+  CountryName: string;
+  StateOrProvinceName: string;
+  LocalityName: string;
+  OrganizationName: string;
+  OrganizationalUnit: string;
+  NotValidAfter: string;
 }) {
-  const NotValidAfterDate = params.NotValidAfter !== "" ? new Date(params.NotValidAfter) : null;
+  const NotValidAfterDate =
+    params.NotValidAfter !== "" ? new Date(params.NotValidAfter) : null;
   const reqParams = {
-    "self_signed": params.SelfSigned,
-    "common_name": params.CommonName,
-    "sans_dns": "",
-    "country_name": params.CountryName,
-    "state_or_province_name": params.StateOrProvinceName,
-    "locality_name": params.LocalityName,
-    "organization_name": params.OrganizationName,
-    "organizational_unit_name": params.OrganizationalUnit,
-    "not_valid_after": NotValidAfterDate?.toISOString(),
-  }
+    self_signed: params.SelfSigned,
+    common_name: params.CommonName,
+    sans_dns: "",
+    country_name: params.CountryName,
+    state_or_province_name: params.StateOrProvinceName,
+    locality_name: params.LocalityName,
+    organization_name: params.OrganizationName,
+    organizational_unit_name: params.OrganizationalUnit,
+    not_valid_after: NotValidAfterDate?.toISOString(),
+  };
   const response = await fetch("/api/v1/certificate_authorities", {
-    method: 'post',
+    method: "post",
     headers: {
-      'Authorization': "Bearer " + params.authToken,
-      'Content-Type': 'application/json',
+      Authorization: "Bearer " + params.authToken,
+      "Content-Type": "application/json",
     },
-    body: JSON.stringify(reqParams)
-  })
+    body: JSON.stringify(reqParams),
+  });
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
 }
 
 export async function deleteCA(params: RequiredCAParams) {
   const response = await fetch("/api/v1/certificate_authorities/" + params.id, {
-    method: 'delete',
+    method: "delete",
     headers: {
-      'Authorization': "Bearer " + params.authToken
-    }
-  })
+      Authorization: "Bearer " + params.authToken,
+    },
+  });
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
 }
 
 export async function revokeCA(params: RequiredCAParams) {
-  const response = await fetch("/api/v1/certificate_authorities/" + params.id + "/revoke", {
-    method: 'post',
-    headers: {
-      'Authorization': 'Bearer ' + params.authToken
-    }
-  })
+  const response = await fetch(
+    "/api/v1/certificate_authorities/" + params.id + "/revoke",
+    {
+      method: "post",
+      headers: {
+        Authorization: "Bearer " + params.authToken,
+      },
+    },
+  );
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
 }
 
 export async function makeCALegacy(params: RequiredCAParams) {
   const response = await fetch("/api/v1/certificate_authorities/" + params.id, {
-    method: 'PUT',
+    method: "PUT",
     headers: {
-      'Authorization': 'Bearer ' + params.authToken,
-      'Content-Type': 'application/json'
+      Authorization: "Bearer " + params.authToken,
+      "Content-Type": "application/json",
     },
-    body: JSON.stringify({ "status": "legacy" })
-  })
+    body: JSON.stringify({ status: "legacy" }),
+  });
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
 }
 
-export async function postCertToCA(params: RequiredCAParams & { certificate_chain: string }) {
+export async function postCertToCA(
+  params: RequiredCAParams & { certificate_chain: string },
+) {
   if (!params.certificate_chain) {
-    throw new Error('Certificate not provided')
+    throw new Error("Certificate not provided");
   }
   const reqParams = {
-    "certificate_chain": params.certificate_chain.trim()
-  }
-  const response = await fetch("/api/v1/certificate_authorities/" + params.id + "/certificate", {
-    method: 'post',
-    headers: {
-      'Authorization': "Bearer " + params.authToken,
-      'Content-Type': 'application/json',
+    certificate_chain: params.certificate_chain.trim(),
+  };
+  const response = await fetch(
+    "/api/v1/certificate_authorities/" + params.id + "/certificate",
+    {
+      method: "post",
+      headers: {
+        Authorization: "Bearer " + params.authToken,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(reqParams),
     },
-    body: JSON.stringify(reqParams)
-  })
+  );
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
 }
 
-export async function signCA(params: RequiredCAParams & { certificate_authority_id: number }) {
+export async function signCA(
+  params: RequiredCAParams & { certificate_authority_id: number },
+) {
   if (!params.certificate_authority_id) {
-    throw new Error('Certificate not provided')
+    throw new Error("Certificate not provided");
   }
   const reqParams = {
-    "certificate_authority_id": params.certificate_authority_id.toString()
-  }
-  const response = await fetch("/api/v1/certificate_authorities/" + params.id + "/sign", {
-    method: 'post',
-    headers: {
-      'Authorization': "Bearer " + params.authToken,
-      'Content-Type': 'application/json',
+    certificate_authority_id: params.certificate_authority_id.toString(),
+  };
+  const response = await fetch(
+    "/api/v1/certificate_authorities/" + params.id + "/sign",
+    {
+      method: "post",
+      headers: {
+        Authorization: "Bearer " + params.authToken,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(reqParams),
     },
-    body: JSON.stringify(reqParams)
-  })
+  );
   const respData = await response.json();
   if (!response.ok) {
-    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+    throw new Error(
+      `${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`,
+    );
   }
-  return respData.result
+  return respData.result;
 }

--- a/ui/src/queries.ts
+++ b/ui/src/queries.ts
@@ -1,378 +1,392 @@
+// FIXME: Update the response and param types to match the actual API response when they are standardized
+/* eslint-disable */
+
 import { CertificateAuthorityEntry, CSREntry, UserEntry } from "@/types"
 import { HTTPStatus } from "@/utils"
 
 export type RequiredCSRParams = {
-    id: string
-    authToken: string
-    csr?: string
-    cert?: string
+  id: string
+  authToken: string
+  csr?: string
+  cert?: string
 }
 
 export type RequiredCAParams = {
-    id: string
-    authToken: string
+  id: string
+  authToken: string
 }
 
-export async function getStatus() {
-    const response = await fetch("/status")
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
-    }
-    return respData.result
+export type Response<T> = {
+  result: T
+  error: string
+}
+
+type GETStatus = {
+  initialized: boolean
+  version: string
+}
+
+export async function getStatus(): Promise<GETStatus> {
+  const response = await fetch("/status")
+  const respData = await response.json() as Response<GETStatus>
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
 export async function getCertificateRequests(params: { authToken: string }): Promise<CSREntry[]> {
-    const response = await fetch("/api/v1/certificate_requests", {
-        headers: { "Authorization": "Bearer " + params.authToken }
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
-    }
-    return respData.result
+  const response = await fetch("/api/v1/certificate_requests", {
+    headers: { "Authorization": "Bearer " + params.authToken }
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  console.log(respData)
+  return respData.result
 }
 
 export async function postCSR(params: { authToken: string, csr: string }) {
-    if (!params.csr) {
-        throw new Error('CSR not provided')
-    }
-    const reqParams = {
-        "csr": params.csr.trim()
-    }
-    const response = await fetch("/api/v1/certificate_requests", {
-        method: 'post',
-        headers: {
-            'Content-Type': 'text/plain',
-            'Authorization': "Bearer " + params.authToken
-        },
-        body: JSON.stringify(reqParams)
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
-    }
-    return respData.result
+  if (!params.csr) {
+    throw new Error('CSR not provided')
+  }
+  const reqParams = {
+    "csr": params.csr.trim()
+  }
+  const response = await fetch("/api/v1/certificate_requests", {
+    method: 'post',
+    headers: {
+      'Content-Type': 'text/plain',
+      'Authorization': "Bearer " + params.authToken
+    },
+    body: JSON.stringify(reqParams)
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
 export async function postCertToID(params: RequiredCSRParams) {
-    if (!params.cert) {
-        throw new Error('Certificate not provided')
-    }
-    const reqParams = {
-        "certificate": params.cert.trim()
-    }
-    const response = await fetch("/api/v1/certificate_requests/" + params.id + "/certificate", {
-        method: 'post',
-        headers: {
-            'Content-Type': 'text/plain',
-            'Authorization': "Bearer " + params.authToken
-        },
-        body: JSON.stringify(reqParams)
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
-    }
-    return respData.result
+  if (!params.cert) {
+    throw new Error('Certificate not provided')
+  }
+  const reqParams = {
+    "certificate": params.cert.trim()
+  }
+  const response = await fetch("/api/v1/certificate_requests/" + params.id + "/certificate", {
+    method: 'post',
+    headers: {
+      'Content-Type': 'text/plain',
+      'Authorization': "Bearer " + params.authToken
+    },
+    body: JSON.stringify(reqParams)
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
 export async function deleteCSR(params: RequiredCSRParams) {
-    const response = await fetch("/api/v1/certificate_requests/" + params.id, {
-        method: 'delete',
-        headers: {
-            'Authorization': "Bearer " + params.authToken
-        }
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  const response = await fetch("/api/v1/certificate_requests/" + params.id, {
+    method: 'delete',
+    headers: {
+      'Authorization': "Bearer " + params.authToken
     }
-    return respData.result
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
 export async function signCSR(params: RequiredCSRParams & { certificate_authority_id: number }) {
-    if (!params.certificate_authority_id) {
-        throw new Error('Certificate not provided')
-    }
-    const reqParams = {
-        "certificate_authority_id": params.certificate_authority_id.toString()
-    }
-    const response = await fetch("/api/v1/certificate_requests/" + params.id + "/sign", {
-        method: 'post',
-        headers: {
-            'Authorization': "Bearer " + params.authToken,
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(reqParams)
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
-    }
-    return respData.result
+  if (!params.certificate_authority_id) {
+    throw new Error('Certificate not provided')
+  }
+  const reqParams = {
+    "certificate_authority_id": params.certificate_authority_id.toString()
+  }
+  const response = await fetch("/api/v1/certificate_requests/" + params.id + "/sign", {
+    method: 'post',
+    headers: {
+      'Authorization': "Bearer " + params.authToken,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(reqParams)
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
 export async function rejectCSR(params: RequiredCSRParams) {
-    const response = await fetch("/api/v1/certificate_requests/" + params.id + "/reject", {
-        method: 'post',
-        headers: {
-            'Authorization': "Bearer " + params.authToken
-        }
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  const response = await fetch("/api/v1/certificate_requests/" + params.id + "/reject", {
+    method: 'post',
+    headers: {
+      'Authorization': "Bearer " + params.authToken
     }
-    return respData.result
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
 export async function revokeCertificate(params: RequiredCSRParams) {
-    const response = await fetch("/api/v1/certificate_requests/" + params.id + "/certificate/revoke", {
-        method: 'post',
-        headers: {
-            'Authorization': 'Bearer ' + params.authToken
-        }
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  const response = await fetch("/api/v1/certificate_requests/" + params.id + "/certificate/revoke", {
+    method: 'post',
+    headers: {
+      'Authorization': 'Bearer ' + params.authToken
     }
-    return respData.result
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
-export async function login(userForm: { username: string, password: string }) {
-    const response = await fetch("/login", {
-        method: "POST",
+export async function login(userForm: { username: string, password: string }): Promise<{ token: string }> {
+  const response = await fetch("/login", {
+    method: "POST",
 
-        body: JSON.stringify({ "username": userForm.username, "password": userForm.password })
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
-    }
-    return respData.result
+    body: JSON.stringify({ "username": userForm.username, "password": userForm.password })
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
 export async function changeSelfPassword(changePasswordForm: { authToken: string, password: string }) {
-    const response = await fetch("/api/v1/accounts/me/change_password", {
-        method: "POST",
-        headers: {
-            'Authorization': 'Bearer ' + changePasswordForm.authToken
-        },
-        body: JSON.stringify({ "password": changePasswordForm.password })
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
-    }
-    return respData.result
+  const response = await fetch("/api/v1/accounts/me/change_password", {
+    method: "POST",
+    headers: {
+      'Authorization': 'Bearer ' + changePasswordForm.authToken
+    },
+    body: JSON.stringify({ "password": changePasswordForm.password })
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
 export async function changePassword(changePasswordForm: { authToken: string, id: string, password: string }) {
-    const response = await fetch("/api/v1/accounts/" + changePasswordForm.id + "/change_password", {
-        method: "POST",
-        headers: {
-            'Authorization': 'Bearer ' + changePasswordForm.authToken
-        },
-        body: JSON.stringify({ "password": changePasswordForm.password })
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
-    }
-    return respData.result
+  const response = await fetch("/api/v1/accounts/" + changePasswordForm.id + "/change_password", {
+    method: "POST",
+    headers: {
+      'Authorization': 'Bearer ' + changePasswordForm.authToken
+    },
+    body: JSON.stringify({ "password": changePasswordForm.password })
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
 export async function ListUsers(params: { authToken: string }): Promise<UserEntry[]> {
-    const response = await fetch("/api/v1/accounts", {
-        headers: { "Authorization": "Bearer " + params.authToken }
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
-    }
-    return respData.result
+  const response = await fetch("/api/v1/accounts", {
+    headers: { "Authorization": "Bearer " + params.authToken }
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
 export async function deleteUser(params: { authToken: string, id: string }) {
-    const response = await fetch("/api/v1/accounts/" + params.id, {
-        method: 'delete',
-        headers: {
-            'Authorization': "Bearer " + params.authToken
-        }
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  const response = await fetch("/api/v1/accounts/" + params.id, {
+    method: 'delete',
+    headers: {
+      'Authorization': "Bearer " + params.authToken
     }
-    return respData.result
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
 export async function postFirstUser(userForm: { username: string, password: string }) {
-    const response = await fetch("/api/v1/accounts", {
-        method: "POST",
-        body: JSON.stringify({ "username": userForm.username, "password": userForm.password })
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
-    }
-    return respData.result
+  const response = await fetch("/api/v1/accounts", {
+    method: "POST",
+    body: JSON.stringify({ "username": userForm.username, "password": userForm.password })
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
 export async function postUser(userForm: { authToken: string, username: string, password: string }) {
-    const response = await fetch("/api/v1/accounts", {
-        method: "POST",
-        body: JSON.stringify({
-            "username": userForm.username, "password": userForm.password
-        }),
-        headers: {
-            'Authorization': "Bearer " + userForm.authToken
-        }
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  const response = await fetch("/api/v1/accounts", {
+    method: "POST",
+    body: JSON.stringify({
+      "username": userForm.username, "password": userForm.password
+    }),
+    headers: {
+      'Authorization': "Bearer " + userForm.authToken
     }
-    return respData.result
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
 export async function getCertificateAuthorities(params: { authToken: string }): Promise<CertificateAuthorityEntry[]> {
-    const response = await fetch("/api/v1/certificate_authorities", {
-        headers: { "Authorization": "Bearer " + params.authToken }
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
-    }
-    return respData.result
+  const response = await fetch("/api/v1/certificate_authorities", {
+    headers: { "Authorization": "Bearer " + params.authToken }
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
 export async function postCA(params: {
-    authToken: string,
+  authToken: string,
 
-    SelfSigned: boolean,
-    CommonName: string,
-    CountryName: string,
-    StateOrProvinceName: string,
-    LocalityName: string,
-    OrganizationName: string,
-    OrganizationalUnit: string,
-    NotValidAfter: string,
+  SelfSigned: boolean,
+  CommonName: string,
+  CountryName: string,
+  StateOrProvinceName: string,
+  LocalityName: string,
+  OrganizationName: string,
+  OrganizationalUnit: string,
+  NotValidAfter: string,
 
 }) {
-    const NotValidAfterDate = params.NotValidAfter !== "" ? new Date(params.NotValidAfter) : null;
-    const reqParams = {
-        "self_signed": params.SelfSigned,
-        "common_name": params.CommonName,
-        "sans_dns": "",
-        "country_name": params.CountryName,
-        "state_or_province_name": params.StateOrProvinceName,
-        "locality_name": params.LocalityName,
-        "organization_name": params.OrganizationName,
-        "organizational_unit_name": params.OrganizationalUnit,
-        "not_valid_after": NotValidAfterDate?.toISOString(),
-    }
-    const response = await fetch("/api/v1/certificate_authorities", {
-        method: 'post',
-        headers: {
-            'Authorization': "Bearer " + params.authToken,
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(reqParams)
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
-    }
-    return respData.result
+  const NotValidAfterDate = params.NotValidAfter !== "" ? new Date(params.NotValidAfter) : null;
+  const reqParams = {
+    "self_signed": params.SelfSigned,
+    "common_name": params.CommonName,
+    "sans_dns": "",
+    "country_name": params.CountryName,
+    "state_or_province_name": params.StateOrProvinceName,
+    "locality_name": params.LocalityName,
+    "organization_name": params.OrganizationName,
+    "organizational_unit_name": params.OrganizationalUnit,
+    "not_valid_after": NotValidAfterDate?.toISOString(),
+  }
+  const response = await fetch("/api/v1/certificate_authorities", {
+    method: 'post',
+    headers: {
+      'Authorization': "Bearer " + params.authToken,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(reqParams)
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
 export async function deleteCA(params: RequiredCAParams) {
-    const response = await fetch("/api/v1/certificate_authorities/" + params.id, {
-        method: 'delete',
-        headers: {
-            'Authorization': "Bearer " + params.authToken
-        }
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  const response = await fetch("/api/v1/certificate_authorities/" + params.id, {
+    method: 'delete',
+    headers: {
+      'Authorization': "Bearer " + params.authToken
     }
-    return respData.result
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
 export async function revokeCA(params: RequiredCAParams) {
-    const response = await fetch("/api/v1/certificate_authorities/" + params.id + "/revoke", {
-        method: 'post',
-        headers: {
-            'Authorization': 'Bearer ' + params.authToken
-        }
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  const response = await fetch("/api/v1/certificate_authorities/" + params.id + "/revoke", {
+    method: 'post',
+    headers: {
+      'Authorization': 'Bearer ' + params.authToken
     }
-    return respData.result
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
 export async function makeCALegacy(params: RequiredCAParams) {
-    const response = await fetch("/api/v1/certificate_authorities/" + params.id, {
-        method: 'PUT',
-        headers: {
-            'Authorization': 'Bearer ' + params.authToken,
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ "status": "legacy" })
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
-    }
-    return respData.result
+  const response = await fetch("/api/v1/certificate_authorities/" + params.id, {
+    method: 'PUT',
+    headers: {
+      'Authorization': 'Bearer ' + params.authToken,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ "status": "legacy" })
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
 export async function postCertToCA(params: RequiredCAParams & { certificate_chain: string }) {
-    if (!params.certificate_chain) {
-        throw new Error('Certificate not provided')
-    }
-    const reqParams = {
-        "certificate_chain": params.certificate_chain.trim()
-    }
-    const response = await fetch("/api/v1/certificate_authorities/" + params.id + "/certificate", {
-        method: 'post',
-        headers: {
-            'Authorization': "Bearer " + params.authToken,
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(reqParams)
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
-    }
-    return respData.result
+  if (!params.certificate_chain) {
+    throw new Error('Certificate not provided')
+  }
+  const reqParams = {
+    "certificate_chain": params.certificate_chain.trim()
+  }
+  const response = await fetch("/api/v1/certificate_authorities/" + params.id + "/certificate", {
+    method: 'post',
+    headers: {
+      'Authorization': "Bearer " + params.authToken,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(reqParams)
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }
 
 export async function signCA(params: RequiredCAParams & { certificate_authority_id: number }) {
-    if (!params.certificate_authority_id) {
-        throw new Error('Certificate not provided')
-    }
-    const reqParams = {
-        "certificate_authority_id": params.certificate_authority_id.toString()
-    }
-    const response = await fetch("/api/v1/certificate_authorities/" + params.id + "/sign", {
-        method: 'post',
-        headers: {
-            'Authorization': "Bearer " + params.authToken,
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(reqParams)
-    })
-    const respData = await response.json();
-    if (!response.ok) {
-        throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
-    }
-    return respData.result
+  if (!params.certificate_authority_id) {
+    throw new Error('Certificate not provided')
+  }
+  const reqParams = {
+    "certificate_authority_id": params.certificate_authority_id.toString()
+  }
+  const response = await fetch("/api/v1/certificate_authorities/" + params.id + "/sign", {
+    method: 'post',
+    headers: {
+      'Authorization': "Bearer " + params.authToken,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(reqParams)
+  })
+  const respData = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${HTTPStatus(response.status)}. ${respData.error}`)
+  }
+  return respData.result
 }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -5,6 +5,19 @@ export type CSREntry = {
     status: "Outstanding" | "Active" | "Rejected" | "Revoked"
 }
 
+export type CertificateSigningRequest = {
+    commonName?: string
+    stateOrProvince?: string
+    OrganizationalUnitName?: string
+    organization?: string
+    emailAddress?: string
+    country?: string
+    locality?: string
+    sansDns: string[]
+    sansIp: string[]
+    is_ca: boolean
+}
+
 export type CertificateAuthorityEntry = {
     id: number,
     status: "active" | "expired" | "pending" | "legacy"
@@ -28,12 +41,12 @@ export type UserEntry = {
     username: string
 }
 
-export type statusResponse = {
-    initialized: boolean
-    version: string
-}
+
 
 export type AsideFormData = {
     formTitle: string
-    formData: any
+    user?: {
+        id: string
+        username: string
+    }
 }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -1,52 +1,50 @@
 export type CSREntry = {
-    id: number,
-    csr: string,
-    certificate_chain: string
-    status: "Outstanding" | "Active" | "Rejected" | "Revoked"
-}
+  id: number;
+  csr: string;
+  certificate_chain: string;
+  status: "Outstanding" | "Active" | "Rejected" | "Revoked";
+};
 
 export type CertificateSigningRequest = {
-    commonName?: string
-    stateOrProvince?: string
-    OrganizationalUnitName?: string
-    organization?: string
-    emailAddress?: string
-    country?: string
-    locality?: string
-    sansDns: string[]
-    sansIp: string[]
-    is_ca: boolean
-}
+  commonName?: string;
+  stateOrProvince?: string;
+  OrganizationalUnitName?: string;
+  organization?: string;
+  emailAddress?: string;
+  country?: string;
+  locality?: string;
+  sansDns: string[];
+  sansIp: string[];
+  is_ca: boolean;
+};
 
 export type CertificateAuthorityEntry = {
-    id: number,
-    status: "active" | "expired" | "pending" | "legacy"
-    certificate: string
-    csr: string
-    crl: string
-}
+  id: number;
+  status: "active" | "expired" | "pending" | "legacy";
+  certificate: string;
+  csr: string;
+  crl: string;
+};
 
 export type User = {
-    exp: number
-    id: number
-    permissions: number
-    username: string
-    authToken: string
+  exp: number;
+  id: number;
+  permissions: number;
+  username: string;
+  authToken: string;
 
-    activeCA: number
-}
+  activeCA: number;
+};
 
 export type UserEntry = {
-    id: number
-    username: string
-}
-
-
+  id: number;
+  username: string;
+};
 
 export type AsideFormData = {
-    formTitle: string
-    user?: {
-        id: string
-        username: string
-    }
-}
+  formTitle: string;
+  user?: {
+    id: string;
+    username: string;
+  };
+};

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -1,6 +1,7 @@
 import { CertificationRequest, Certificate, Extensions, CertificateChainValidationEngine } from "pkijs";
 import { fromBER } from "asn1js";
 import * as pvutils from "pvutils";
+import { CertificateSigningRequest } from "./types";
 
 
 export const oidToName = (oid: string) => {
@@ -76,20 +77,24 @@ function parseExtensions(extensions: Extensions) {
         let extensionName: string;
         try {
             extensionName = oidToName(extension.extnID);
-        } catch (error) {
+        } catch {
             console.error(`Unrecognized extension OID: ${extension.extnID}`);
             return;
         }
 
         if (extensionName === "Subject Alternative Name") {
+            // eslint-disable-next-line
             extension.parsedValue.altNames.forEach((altName: { type: number; value: any; }) => {
                 if (altName.type == 2) {
+                    // eslint-disable-next-line
                     sansDns.push(altName.value);
                 } else if (altName.type == 7) {
+                    // eslint-disable-next-line
                     sansIp.push(hexToIp(altName.value.valueBlock.valueHex));
                 }
             });
         } else if (extensionName === "Basic Constraint") {
+            // eslint-disable-next-line
             is_ca = extension.parsedValue.cA;
         }
     });
@@ -114,7 +119,7 @@ function loadCertificate(certPemString: string) {
     return cert
 }
 
-export const extractCSR = (csrPemString: string) => {
+export const extractCSR = (csrPemString: string): CertificateSigningRequest => {
     const csr = loadCertificateRequest(csrPemString);
 
     // Extract subject information from CSR
@@ -161,7 +166,7 @@ export const csrIsValid = (csrPemString: string) => {
     try {
         extractCSR(csrPemString.trim());
         return true;
-    } catch (error) {
+    } catch {
         return false;
     }
 }

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -90,6 +90,7 @@ function parseExtensions(extensions: Extensions) {
     if (extensionName === "Subject Alternative Name") {
       // eslint-disable-next-line
       extension.parsedValue.altNames.forEach(
+        // eslint-disable-next-line
         (altName: { type: number; value: any }) => {
           if (altName.type == 2) {
             // eslint-disable-next-line

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -1,327 +1,359 @@
-import { CertificationRequest, Certificate, Extensions, CertificateChainValidationEngine } from "pkijs";
+import {
+  CertificationRequest,
+  Certificate,
+  Extensions,
+  CertificateChainValidationEngine,
+} from "pkijs";
 import { fromBER } from "asn1js";
 import * as pvutils from "pvutils";
 import { CertificateSigningRequest } from "./types";
 
-
 export const oidToName = (oid: string) => {
-    const map: { [key: string]: string } = {
-        // Subject OID's
-        "2.5.4.3": "Common Name",
-        "2.5.4.6": "Country",
-        "2.5.4.7": "Locality",
-        "2.5.4.8": "State or Province",
-        "2.5.4.9": "Street Address",
-        "2.5.4.97": "Organization Identifier",
-        "2.5.4.10": "Organization Name",
-        "2.5.4.11": "Organizational Unit Name",
-        "2.5.4.5": "Serial Number",
-        "2.5.4.4": "Surname",
-        "2.5.4.42": "Given Name",
-        "2.5.4.12": "Title",
-        "2.5.4.43": "Initials",
-        "2.5.4.44": "Generation Qualifier",
-        "2.5.4.45": "X500 Unique Identifier",
-        "2.5.4.46": "Dn Qualifier",
-        "2.5.4.65": "Pseudonym",
-        "0.9.2342.19200300.100.1.1": "User Id",
-        "0.9.2342.19200300.100.1.25": "Domain Component",
-        "1.2.840.113549.1.9.1": "Email Address",
-        "1.3.6.1.4.1.311.60.2.1.3": "Jurisdiction Country-Name",
-        "1.3.6.1.4.1.311.60.2.1.1": "Jurisdiction Locality-Name",
-        "1.3.6.1.4.1.311.60.2.1.2": "Jurisdiction State Or Province Name",
-        "2.5.4.15": "Business Category",
-        "2.5.4.16": "Postal Address",
-        "2.5.4.17": "Postal Code",
-        "1.2.643.3.131.1.1": "Inn",
-        "1.2.643.100.1": "Ogrn",
-        "1.2.643.100.3": "Snils",
-        "1.2.840.113549.1.9.2": "Unstructured Name",
-        // OID for pkcs-9-at-extensionRequest
-        "1.2.840.113549.1.9.14": "Extension Request",
-        // OID for basicConstraint
-        "2.5.29.19": "Basic Constraint",
-        "2.5.29.17": "Subject Alternative Name",
-        //
-        "2.5.29.15": "keyUsage",
-        "2.5.29.37": "extKeyUsage",
-        "2.5.29.14": "subjectKeyIdentifier",
-        "2.5.29.35": "authorityKeyIdentifier",
-        "2.5.29.31": "cRLDistributionPoints",
-
-    }
-    if (!(oid in map)) {
-        throw new Error("oid not recognized: " + oid)
-    }
-    return map[oid]
-}
+  const map: { [key: string]: string } = {
+    // Subject OID's
+    "2.5.4.3": "Common Name",
+    "2.5.4.6": "Country",
+    "2.5.4.7": "Locality",
+    "2.5.4.8": "State or Province",
+    "2.5.4.9": "Street Address",
+    "2.5.4.97": "Organization Identifier",
+    "2.5.4.10": "Organization Name",
+    "2.5.4.11": "Organizational Unit Name",
+    "2.5.4.5": "Serial Number",
+    "2.5.4.4": "Surname",
+    "2.5.4.42": "Given Name",
+    "2.5.4.12": "Title",
+    "2.5.4.43": "Initials",
+    "2.5.4.44": "Generation Qualifier",
+    "2.5.4.45": "X500 Unique Identifier",
+    "2.5.4.46": "Dn Qualifier",
+    "2.5.4.65": "Pseudonym",
+    "0.9.2342.19200300.100.1.1": "User Id",
+    "0.9.2342.19200300.100.1.25": "Domain Component",
+    "1.2.840.113549.1.9.1": "Email Address",
+    "1.3.6.1.4.1.311.60.2.1.3": "Jurisdiction Country-Name",
+    "1.3.6.1.4.1.311.60.2.1.1": "Jurisdiction Locality-Name",
+    "1.3.6.1.4.1.311.60.2.1.2": "Jurisdiction State Or Province Name",
+    "2.5.4.15": "Business Category",
+    "2.5.4.16": "Postal Address",
+    "2.5.4.17": "Postal Code",
+    "1.2.643.3.131.1.1": "Inn",
+    "1.2.643.100.1": "Ogrn",
+    "1.2.643.100.3": "Snils",
+    "1.2.840.113549.1.9.2": "Unstructured Name",
+    // OID for pkcs-9-at-extensionRequest
+    "1.2.840.113549.1.9.14": "Extension Request",
+    // OID for basicConstraint
+    "2.5.29.19": "Basic Constraint",
+    "2.5.29.17": "Subject Alternative Name",
+    //
+    "2.5.29.15": "keyUsage",
+    "2.5.29.37": "extKeyUsage",
+    "2.5.29.14": "subjectKeyIdentifier",
+    "2.5.29.35": "authorityKeyIdentifier",
+    "2.5.29.31": "cRLDistributionPoints",
+  };
+  if (!(oid in map)) {
+    throw new Error("oid not recognized: " + oid);
+  }
+  return map[oid];
+};
 
 function pemToArrayBuffer(pem: string): ArrayBuffer {
-    const b64 = pem.replace(/(-----(BEGIN|END) [A-Z ]+-----|\n|\r)/g, "");
-    const binaryDerString = atob(b64);
-    const binaryDer = pvutils.stringToArrayBuffer(binaryDerString);
-    return binaryDer;
+  const b64 = pem.replace(/(-----(BEGIN|END) [A-Z ]+-----|\n|\r)/g, "");
+  const binaryDerString = atob(b64);
+  const binaryDer = pvutils.stringToArrayBuffer(binaryDerString);
+  return binaryDer;
 }
 
 function hexToIp(hex: ArrayBuffer): string {
-    const byteArray = new Uint8Array(hex);
-    return Array.from(byteArray).map(byte => byte.toString(10)).join('.');
+  const byteArray = new Uint8Array(hex);
+  return Array.from(byteArray)
+    .map((byte) => byte.toString(10))
+    .join(".");
 }
 
 function parseExtensions(extensions: Extensions) {
-    const sansDns: string[] = [];
-    const sansIp: string[] = [];
-    let is_ca = false;
+  const sansDns: string[] = [];
+  const sansIp: string[] = [];
+  let is_ca = false;
 
-    extensions.extensions.forEach(extension => {
-        let extensionName: string;
-        try {
-            extensionName = oidToName(extension.extnID);
-        } catch {
-            console.error(`Unrecognized extension OID: ${extension.extnID}`);
-            return;
-        }
+  extensions.extensions.forEach((extension) => {
+    let extensionName: string;
+    try {
+      extensionName = oidToName(extension.extnID);
+    } catch {
+      console.error(`Unrecognized extension OID: ${extension.extnID}`);
+      return;
+    }
 
-        if (extensionName === "Subject Alternative Name") {
+    if (extensionName === "Subject Alternative Name") {
+      // eslint-disable-next-line
+      extension.parsedValue.altNames.forEach(
+        (altName: { type: number; value: any }) => {
+          if (altName.type == 2) {
             // eslint-disable-next-line
-            extension.parsedValue.altNames.forEach((altName: { type: number; value: any; }) => {
-                if (altName.type == 2) {
-                    // eslint-disable-next-line
-                    sansDns.push(altName.value);
-                } else if (altName.type == 7) {
-                    // eslint-disable-next-line
-                    sansIp.push(hexToIp(altName.value.valueBlock.valueHex));
-                }
-            });
-        } else if (extensionName === "Basic Constraint") {
+            sansDns.push(altName.value);
+          } else if (altName.type == 7) {
             // eslint-disable-next-line
-            is_ca = extension.parsedValue.cA;
-        }
-    });
+            sansIp.push(hexToIp(altName.value.valueBlock.valueHex));
+          }
+        },
+      );
+    } else if (extensionName === "Basic Constraint") {
+      // eslint-disable-next-line
+      is_ca = extension.parsedValue.cA;
+    }
+  });
 
-    return { sansDns, sansIp, is_ca };
+  return { sansDns, sansIp, is_ca };
 }
 
 function loadCertificateRequest(csrPemString: string) {
-    const binaryDer = pemToArrayBuffer(csrPemString)
-    const asn1 = fromBER(binaryDer)
-    const csr = new CertificationRequest({ schema: asn1.result });
-    return csr
+  const binaryDer = pemToArrayBuffer(csrPemString);
+  const asn1 = fromBER(binaryDer);
+  const csr = new CertificationRequest({ schema: asn1.result });
+  return csr;
 }
 
 function loadCertificate(certPemString: string) {
-    const binaryDer = pemToArrayBuffer(certPemString)
-    const asn1 = fromBER(binaryDer)
-    if (asn1.offset === -1) {
-        throw new Error("Error parsing certificate");
-    }
-    const cert = new Certificate({ schema: asn1.result });
-    return cert
+  const binaryDer = pemToArrayBuffer(certPemString);
+  const asn1 = fromBER(binaryDer);
+  if (asn1.offset === -1) {
+    throw new Error("Error parsing certificate");
+  }
+  const cert = new Certificate({ schema: asn1.result });
+  return cert;
 }
 
 export const extractCSR = (csrPemString: string): CertificateSigningRequest => {
-    const csr = loadCertificateRequest(csrPemString);
+  const csr = loadCertificateRequest(csrPemString);
 
-    // Extract subject information from CSR
-    const subjects = csr.subject.typesAndValues.map(typeAndValue => ({
-        type: oidToName(typeAndValue.type),
-        value: typeAndValue.value.valueBlock.value
-    }));
-    const getValue = (type: string) => subjects.find(subject => subject.type === type)?.value;
+  // Extract subject information from CSR
+  const subjects = csr.subject.typesAndValues.map((typeAndValue) => ({
+    type: oidToName(typeAndValue.type),
+    value: typeAndValue.value.valueBlock.value,
+  }));
+  const getValue = (type: string) =>
+    subjects.find((subject) => subject.type === type)?.value;
 
-    const commonName = getValue("Common Name");
-    const organization = getValue("Organization Name");
-    const emailAddress = getValue("Email Address");
-    const country = getValue("Country");
-    const locality = getValue("Locality");
-    const stateOrProvince = getValue("State or Province");
-    const OrganizationalUnitName = getValue("Organizational Unit Name");
+  const commonName = getValue("Common Name");
+  const organization = getValue("Organization Name");
+  const emailAddress = getValue("Email Address");
+  const country = getValue("Country");
+  const locality = getValue("Locality");
+  const stateOrProvince = getValue("State or Province");
+  const OrganizationalUnitName = getValue("Organizational Unit Name");
 
-    let sansDns: string[] = [];
-    let sansIp: string[] = [];
-    let is_ca = false;
+  let sansDns: string[] = [];
+  let sansIp: string[] = [];
+  let is_ca = false;
 
-    if (csr.attributes) {
-        const extensionAttributes = csr.attributes.filter(attribute => oidToName(attribute.type) === "Extension Request");
-        if (extensionAttributes.length > 0) {
-            const extensions = new Extensions({ schema: extensionAttributes[0].values[0] });
-            ({ sansDns, sansIp, is_ca } = parseExtensions(extensions));
-        }
+  if (csr.attributes) {
+    const extensionAttributes = csr.attributes.filter(
+      (attribute) => oidToName(attribute.type) === "Extension Request",
+    );
+    if (extensionAttributes.length > 0) {
+      const extensions = new Extensions({
+        schema: extensionAttributes[0].values[0],
+      });
+      ({ sansDns, sansIp, is_ca } = parseExtensions(extensions));
     }
-    return {
-        commonName,
-        stateOrProvince,
-        OrganizationalUnitName,
-        organization,
-        emailAddress,
-        country,
-        locality,
-        sansDns,
-        sansIp,
-        is_ca
-    }
-}
+  }
+  return {
+    commonName,
+    stateOrProvince,
+    OrganizationalUnitName,
+    organization,
+    emailAddress,
+    country,
+    locality,
+    sansDns,
+    sansIp,
+    is_ca,
+  };
+};
 
 export const csrIsValid = (csrPemString: string) => {
-    try {
-        extractCSR(csrPemString.trim());
-        return true;
-    } catch {
-        return false;
-    }
-}
-
+  try {
+    extractCSR(csrPemString.trim());
+    return true;
+  } catch {
+    return false;
+  }
+};
 
 export const extractCert = (certPemString: string) => {
-    if (certPemString === "" || certPemString === "rejected") {
-        return null;
-    }
+  if (certPemString === "" || certPemString === "rejected") {
+    return null;
+  }
 
-    const cert = loadCertificate(certPemString)
+  const cert = loadCertificate(certPemString);
 
-    const subjects = cert.subject.typesAndValues.map(typeAndValue => ({
-        type: oidToName(typeAndValue.type),
-        value: typeAndValue.value.valueBlock.value
-    }));
-    const issuerInfo = cert.issuer.typesAndValues.map(typeAndValue => ({
-        type: oidToName(typeAndValue.type),
-        value: typeAndValue.value.valueBlock.value
-    }));
-    const getSubjectValue = (type: string) => subjects.find(subject => subject.type === type)?.value;
-    const getIssuerValue = (type: string) => issuerInfo.find(info => info.type === type)?.value;
+  const subjects = cert.subject.typesAndValues.map((typeAndValue) => ({
+    type: oidToName(typeAndValue.type),
+    value: typeAndValue.value.valueBlock.value,
+  }));
+  const issuerInfo = cert.issuer.typesAndValues.map((typeAndValue) => ({
+    type: oidToName(typeAndValue.type),
+    value: typeAndValue.value.valueBlock.value,
+  }));
+  const getSubjectValue = (type: string) =>
+    subjects.find((subject) => subject.type === type)?.value;
+  const getIssuerValue = (type: string) =>
+    issuerInfo.find((info) => info.type === type)?.value;
 
-    const commonName = getSubjectValue("Common Name");
-    const organization = getSubjectValue("Organization Name");
-    const emailAddress = getSubjectValue("Email Address");
-    const country = getSubjectValue("Country");
-    const locality = getSubjectValue("Locality");
-    const stateOrProvince = getSubjectValue("State or Province");
-    const OrganizationalUnitName = getSubjectValue("Organizational Unit Name");
-    const issuerCommonName = getIssuerValue("Common Name");
-    const issuerOrganization = getIssuerValue("Organization Name");
-    const issuerEmailAddress = getIssuerValue("Email Address");
-    const issuerCountry = getIssuerValue("Country");
-    const issuerLocality = getIssuerValue("Locality");
-    const issuerStateOrProvince = getIssuerValue("State or Province");
-    const issuerOrganizationalUnitName = getIssuerValue("Organizational Unit Name");
+  const commonName = getSubjectValue("Common Name");
+  const organization = getSubjectValue("Organization Name");
+  const emailAddress = getSubjectValue("Email Address");
+  const country = getSubjectValue("Country");
+  const locality = getSubjectValue("Locality");
+  const stateOrProvince = getSubjectValue("State or Province");
+  const OrganizationalUnitName = getSubjectValue("Organizational Unit Name");
+  const issuerCommonName = getIssuerValue("Common Name");
+  const issuerOrganization = getIssuerValue("Organization Name");
+  const issuerEmailAddress = getIssuerValue("Email Address");
+  const issuerCountry = getIssuerValue("Country");
+  const issuerLocality = getIssuerValue("Locality");
+  const issuerStateOrProvince = getIssuerValue("State or Province");
+  const issuerOrganizationalUnitName = getIssuerValue(
+    "Organizational Unit Name",
+  );
 
-    const notBeforeUnformatted = cert.notBefore.value.toString();
-    const notBefore = notBeforeUnformatted ? notBeforeUnformatted.replace(/\s*\(.+\)/, '') : '';
-    const notAfterUnformatted = cert.notAfter.value.toString();
-    const notAfter = notAfterUnformatted ? notAfterUnformatted.replace(/\s*\(.+\)/, '') : '';
+  const notBeforeUnformatted = cert.notBefore.value.toString();
+  const notBefore = notBeforeUnformatted
+    ? notBeforeUnformatted.replace(/\s*\(.+\)/, "")
+    : "";
+  const notAfterUnformatted = cert.notAfter.value.toString();
+  const notAfter = notAfterUnformatted
+    ? notAfterUnformatted.replace(/\s*\(.+\)/, "")
+    : "";
 
-    // Extract extensions such as SANs and Basic Constraints
-    let sansDns: string[] = [];
-    let sansIp: string[] = [];
-    let is_ca = false;
+  // Extract extensions such as SANs and Basic Constraints
+  let sansDns: string[] = [];
+  let sansIp: string[] = [];
+  let is_ca = false;
 
-    if (cert.extensions) {
-        // Correctly handle extensions by creating a new Extensions object
-        const extensionsInstance = new Extensions({ extensions: cert.extensions });
-        const ext = parseExtensions(extensionsInstance);
-        sansDns = ext.sansDns;
-        sansIp = ext.sansIp;
-        is_ca = ext.is_ca;
-    }
-    return {
-        commonName,
-        stateOrProvince,
-        OrganizationalUnitName,
-        organization,
-        emailAddress,
-        country,
-        locality,
-        sansDns,
-        sansIp,
-        is_ca,
-        notBefore,
-        notAfter,
-        issuerCommonName,
-        issuerOrganization,
-        issuerEmailAddress,
-        issuerCountry,
-        issuerLocality,
-        issuerStateOrProvince,
-        issuerOrganizationalUnitName,
-    };
-}
+  if (cert.extensions) {
+    // Correctly handle extensions by creating a new Extensions object
+    const extensionsInstance = new Extensions({ extensions: cert.extensions });
+    const ext = parseExtensions(extensionsInstance);
+    sansDns = ext.sansDns;
+    sansIp = ext.sansIp;
+    is_ca = ext.is_ca;
+  }
+  return {
+    commonName,
+    stateOrProvince,
+    OrganizationalUnitName,
+    organization,
+    emailAddress,
+    country,
+    locality,
+    sansDns,
+    sansIp,
+    is_ca,
+    notBefore,
+    notAfter,
+    issuerCommonName,
+    issuerOrganization,
+    issuerEmailAddress,
+    issuerCountry,
+    issuerLocality,
+    issuerStateOrProvince,
+    issuerOrganizationalUnitName,
+  };
+};
 
-export const csrMatchesCertificate = (csrPemString: string, certPemString: string) => {
-    const cert = loadCertificate(certPemString);
-    const csr = loadCertificateRequest(csrPemString);
+export const csrMatchesCertificate = (
+  csrPemString: string,
+  certPemString: string,
+) => {
+  const cert = loadCertificate(certPemString);
+  const csr = loadCertificateRequest(csrPemString);
 
-    const csrPKbytes = csr.subjectPublicKeyInfo.subjectPublicKey.valueBeforeDecodeView
-    const certPKbytes = cert.subjectPublicKeyInfo.subjectPublicKey.valueBeforeDecodeView
-    return csrPKbytes.toString() == certPKbytes.toString()
-}
+  const csrPKbytes =
+    csr.subjectPublicKeyInfo.subjectPublicKey.valueBeforeDecodeView;
+  const certPKbytes =
+    cert.subjectPublicKeyInfo.subjectPublicKey.valueBeforeDecodeView;
+  return csrPKbytes.toString() == certPKbytes.toString();
+};
 
 export const HTTPStatus = (code: number): string => {
-    const map: { [key: number]: string } = {
-        400: "Bad Request",
-        401: "Unauthorized",
-        403: "Forbidden",
-        404: "Not Found",
-        500: "Internal Server Error",
-    }
-    if (!(code in map)) {
-        throw new Error("code not recognized: " + code)
-    }
-    return map[code]
-}
+  const map: { [key: number]: string } = {
+    400: "Bad Request",
+    401: "Unauthorized",
+    403: "Forbidden",
+    404: "Not Found",
+    500: "Internal Server Error",
+  };
+  if (!(code in map)) {
+    throw new Error("code not recognized: " + code);
+  }
+  return map[code];
+};
 
 export const passwordIsValid = (pw: string) => {
-    if (pw.length < 8) return false
+  if (pw.length < 8) return false;
 
-    const result = {
-        hasCapital: false,
-        hasLowercase: false,
-        hasSymbol: false,
-        hasNumber: false
-    };
+  const result = {
+    hasCapital: false,
+    hasLowercase: false,
+    hasSymbol: false,
+    hasNumber: false,
+  };
 
-    if (/[A-Z]/.test(pw)) {
-        result.hasCapital = true;
-    }
-    if (/[a-z]/.test(pw)) {
-        result.hasLowercase = true;
-    }
-    if (/[0-9]/.test(pw)) {
-        result.hasNumber = true;
-    }
-    if (/[^A-Za-z0-9]/.test(pw)) {
-        result.hasSymbol = true;
-    }
+  if (/[A-Z]/.test(pw)) {
+    result.hasCapital = true;
+  }
+  if (/[a-z]/.test(pw)) {
+    result.hasLowercase = true;
+  }
+  if (/[0-9]/.test(pw)) {
+    result.hasNumber = true;
+  }
+  if (/[^A-Za-z0-9]/.test(pw)) {
+    result.hasSymbol = true;
+  }
 
-    if (result.hasCapital && result.hasLowercase && (result.hasSymbol || result.hasNumber)) {
-        return true
-    }
-    return false
-}
+  if (
+    result.hasCapital &&
+    result.hasLowercase &&
+    (result.hasSymbol || result.hasNumber)
+  ) {
+    return true;
+  }
+  return false;
+};
 
 export const splitBundle = (bundle: string): string[] => {
-    const pemPattern = /-----BEGIN CERTIFICATE-----(?:.|\n)*?-----END CERTIFICATE-----/g;
-    const pemMatches = bundle.match(pemPattern);
-    return pemMatches ? pemMatches.map((e) => e.toString()) : [];
-}
+  const pemPattern =
+    /-----BEGIN CERTIFICATE-----(?:.|\n)*?-----END CERTIFICATE-----/g;
+  const pemMatches = bundle.match(pemPattern);
+  return pemMatches ? pemMatches.map((e) => e.toString()) : [];
+};
 
 export const validateBundle = async (bundle: string) => {
-    const bundleList = splitBundle(bundle)
-    const extractedCerts = bundleList.map((cert) => loadCertificate(cert))
-    const rootCa = extractedCerts.at(-1)
-    if (rootCa == undefined) {
-        return "less than 2 certificates found."
-    }
-    const chainEngine = new CertificateChainValidationEngine({
-        certs: extractedCerts,
-        trustedCerts: [rootCa]
-    })
-    const result = await chainEngine.verify()
-    return result.resultMessage
-}
+  const bundleList = splitBundle(bundle);
+  const extractedCerts = bundleList.map((cert) => loadCertificate(cert));
+  const rootCa = extractedCerts.at(-1);
+  if (rootCa == undefined) {
+    return "less than 2 certificates found.";
+  }
+  const chainEngine = new CertificateChainValidationEngine({
+    certs: extractedCerts,
+    trustedCerts: [rootCa],
+  });
+  const result = await chainEngine.verify();
+  return result.resultMessage;
+};
 
-export const retryUnlessUnauthorized = (failureCount: number, error: Error): boolean => {
-    if (error.message.includes("401")) {
-        return false
-    }
-    return true
-}
+export const retryUnlessUnauthorized = (
+  failureCount: number,
+  error: Error,
+): boolean => {
+  if (error.message.includes("401")) {
+    return false;
+  }
+  return true;
+};

--- a/ui/src/validators.ts
+++ b/ui/src/validators.ts
@@ -1,5 +1,5 @@
 // This file contains the validation functions for forms in Notary
-// A validator function takes in at least the value to be validated, and returns a 
+// A validator function takes in at least the value to be validated, and returns a
 // validationResult object. The validationResult object contains three properties:
 // error, caution, and success. Each of these properties is a string that contains
 // the validation message. The error property is used to indicate that the value is
@@ -8,86 +8,86 @@
 // valid.
 
 export type validationResult = {
-    error: string
-    caution: string
-    success: string
-}
+  error: string;
+  caution: string;
+  success: string;
+};
 
 export function validateCommonName(value: string): validationResult {
-    const vr: validationResult = { error: "", caution: "", success: "" };
-    if (value.length == 0) {
-        return vr
-    }
-    if (value.length < 1 || value.length > 64) {
-        vr.error = "must be between 1 and 64 characters"
-    }
-    return vr
+  const vr: validationResult = { error: "", caution: "", success: "" };
+  if (value.length == 0) {
+    return vr;
+  }
+  if (value.length < 1 || value.length > 64) {
+    vr.error = "must be between 1 and 64 characters";
+  }
+  return vr;
 }
 
 export function validateOrganizationName(value: string): validationResult {
-    const vr: validationResult = { error: "", caution: "", success: "" };
-    if (value.length == 0) {
-        return vr
-    }
-    if (value.length < 1 || value.length > 64) {
-        vr.caution = "must be between 1 and 64 characters"
-    }
-    return vr
+  const vr: validationResult = { error: "", caution: "", success: "" };
+  if (value.length == 0) {
+    return vr;
+  }
+  if (value.length < 1 || value.length > 64) {
+    vr.caution = "must be between 1 and 64 characters";
+  }
+  return vr;
 }
 
 export function validateOrganizationalUnit(value: string): validationResult {
-    const vr: validationResult = { error: "", caution: "", success: "" };
-    if (value.length == 0) {
-        return vr
-    }
-    if (value.length < 1 || value.length > 64) {
-        vr.caution = "must be between 1 and 64 characters"
-    }
-    return vr
+  const vr: validationResult = { error: "", caution: "", success: "" };
+  if (value.length == 0) {
+    return vr;
+  }
+  if (value.length < 1 || value.length > 64) {
+    vr.caution = "must be between 1 and 64 characters";
+  }
+  return vr;
 }
 
 export function validateCountryName(value: string): validationResult {
-    const vr: validationResult = { error: "", caution: "", success: "" };
-    if (value.length == 0) {
-        return vr
-    }
-    if (value.length !== 2) {
-        vr.error = "must be exactly 2 characters"
-    }
-    if (value !== value.toUpperCase()) {
-        vr.error = "must be uppercase letters"
-    }
-    return vr
+  const vr: validationResult = { error: "", caution: "", success: "" };
+  if (value.length == 0) {
+    return vr;
+  }
+  if (value.length !== 2) {
+    vr.error = "must be exactly 2 characters";
+  }
+  if (value !== value.toUpperCase()) {
+    vr.error = "must be uppercase letters";
+  }
+  return vr;
 }
 
 export function validateStateOrProvinceName(value: string): validationResult {
-    const vr: validationResult = { error: "", caution: "", success: "" };
-    if (value.length == 0) {
-        return vr
-    }
-    if (value.length < 1 || value.length > 64) {
-        vr.error = "must be between 1 and 64 characters"
-    }
-    return vr
+  const vr: validationResult = { error: "", caution: "", success: "" };
+  if (value.length == 0) {
+    return vr;
+  }
+  if (value.length < 1 || value.length > 64) {
+    vr.error = "must be between 1 and 64 characters";
+  }
+  return vr;
 }
 
 export function validateLocalityName(value: string): validationResult {
-    const vr: validationResult = { error: "", caution: "", success: "" };
-    if (value.length == 0) {
-        return vr
-    }
-    if (value.length < 1 || value.length > 64) {
-        vr.error = "must be between 1 and 64 characters"
-    }
-    return vr
+  const vr: validationResult = { error: "", caution: "", success: "" };
+  if (value.length == 0) {
+    return vr;
+  }
+  if (value.length < 1 || value.length > 64) {
+    vr.error = "must be between 1 and 64 characters";
+  }
+  return vr;
 }
 
 export function validateNotAfter(value: string): validationResult {
-    const vr: validationResult = { error: "", caution: "", success: "" };
-    const date = new Date(value);
-    const now = new Date();
-    if (date < now) {
-        vr.caution = "This date is in the past";
-    }
-    return vr
+  const vr: validationResult = { error: "", caution: "", success: "" };
+  const date = new Date(value);
+  const now = new Date();
+  if (date < now) {
+    vr.caution = "This date is in the past";
+  }
+  return vr;
 }

--- a/ui/src/validators.ts
+++ b/ui/src/validators.ts
@@ -14,7 +14,7 @@ export type validationResult = {
 }
 
 export function validateCommonName(value: string): validationResult {
-    let vr: validationResult = { error: "", caution: "", success: "" };
+    const vr: validationResult = { error: "", caution: "", success: "" };
     if (value.length == 0) {
         return vr
     }
@@ -25,7 +25,7 @@ export function validateCommonName(value: string): validationResult {
 }
 
 export function validateOrganizationName(value: string): validationResult {
-    let vr: validationResult = { error: "", caution: "", success: "" };
+    const vr: validationResult = { error: "", caution: "", success: "" };
     if (value.length == 0) {
         return vr
     }
@@ -36,7 +36,7 @@ export function validateOrganizationName(value: string): validationResult {
 }
 
 export function validateOrganizationalUnit(value: string): validationResult {
-    let vr: validationResult = { error: "", caution: "", success: "" };
+    const vr: validationResult = { error: "", caution: "", success: "" };
     if (value.length == 0) {
         return vr
     }
@@ -47,7 +47,7 @@ export function validateOrganizationalUnit(value: string): validationResult {
 }
 
 export function validateCountryName(value: string): validationResult {
-    let vr: validationResult = { error: "", caution: "", success: "" };
+    const vr: validationResult = { error: "", caution: "", success: "" };
     if (value.length == 0) {
         return vr
     }
@@ -61,7 +61,7 @@ export function validateCountryName(value: string): validationResult {
 }
 
 export function validateStateOrProvinceName(value: string): validationResult {
-    let vr: validationResult = { error: "", caution: "", success: "" };
+    const vr: validationResult = { error: "", caution: "", success: "" };
     if (value.length == 0) {
         return vr
     }
@@ -72,7 +72,7 @@ export function validateStateOrProvinceName(value: string): validationResult {
 }
 
 export function validateLocalityName(value: string): validationResult {
-    let vr: validationResult = { error: "", caution: "", success: "" };
+    const vr: validationResult = { error: "", caution: "", success: "" };
     if (value.length == 0) {
         return vr
     }
@@ -83,7 +83,7 @@ export function validateLocalityName(value: string): validationResult {
 }
 
 export function validateNotAfter(value: string): validationResult {
-    let vr: validationResult = { error: "", caution: "", success: "" };
+    const vr: validationResult = { error: "", caution: "", success: "" };
     const date = new Date(value);
     const now = new Date();
     if (date < now) {


### PR DESCRIPTION
# Description

This PR introduces prettier for formatting the frontend and an eslint configuration to enforce typescript and react code styles. Future PR's including this one will not be passing if the linting fails. 

I've disabled some lines that would require more advanced types than would be necessary for this PR, and simply fixed the low hanging fruit when it comes to the linting errors.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
