### PR TITLE
feat: certificate authority management page

### DIFF
--- a/internal/db/db_certificate_authorities.go
+++ b/internal/db/db_certificate_authorities.go
@@ -444,9 +444,6 @@ func (db *Database) SignCertificateRequest(csrFilter CSRFilter, caFilter Certifi
 	if err != nil {
 		return err
 	}
-	if csrRow.CertificateID != 0 {
-		return errors.New("CSR already signed. please renew instead")
-	}
 	if caRow.CertificateChain == "" {
 		return errors.New("CA does not have a valid signed certificate to sign certificates")
 	}
@@ -462,6 +459,11 @@ func (db *Database) SignCertificateRequest(csrFilter CSRFilter, caFilter Certifi
 	certChain, err := ParseCertificateChain(caRow.CertificateChain)
 	if err != nil {
 		return err
+	}
+	wasSelfSigned := false
+	if csrRow.CSR == caRow.CSRPEM {
+		log.Println("thissa self sign")
+		wasSelfSigned = true
 	}
 	block, _ = pem.Decode([]byte(caRow.PrivateKeyPEM))
 	caPrivateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
@@ -515,9 +517,16 @@ func (db *Database) SignCertificateRequest(csrFilter CSRFilter, caFilter Certifi
 		return err
 	}
 	if CSRIsForACertificateAuthority {
-		err := db.UpdateCertificateAuthorityCertificate(ByCertificateAuthorityID(caToBeSigned.CertificateAuthorityID), certPEM.String()+caRow.CertificateChain)
-		if err != nil {
-			return err
+		if wasSelfSigned {
+			err := db.UpdateCertificateAuthorityCertificate(ByCertificateAuthorityID(caToBeSigned.CertificateAuthorityID), certPEM.String()+certPEM.String())
+			if err != nil {
+				return err
+			}
+		} else {
+			err := db.UpdateCertificateAuthorityCertificate(ByCertificateAuthorityID(caToBeSigned.CertificateAuthorityID), certPEM.String()+caRow.CertificateChain)
+			if err != nil {
+				return err
+			}
 		}
 	} else {
 		_, err = db.AddCertificateChainToCertificateRequest(csrFilter, certPEM.String()+caRow.CertificateChain)
@@ -575,10 +584,10 @@ func (db *Database) RevokeCertificate(filter CSRFilter) error {
 		return err
 	}
 
-	// Check if the certificate being revoked belongs to a CA, if so, set its status to legacy
+	// Check if the certificate being revoked belongs to a CA, if so, set its status to pending
 	revokedCA, err := db.GetCertificateAuthority(ByCertificateAuthorityCertificateID(certToRevoke.CertificateID))
 	if rowFound(err) {
-		err = db.UpdateCertificateAuthorityStatus(ByCertificateAuthorityID(revokedCA.CertificateAuthorityID), CALegacy)
+		err = db.UpdateCertificateAuthorityStatus(ByCertificateAuthorityID(revokedCA.CertificateAuthorityID), CAPending)
 		if err != nil {
 			return err
 		}

--- a/internal/db/db_certificate_authorities.go
+++ b/internal/db/db_certificate_authorities.go
@@ -460,10 +460,7 @@ func (db *Database) SignCertificateRequest(csrFilter CSRFilter, caFilter Certifi
 	if err != nil {
 		return err
 	}
-	wasSelfSigned := false
-	if csrRow.CSR == caRow.CSRPEM {
-		wasSelfSigned = true
-	}
+	wasSelfSigned := csrRow.CSR == caRow.CSRPEM
 	block, _ = pem.Decode([]byte(caRow.PrivateKeyPEM))
 	caPrivateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err != nil {

--- a/internal/db/db_certificate_authorities.go
+++ b/internal/db/db_certificate_authorities.go
@@ -462,7 +462,6 @@ func (db *Database) SignCertificateRequest(csrFilter CSRFilter, caFilter Certifi
 	}
 	wasSelfSigned := false
 	if csrRow.CSR == caRow.CSRPEM {
-		log.Println("thissa self sign")
 		wasSelfSigned = true
 	}
 	block, _ = pem.Decode([]byte(caRow.PrivateKeyPEM))

--- a/internal/server/handlers_certificate_authorities.go
+++ b/internal/server/handlers_certificate_authorities.go
@@ -275,9 +275,9 @@ func CreateCertificateAuthority(env *HandlerConfig) http.HandlerFunc {
 		}
 		var newCAID int64
 		if certPEM != "" {
-			newCAID, err = env.DB.CreateCertificateAuthority(csrPEM, privPEM, crlPEM, certPEM+certPEM)
+			newCAID, err = env.DB.CreateCertificateAuthority(strings.TrimSpace(csrPEM), strings.TrimSpace(privPEM), strings.TrimSpace(crlPEM), strings.TrimSpace(certPEM+certPEM))
 		} else {
-			newCAID, err = env.DB.CreateCertificateAuthority(csrPEM, privPEM, "", "")
+			newCAID, err = env.DB.CreateCertificateAuthority(strings.TrimSpace(csrPEM), strings.TrimSpace(privPEM), "", "")
 		}
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "Failed to create certificate authority")

--- a/internal/server/handlers_certificate_authorities.go
+++ b/internal/server/handlers_certificate_authorities.go
@@ -407,7 +407,6 @@ func DeleteCertificateAuthority(env *HandlerConfig) http.HandlerFunc {
 // It returns a 201 Created on success
 func PostCertificateAuthorityCertificate(env *HandlerConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		log.Println("i live")
 		id := r.PathValue("id")
 		idNum, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {

--- a/internal/server/handlers_certificate_authorities_test.go
+++ b/internal/server/handlers_certificate_authorities_test.go
@@ -1292,7 +1292,6 @@ func TestUnsuccessfulRequestsMadeToCACSRs(t *testing.T) {
 
 	t.Run("4. Get CSRs - only 1 should appear", func(t *testing.T) {
 		statusCode, listCertsResponse, err := listCertificateRequests(ts.URL, client, adminToken)
-		fmt.Println(listCertsResponse.Result)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/server/handlers_certificate_authorities_test.go
+++ b/internal/server/handlers_certificate_authorities_test.go
@@ -1644,8 +1644,8 @@ func TestCertificateRevocationListsEndToEnd(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected no error, got: %s", err)
 		}
-		if cas.Result[1].Status != "legacy" {
-			t.Fatalf("expected revoked intermediate CA to have legacy status")
+		if cas.Result[1].Status != "pending" {
+			t.Fatalf("expected revoked intermediate CA to have pending status")
 		}
 		if cas.Result[1].CertificatePEM != "" {
 			t.Fatalf("expected revoked intermediate CA to not have a certificate")

--- a/ui/src/app/(notary)/certificate_authorities/asideForm.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/asideForm.tsx
@@ -1,0 +1,225 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCookies } from "react-cookie";
+import { postCA } from "@/queries";
+import { ChangeEvent, useState, Dispatch, SetStateAction } from "react";
+import { Button, Input, Panel, Form, Notification } from "@canonical/react-components";
+import { validationResult, validateCommonName, validateOrganizationName, validateOrganizationalUnit, validateCountryName, validateStateOrProvinceName, validateLocalityName, validateNotAfter } from "@/validators";
+
+type AsideProps = {
+  setAsideOpen: Dispatch<SetStateAction<boolean>>
+};
+
+export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: AsideProps): JSX.Element {
+  const queryClient = useQueryClient();
+  const [cookies] = useCookies(['user_token']);
+
+  const [isSelfSigned, setIsSelfSigned] = useState<boolean | null>(null);
+
+  const [commonName, setCommonName] = useState<string>("");
+  const [commonNameValidation, setCommonNameValidation] = useState<validationResult>({ error: "", caution: "", success: "" });
+  const [organizationName, setOrganizationName] = useState<string>("");
+  const [organizationNameValidation, setOrganizationNameValidation] = useState<validationResult>({ error: "", caution: "", success: "" });
+  const [organizationalUnit, setOrganizationalUnit] = useState<string>("");
+  const [organizationalUnitValidation, setOrganizationalUnitValidation] = useState<validationResult>({ error: "", caution: "", success: "" });
+  const [countryName, setCountryName] = useState<string>("");
+  const [countryNameValidation, setCountryNameValidation] = useState<validationResult>({ error: "", caution: "", success: "" });
+  const [stateOrProvinceName, setStateOrProvinceName] = useState<string>("");
+  const [stateOrProvinceNameValidation, setStateOrProvinceNameValidation] = useState<validationResult>({ error: "", caution: "", success: "" });
+  const [localityName, setLocalityName] = useState<string>("");
+  const [localityNameValidation, setLocalityNameValidation] = useState<validationResult>({ error: "", caution: "", success: "" });
+  const [notValidAfter, setNotValidAfter] = useState<string>("");
+  const [notValidAfterValidation, setNotValidAfterValidation] = useState<validationResult>({ error: "", caution: "", success: "" });
+  const [formError, setFormError] = useState<string>("");
+
+  const mutation = useMutation({
+    mutationFn: postCA,
+    onSuccess: () => {
+      setFormError("");
+      setAsideOpen(false);
+      queryClient.invalidateQueries({ queryKey: ['cas'] });
+    },
+    onError: (e: Error) => {
+      setFormError(e.message);
+    }
+  });
+
+  const handleSubmit = () => {
+    mutation.mutate({
+      authToken: cookies.user_token,
+
+      SelfSigned: isSelfSigned ? isSelfSigned : false,
+
+      CommonName: commonName,
+      OrganizationName: organizationName,
+      OrganizationalUnit: organizationalUnit,
+      CountryName: countryName,
+      StateOrProvinceName: stateOrProvinceName,
+      LocalityName: localityName,
+
+      NotValidAfter: notValidAfter,
+    });
+  };
+
+  return (
+    <Panel
+      title="Add a New Certificate Authority"
+      controls={
+        <Button onClick={() => setAsideOpen(false)} hasIcon>
+          <i className="p-icon--close" />
+        </Button>
+      }
+    >
+      <Form stacked>
+        {isSelfSigned === null &&
+          <div className="p-form__group row">
+            <Input
+              label="Self-Signed"
+              id="self-signed"
+              type="radio"
+              name="ca-type"
+              checked={isSelfSigned == true}
+              onChange={(e) => setIsSelfSigned(true)}
+              help="This is a self-signed certificate authority."
+            />
+            <Input
+              label="Intermediate-Signed"
+              id="self-signed"
+              type="radio"
+              name="ca-type"
+              checked={isSelfSigned == false}
+              onChange={(e) => setIsSelfSigned(false)}
+              help="This is an intermediate certificate"
+            />
+          </div>
+        }
+        {isSelfSigned !== null &&
+          <>
+            <div className="p-form__group row">
+              <Button hasIcon onClick={() => setIsSelfSigned(null)}>
+                <i className="p-icon--chevron-left" />
+                {' '}
+                <span> Back </span>
+              </Button>
+              <h4>{isSelfSigned ? "Root Certificate Authority" : "Intermediate Certificate Authority"}</h4>
+              <fieldset>
+                <legend>Subject</legend>
+                <Input
+                  label="Common Name"
+                  id="common-name"
+                  type="text"
+                  value={commonName}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => { setCommonName(e.target.value); setCommonNameValidation(validateCommonName(e.target.value)); }}
+                  error={commonNameValidation.error}
+                  caution={commonNameValidation.caution}
+                  success={commonNameValidation.success}
+                  stacked
+                />
+                <Input
+                  label="Organization Name"
+                  id="organization-name"
+                  type="text"
+                  value={organizationName}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => { setOrganizationName(e.target.value); setOrganizationNameValidation(validateOrganizationName(e.target.value)); }}
+                  error={organizationNameValidation.error}
+                  caution={organizationNameValidation.caution}
+                  success={organizationNameValidation.success}
+                  stacked
+                />
+                <Input
+                  label="Organizational Unit"
+                  id="organizational-unit"
+                  type="text"
+                  value={organizationalUnit}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => { setOrganizationalUnit(e.target.value); setOrganizationalUnitValidation(validateOrganizationalUnit(e.target.value)); }}
+                  error={organizationalUnitValidation.error}
+                  caution={organizationalUnitValidation.caution}
+                  success={organizationalUnitValidation.success}
+                  stacked
+                />
+                <Input
+                  label="Country Name"
+                  id="country-name"
+                  type="text"
+                  value={countryName}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => { setCountryName(e.target.value); setCountryNameValidation(validateCountryName(e.target.value)); }}
+                  error={countryNameValidation.error}
+                  caution={countryNameValidation.caution}
+                  success={countryNameValidation.success}
+                  stacked
+                />
+                <Input
+                  label="State or Province Name"
+                  id="state-or-province-name"
+                  type="text"
+                  value={stateOrProvinceName}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => { setStateOrProvinceName(e.target.value); setStateOrProvinceNameValidation(validateStateOrProvinceName(e.target.value)); }}
+                  error={stateOrProvinceNameValidation.error}
+                  caution={stateOrProvinceNameValidation.caution}
+                  success={stateOrProvinceNameValidation.success}
+                  stacked
+                />
+                <Input
+                  label="Locality Name"
+                  id="locality-name"
+                  type="text"
+                  value={localityName}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => { setLocalityName(e.target.value); setLocalityNameValidation(validateLocalityName(e.target.value)); }}
+                  error={localityNameValidation.error}
+                  caution={localityNameValidation.caution}
+                  success={localityNameValidation.success}
+                  stacked
+                />
+              </fieldset>
+              {isSelfSigned === true &&
+                <fieldset>
+                  <legend>Validity</legend>
+                  <Input
+                    label="Not Valid After"
+                    id="not-valid-after"
+                    type="datetime-local"
+                    value={notValidAfter}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => { setNotValidAfter(e.target.value); setNotValidAfterValidation(validateNotAfter(e.target.value)); }}
+                    error={notValidAfterValidation.error}
+                    caution={notValidAfterValidation.caution}
+                    success={notValidAfterValidation.success}
+                    stacked
+                  >
+                  </Input>
+                </fieldset>
+              }
+              {isSelfSigned === false &&
+                <small>Download the Certificate Signing Request and get it signed by the appropriate authority. Upload the certificate at any moment using the action button.</small>
+              }
+            </div>
+            <div className="p-form__group row">
+              {formError &&
+                <Notification
+                  severity="negative"
+                  title="Error"
+                >
+                  {formError.split("error: ")}
+                </Notification>
+              }
+              {mutation.isPending ?
+                <Button
+                  appearance="positive"
+                  name="submit"
+                  disabled={true}
+                  hasIcon
+                >
+                  <i className="p-icon--spinner u-animation--spin"></i>
+                </Button> : <Button
+                  appearance="positive"
+                  name="submit"
+                  onClick={(e) => { e.preventDefault(); handleSubmit() }}
+                >
+                  {isSelfSigned === true ? "Create Self Signed CA Certificate" : "Create Intermediate CA CSR"}
+                </Button>
+              }
+            </div>
+          </>
+        }
+      </Form>
+    </Panel >
+  );
+}

--- a/ui/src/app/(notary)/certificate_authorities/asideForm.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/asideForm.tsx
@@ -79,7 +79,7 @@ export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: Aside
               name="ca-type"
               checked={isSelfSigned == true}
               onChange={(e) => setIsSelfSigned(true)}
-              help="This is a self-signed certificate authority."
+              help="A self-signed certificate authority signs itself and acts as the root certificate for all other types of certificates."
             />
             <Input
               label="Intermediate"
@@ -88,7 +88,7 @@ export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: Aside
               name="ca-type"
               checked={isSelfSigned == false}
               onChange={(e) => setIsSelfSigned(false)}
-              help="This is an intermediate certificate authority"
+              help="An intermediate certificate authority is signed by a root certificate authority and can sign end certificates."
             />
           </div>
         }

--- a/ui/src/app/(notary)/certificate_authorities/asideForm.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/asideForm.tsx
@@ -88,7 +88,7 @@ export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: Aside
               name="ca-type"
               checked={isSelfSigned == false}
               onChange={(e) => setIsSelfSigned(false)}
-              help="This is an intermediate certificate"
+              help="This is an intermediate certificate authority"
             />
           </div>
         }

--- a/ui/src/app/(notary)/certificate_authorities/asideForm.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/asideForm.tsx
@@ -82,7 +82,7 @@ export default function CertificateAuthoritiesAsidePanel({ setAsideOpen }: Aside
               help="This is a self-signed certificate authority."
             />
             <Input
-              label="Intermediate-Signed"
+              label="Intermediate"
               id="self-signed"
               type="radio"
               name="ca-type"

--- a/ui/src/app/(notary)/certificate_authorities/components.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/components.tsx
@@ -1,0 +1,131 @@
+import { Dispatch, SetStateAction, useState, ChangeEvent, useEffect } from "react"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { csrMatchesCertificate, splitBundle, validateBundle } from "@/utils"
+import { postCertToCA } from "@/queries"
+import { useCookies } from "react-cookie"
+import { Button, Input, Textarea, Form, Modal, Icon } from "@canonical/react-components";
+
+interface SubmitCertificateModalProps {
+    id: string
+    csr: string
+    cert: string
+    setFormOpen: Dispatch<SetStateAction<boolean>>
+}
+
+export function SubmitCertificateModal({ id, csr, cert, setFormOpen }: SubmitCertificateModalProps) {
+    const [cookies] = useCookies(['user_token']);
+    const [errorText, setErrorText] = useState<string>("");
+    const [certificatePEMString, setCertificatePEMString] = useState<string>(cert);
+    const [validationErrorText, setValidationErrorText] = useState<string>("");
+    const queryClient = useQueryClient();
+
+    const mutation = useMutation({
+        mutationFn: postCertToCA,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['cas'] });
+            setErrorText("");
+            setFormOpen(false);
+        },
+        onError: (e: Error) => {
+            setErrorText(e.message);
+        }
+    });
+
+    const handleTextChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+        setCertificatePEMString(event.target.value);
+    };
+
+    const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        if (file) {
+            const reader = new FileReader();
+            reader.onload = (e: ProgressEvent<FileReader>) => {
+                if (e.target?.result) {
+                    setCertificatePEMString(e.target.result.toString());
+                }
+            };
+            reader.readAsText(file);
+        }
+    };
+
+    useEffect(() => {
+        const validateCertificate = async () => {
+            try {
+                const certs = splitBundle(certificatePEMString);
+                if (certs.length < 2) {
+                    setValidationErrorText("Bundle with 2 certificates required");
+                    return;
+                }
+                if (!csrMatchesCertificate(csr, certs[0])) {
+                    setValidationErrorText("Certificate does not match request");
+                    return;
+                }
+                const validationMessage = await validateBundle(certificatePEMString);
+                if (validationMessage !== "") {
+                    setValidationErrorText("Bundle validation failed: " + validationMessage);
+                    return;
+                }
+            } catch {
+                setValidationErrorText("A certificate is invalid");
+                return;
+            }
+            setValidationErrorText("");
+        };
+        validateCertificate();
+    }, [csr, certificatePEMString]);
+
+    return (
+        <Modal
+            title="Submit Certificate"
+            buttonRow={
+                <>
+                    <Button
+                        onClick={() => mutation.mutate({ id, authToken: cookies.user_token, certificate_chain: certificatePEMString })}
+                        appearance="positive"
+                        disabled={validationErrorText !== "" || certificatePEMString === ""}
+                    >
+                        Submit
+                    </Button>
+                    <Button onMouseDown={() => setFormOpen(false)}>
+                        Cancel
+                    </Button>
+                </>
+            }
+        >
+            <Form stacked={true}>
+                <div className="p-form__group row">
+                    <Textarea
+                        name="textarea"
+                        id="csr-textarea"
+                        label="Enter or upload the Certificate in PEM format below"
+                        placeholder="-----BEGIN CERTIFICATE-----"
+                        rows={10}
+                        onChange={handleTextChange}
+                        value={certificatePEMString}
+                        error={validationErrorText || errorText}
+                    />
+                </div>
+                <div className="p-form__group row">
+                    <Input
+                        type="file"
+                        name="upload"
+                        accept=".pem,.crt"
+                        onChange={handleFileChange}
+                    />
+                </div>
+            </Form>
+        </Modal>
+    );
+}
+
+export function SuccessNotification({ successMessage }: { successMessage: string }) {
+    const style = {
+        display: 'inline'
+    }
+    return (
+        <p style={style}>
+            <Icon name="success" />
+            {successMessage}
+        </p>
+    );
+}

--- a/ui/src/app/(notary)/certificate_authorities/page.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/page.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { CertificateAuthoritiesTable } from "./table"
+import { getCertificateAuthorities } from "@/queries"
+import { CertificateAuthorityEntry, CSREntry } from "@/types"
+import { useCookies } from "react-cookie"
+import { useRouter } from "next/navigation"
+import Loading from "@/components/loading"
+import Error from "@/components/error"
+import { useState } from "react"
+import { AppAside, Application, AppMain } from "@canonical/react-components"
+import CertificateAuthoritiesAsidePanel from "./asideForm"
+import NotaryAppNavigationBars from "@/components/NotaryAppNavigationBars"
+import { retryUnlessUnauthorized } from "@/utils"
+import NotaryAppStatus from "@/components/NotaryAppStatus"
+
+
+export default function CertificateRequestsPanel() {
+  const router = useRouter()
+  const [asideOpen, setAsideOpen] = useState<boolean>(false)
+  const [cookies, setCookie, removeCookie] = useCookies(['user_token']);
+
+  if (!cookies.user_token) {
+    router.push("/login")
+  }
+
+  const query = useQuery<CertificateAuthorityEntry[], Error>({
+    queryKey: ['cas', cookies.user_token],
+    queryFn: () => getCertificateAuthorities({ authToken: cookies.user_token }),
+    retry: retryUnlessUnauthorized,
+  })
+  if (query.status == "pending") { return <Loading /> }
+  if (query.status == "error") {
+    if (query.error.message.includes("401")) {
+      removeCookie("user_token")
+    }
+    return <Error msg={query.error.message} />
+  }
+  const cas = Array.from(query.data ? query.data : [])
+  return (
+    <Application>
+      <NotaryAppNavigationBars />
+      <AppAside collapsed={!asideOpen} pinned={true}>
+        <CertificateAuthoritiesAsidePanel setAsideOpen={setAsideOpen} />
+      </AppAside>
+      <AppMain>
+        <CertificateAuthoritiesTable cas={cas} setAsideOpen={setAsideOpen} />
+      </AppMain>
+      <NotaryAppStatus />
+    </Application>
+  )
+}

--- a/ui/src/app/(notary)/certificate_authorities/table.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/table.tsx
@@ -61,7 +61,7 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
       queryKey: "cas",
       closeFn: () => setConfirmationModalData(null),
       buttonConfirmText: "Revoke",
-      warningText: "Revoking a CA Certificate will prevent signing CSR's and issueing a new CRL with this CA. This action cannot be undone.",
+      warningText: "Revoking a CA Certificate will prevent signing CSR's and issuing a new CRL with this CA. This action cannot be undone.",
     });
   };
 

--- a/ui/src/app/(notary)/certificate_authorities/table.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/table.tsx
@@ -88,7 +88,7 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
       queryParams: { id: id.toString(), authToken: auth.user?.authToken || "" },
       closeFn: () => setConfirmationModalData(null),
       queryKey: "cas",
-      warningText: "Deleting a Certificate Authority means this row will be completely removed from the application. This action cannot be undone.",
+      warningText: "Deleting a Certificate Authority means the private key and the subject details of this CA will be removed. Deleting the CA does not revoke this certificate, and does not revoke any certificates this CA has signed. This action cannot be undone.",
       buttonConfirmText: "Delete",
     });
   };

--- a/ui/src/app/(notary)/certificate_authorities/table.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/table.tsx
@@ -159,7 +159,7 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
                 hasToggleIcon
                 position="right"
               >
-                {!isSelfSigned && caEntry.status !== "legacy" &&
+                {!isSelfSigned &&
                   <span className="p-contextual-menu__group">
                     <Button
                       className="p-contextual-menu__link"
@@ -178,49 +178,47 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
                     </Button>
                   </span>
                 }
-                {caEntry.certificate != "" &&
-                  <span className="p-contextual-menu__group">
+                <span className="p-contextual-menu__group">
+                  <Button
+                    className="p-contextual-menu__link"
+                    disabled={caEntry.status == "pending"}
+                    onMouseDown={() => handleExpand(caEntry.id, 'Cert')}>
+                    {isCertContentVisible ? "Hide Certificate Content" : "Show Certificate Content"}
+                  </Button>
+                  {!isSelfSigned &&
+                    <Button
+                      className="p-contextual-menu__link"
+                      disabled={auth.activeCA == null}
+                      onMouseDown={() => handleSign(caEntry.id)}>
+                      {caEntry.status === "active" ? "Re-sign CSR" : "Sign CSR"}
+                    </Button>
+                  }
+                  {isSelfSigned &&
+                    <Button
+                      className="p-contextual-menu__link"
+                      onMouseDown={() => handleSign(caEntry.id, caEntry.id)}>
+                      Renew Certificate
+                    </Button>
+                  }
+                  {!isSelfSigned &&
+                    <Button
+                      className="p-contextual-menu__link"
+                      onMouseDown={() => {
+                        setCertificateFormOpen(true);
+                        setSelectedCA(caEntry);
+                      }}>
+                      Upload New Certificate
+                    </Button>
+                  }
+                  {!isSelfSigned &&
                     <Button
                       className="p-contextual-menu__link"
                       disabled={caEntry.status == "pending"}
-                      onMouseDown={() => handleExpand(caEntry.id, 'Cert')}>
-                      {isCertContentVisible ? "Hide Certificate Content" : "Show Certificate Content"}
+                      onMouseDown={() => handleRevoke(caEntry.id)}>
+                      Revoke Certificate
                     </Button>
-                    {!isSelfSigned &&
-                      <Button
-                        className="p-contextual-menu__link"
-                        disabled={auth.activeCA == null}
-                        onMouseDown={() => handleSign(caEntry.id)}>
-                        {caEntry.status === "active" ? "Re-sign CSR" : "Sign CSR"}
-                      </Button>
-                    }
-                    {isSelfSigned && caEntry.status === "active" &&
-                      <Button
-                        className="p-contextual-menu__link"
-                        onMouseDown={() => handleSign(caEntry.id, caEntry.id)}>
-                        Renew Certificate
-                      </Button>
-                    }
-                    {!isSelfSigned &&
-                      <Button
-                        className="p-contextual-menu__link"
-                        onMouseDown={() => {
-                          setCertificateFormOpen(true);
-                          setSelectedCA(caEntry);
-                        }}>
-                        Upload New Certificate
-                      </Button>
-                    }
-                    {!isSelfSigned &&
-                      <Button
-                        className="p-contextual-menu__link"
-                        disabled={caEntry.status == "pending"}
-                        onMouseDown={() => handleRevoke(caEntry.id)}>
-                        Revoke Certificate
-                      </Button>
-                    }
-                  </span>
-                }
+                  }
+                </span>
                 <span className="p-contextual-menu__group">
                   {caEntry.status === "active" &&
                     <Button

--- a/ui/src/app/(notary)/certificate_authorities/table.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/table.tsx
@@ -227,7 +227,7 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
                       onMouseDown={() => {
                         auth.setActiveCA(caEntry);
                       }}>
-                      Select CA for Signing
+                      Set as default for signing CSRs
                     </Button>
                   }
                   {caEntry.status === "active" &&
@@ -237,11 +237,6 @@ export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TablePr
                       Make CA Legacy
                     </Button>
                   }
-                  <Button
-                    className="p-contextual-menu__link"
-                    onMouseDown={() => console.log("TODO")}>
-                    Revoke All Signed Certificates
-                  </Button>
                   <Button
                     className="p-contextual-menu__link"
                     onMouseDown={() => handleDelete(caEntry.id)}>

--- a/ui/src/app/(notary)/certificate_authorities/table.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/table.tsx
@@ -1,0 +1,375 @@
+import { useState, Dispatch, SetStateAction, useReducer, useRef } from "react";
+import { CertificateAuthorityEntry } from "@/types";
+import { Button, MainTable, Panel, EmptyState, ContextualMenu } from "@canonical/react-components";
+import { deleteCA, makeCALegacy, revokeCA, signCA } from "@/queries"
+import { extractCSR, extractCert, splitBundle } from "@/utils";
+import { useQueryClient } from "@tanstack/react-query"
+import { SubmitCertificateModal, SuccessNotification } from "./components"
+import { useAuth } from "@/hooks/useAuth";
+import { NotaryConfirmationModalData, NotaryConfirmationModal } from "@/components/NotaryConfirmationModal";
+
+
+type TableProps = {
+  cas: CertificateAuthorityEntry[];
+  setAsideOpen: Dispatch<SetStateAction<boolean>>
+};
+
+export function CertificateAuthoritiesTable({ cas: rows, setAsideOpen }: TableProps) {
+  const auth = useAuth();
+  const queryClient = useQueryClient();
+  const [certificateFormOpen, setCertificateFormOpen] = useState<boolean>(false);
+  const [confirmationModalData, setConfirmationModalData] = useState<NotaryConfirmationModalData | null>(null);
+  const [selectedCA, setSelectedCA] = useState<CertificateAuthorityEntry | null>(null);
+  const [showCACSRContent, setShowCACSRContent] = useState<number | null>(null);
+  const [showCACertificateContent, setShowCACertificateContent] = useState<number | null>(null);
+  const [successNotificationId, setSuccessNotificationId] = useState<number | null>(null);
+
+  const handleCopy = (csr: string, id: number) => {
+    navigator.clipboard.writeText(csr).then(() => {
+      setSuccessNotificationId(id);
+      setTimeout(() => setSuccessNotificationId(null), 2500);
+    });
+  };
+
+  const handleDownload = (csr: string, id: number, csrObj: any) => {
+    const blob = new Blob([csr], { type: 'text/plain' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = `csr-${csrObj.commonName || id}.pem`;
+    link.click();
+    URL.revokeObjectURL(link.href);
+  };
+
+  const handleSign = (id: number, override: number | null = null) => {
+    setConfirmationModalData({
+      queryFn: signCA,
+      queryParams: { id: id.toString(), authToken: auth.user?.authToken || "", certificate_authority_id: override ? override : auth.activeCA?.id },
+      queryKey: "cas",
+      closeFn: () => setConfirmationModalData(null),
+      buttonConfirmText: "Sign",
+      warningText: "Signing a CSR will create a new certificate and replace the old one. This action cannot be undone.",
+    });
+  };
+
+  const handleRevoke = (id: number) => {
+    if (id === auth.activeCA?.id) {
+      auth.setActiveCA(null);
+    }
+    setConfirmationModalData({
+      queryFn: revokeCA,
+      queryParams: { id: id.toString(), authToken: auth.user?.authToken || "" },
+      queryKey: "cas",
+      closeFn: () => setConfirmationModalData(null),
+      buttonConfirmText: "Revoke",
+      warningText: "Revoking a CA Certificate will prevent signing CSR's and issueing a new CRL with this CA. This action cannot be undone.",
+    });
+  };
+
+  const handleMakeLegacy = (id: number) => {
+    if (id === auth.activeCA?.id) {
+      auth.setActiveCA(null);
+    }
+    setConfirmationModalData({
+      queryFn: makeCALegacy,
+      queryParams: { id: id.toString(), authToken: auth.user?.authToken || "" },
+      queryKey: "cas",
+      closeFn: () => setConfirmationModalData(null),
+      buttonConfirmText: "Continue",
+      warningText: "Making a CA Certificate Legacy will prevent signing CSR's with or renewing the CA certificate, but will not revoke any signed certificates. This action cannot be undone.",
+    });
+  }
+
+  const handleDelete = (id: number) => {
+    if (id === auth.activeCA?.id) {
+      auth.setActiveCA(null);
+    }
+    setConfirmationModalData({
+      queryFn: deleteCA,
+      queryParams: { id: id.toString(), authToken: auth.user?.authToken || "" },
+      closeFn: () => setConfirmationModalData(null),
+      queryKey: "cas",
+      warningText: "Deleting a Certificate Authority means this row will be completely removed from the application. This action cannot be undone.",
+      buttonConfirmText: "Delete",
+    });
+  };
+
+  const handleExpand = (id: number, type: 'CSR' | 'Cert') => {
+    if (type === 'CSR') {
+      setShowCACSRContent(id === showCACSRContent ? null : id);
+      setShowCACertificateContent(null);
+    } else {
+      setShowCACertificateContent(id === showCACertificateContent ? null : id);
+      setShowCACSRContent(null);
+    }
+  };
+
+  const getExpiryColor = (notAfter?: string): string => {
+    if (!notAfter) return 'inherit';
+    const expiryDate = new Date(notAfter);
+    const now = new Date();
+    const timeDifference = expiryDate.getTime() - now.getTime();
+    if (timeDifference < 0) return "rgba(199, 22, 43, 1)";
+    if (timeDifference < 24 * 60 * 60 * 1000) return "rgba(249, 155, 17, 0.45)";
+    return "rgba(14, 132, 32, 0.35)";
+  };
+
+  const getFieldDisplay = (label: string, field: string | undefined, compareField?: string | undefined) => {
+    const isMismatched = compareField !== undefined && compareField !== field;
+    return field ? (
+      <p style={{ marginBottom: "4px" }}>
+        <b>{label}:</b>{" "}
+        <span style={{ color: isMismatched ? "rgba(199, 22, 43, 1)" : "inherit" }}>
+          {field}
+        </span>
+      </p>
+    ) : null;
+  };
+
+  const carows = rows.map((caEntry) => {
+    const csrObj = extractCSR(caEntry.csr);
+    const certs = splitBundle(caEntry.certificate);
+    const clientCertificate = certs?.at(0);
+    const certObj = clientCertificate ? extractCert(clientCertificate) : null;
+
+    const isSelfSigned = certs.length == 1;
+    const isCSRContentVisible = showCACSRContent === caEntry.id;
+    const isCertContentVisible = showCACertificateContent === caEntry.id;
+
+    return {
+      sortData: {
+        id: caEntry.id,
+        common_name: csrObj.commonName,
+        ca_status: caEntry.status,
+        cert_expiry_date: certObj?.notAfter || "",
+      },
+      columns: [
+        { content: caEntry.id.toString() },
+        { content: isSelfSigned ? "Self Signed" : "Intermediate" },
+        { content: csrObj.commonName || "N/A" },
+        { content: caEntry.status + (auth.activeCA?.id === caEntry.id ? " (selected)" : "") },
+        {
+          content: certObj?.notAfter || "",
+          style: { backgroundColor: getExpiryColor(certObj?.notAfter) },
+        },
+        {
+          content: (
+            <>
+              {successNotificationId === caEntry.id && <SuccessNotification successMessage="CSR copied to clipboard" />}
+              <ContextualMenu
+                hasToggleIcon
+                position="right"
+              >
+                {!isSelfSigned && caEntry.status !== "legacy" &&
+                  <span className="p-contextual-menu__group">
+                    <Button
+                      className="p-contextual-menu__link"
+                      onMouseDown={() => handleExpand(caEntry.id, 'CSR')}>
+                      {isCSRContentVisible ? "Hide CSR Content" : "Show CSR Content"}
+                    </Button>
+                    <Button
+                      className="p-contextual-menu__link"
+                      onMouseDown={() => handleCopy(caEntry.csr, caEntry.id)}>
+                      Copy CSR to Clipboard
+                    </Button>
+                    <Button
+                      className="p-contextual-menu__link"
+                      onMouseDown={() => handleDownload(caEntry.csr, caEntry.id, csrObj)}>
+                      Download CSR
+                    </Button>
+                  </span>
+                }
+                {caEntry.certificate != "" &&
+                  <span className="p-contextual-menu__group">
+                    <Button
+                      className="p-contextual-menu__link"
+                      disabled={caEntry.status == "pending"}
+                      onMouseDown={() => handleExpand(caEntry.id, 'Cert')}>
+                      {isCertContentVisible ? "Hide Certificate Content" : "Show Certificate Content"}
+                    </Button>
+                    {!isSelfSigned &&
+                      <Button
+                        className="p-contextual-menu__link"
+                        disabled={auth.activeCA == null}
+                        onMouseDown={() => handleSign(caEntry.id)}>
+                        {caEntry.status === "active" ? "Re-sign CSR" : "Sign CSR"}
+                      </Button>
+                    }
+                    {isSelfSigned && caEntry.status === "active" &&
+                      <Button
+                        className="p-contextual-menu__link"
+                        onMouseDown={() => handleSign(caEntry.id, caEntry.id)}>
+                        Renew Certificate
+                      </Button>
+                    }
+                    {!isSelfSigned &&
+                      <Button
+                        className="p-contextual-menu__link"
+                        onMouseDown={() => {
+                          setCertificateFormOpen(true);
+                          setSelectedCA(caEntry);
+                        }}>
+                        Upload New Certificate
+                      </Button>
+                    }
+                    {!isSelfSigned &&
+                      <Button
+                        className="p-contextual-menu__link"
+                        disabled={caEntry.status == "pending"}
+                        onMouseDown={() => handleRevoke(caEntry.id)}>
+                        Revoke Certificate
+                      </Button>
+                    }
+                  </span>
+                }
+                <span className="p-contextual-menu__group">
+                  {caEntry.status === "active" &&
+                    <Button
+                      className="p-contextual-menu__link"
+                      disabled={caEntry.status != "active" || auth.activeCA?.id === caEntry.id}
+                      onMouseDown={() => {
+                        auth.setActiveCA(caEntry);
+                      }}>
+                      Select CA for Signing
+                    </Button>
+                  }
+                  {caEntry.status === "active" &&
+                    <Button
+                      className="p-contextual-menu__link"
+                      onMouseDown={() => handleMakeLegacy(caEntry.id)}>
+                      Make CA Legacy
+                    </Button>
+                  }
+                  <Button
+                    className="p-contextual-menu__link"
+                    onMouseDown={() => console.log("TODO")}>
+                    Revoke All Signed Certificates
+                  </Button>
+                  <Button
+                    className="p-contextual-menu__link"
+                    onMouseDown={() => handleDelete(caEntry.id)}>
+                    Delete Certificate Authority
+                  </Button>
+                </span>
+              </ContextualMenu>
+            </>
+          ),
+          className: "u-align--right has-overflow",
+          style: { height: "58px", overflow: "hidden" },
+        },
+      ],
+      expanded: isCSRContentVisible || isCertContentVisible,
+      expandedContent: (
+        <div >
+          {isCSRContentVisible && (
+            <div >
+              <h4>Certificate Request Content</h4>
+              {getFieldDisplay("Common Name", csrObj.commonName)}
+              {getFieldDisplay("Subject Alternative Name DNS", csrObj.sansDns?.join(', '))}
+              {getFieldDisplay("Subject Alternative Name IP addresses", csrObj.sansIp?.join(', '))}
+              {getFieldDisplay("Country", csrObj.country)}
+              {getFieldDisplay("State or Province", csrObj.stateOrProvince)}
+              {getFieldDisplay("Locality", csrObj.locality)}
+              {getFieldDisplay("Organization", csrObj.organization)}
+              {getFieldDisplay("Organizational Unit", csrObj.OrganizationalUnitName)}
+              {getFieldDisplay("Email Address", csrObj.emailAddress)}
+              <p><b>Certificate request for a certificate authority</b>: {csrObj.is_ca ? "Yes" : "No"}</p>
+            </div>
+          )}
+          {isCertContentVisible && certObj && (
+            <div >
+              <h4>Certificate Content</h4>
+              {getFieldDisplay("Common Name", certObj.commonName)}
+              {getFieldDisplay("Subject Alternative Name DNS", certObj.sansDns?.join(', '))}
+              {getFieldDisplay("Subject Alternative Name IP addresses", certObj.sansIp?.join(', '))}
+              {getFieldDisplay("Country", certObj.country)}
+              {getFieldDisplay("State or Province", certObj.stateOrProvince)}
+              {getFieldDisplay("Locality", certObj.locality)}
+              {getFieldDisplay("Organization", certObj.organization)}
+              {getFieldDisplay("Organizational Unit", certObj.OrganizationalUnitName)}
+              {getFieldDisplay("Email Address", certObj.emailAddress)}
+              {getFieldDisplay("Start of validity", certObj.notBefore)}
+              {getFieldDisplay("Expiry Time", certObj.notAfter)}
+              {getFieldDisplay("Issuer Common Name", certObj.issuerCommonName)}
+              <p><b>Certificate for a certificate authority</b>: {certObj.is_ca ? "Yes" : "No"}</p>
+            </div>
+          )}
+        </div>
+      ),
+    };
+  });
+  return (
+    <Panel
+      stickyHeader
+      title="Certificate Authorities"
+      className="u-fixed-width"
+      controls={rows.length > 0 && (
+        <Button appearance="positive" onClick={() => setAsideOpen(true)}>
+          Add New CA
+        </Button>
+      )}
+    >
+      <MainTable
+        emptyStateMsg={<CAEmptyState setAsideOpen={setAsideOpen} />}
+        expanding
+        sortable
+        headers={[
+          {
+            content: "ID",
+            sortKey: "id",
+          },
+          {
+            content: "CA Type",
+            sortKey: "type",
+          },
+          {
+            content: "Common Name",
+            sortKey: "common_name",
+          },
+          {
+            content: "CA Status",
+            sortKey: "ca_status",
+          },
+          {
+            content: "Certificate Expiry Date",
+            sortKey: "cert_expiry_date",
+          },
+          {
+            content: "Actions",
+            className: "u-align--right has-overflow"
+          }
+        ]}
+        rows={carows}
+      />
+      {confirmationModalData && (
+        <NotaryConfirmationModal {...confirmationModalData} />
+      )}
+      {certificateFormOpen && selectedCA && (
+        <SubmitCertificateModal
+          id={selectedCA.id.toString()}
+          csr={selectedCA.csr}
+          cert={selectedCA.certificate}
+          setFormOpen={setCertificateFormOpen}
+        />
+      )}
+    </Panel>
+  );
+}
+
+function CAEmptyState({ setAsideOpen }: { setAsideOpen: Dispatch<SetStateAction<boolean>> }) {
+  return (
+    <EmptyState
+      image={""}
+      title="No Certificate Authorities available yet."
+    >
+      <p>
+        There are no Certificate Authorities in Notary. Create your first one to start signing certificates!
+      </p>
+      <Button
+        appearance="positive"
+        aria-label="add-ca-button"
+        onClick={() => setAsideOpen(true)}>
+        Add New Certificate Authority
+      </Button>
+    </EmptyState>
+  );
+}

--- a/ui/src/app/(notary)/certificate_requests/table.tsx
+++ b/ui/src/app/(notary)/certificate_requests/table.tsx
@@ -1,329 +1,328 @@
 import { useState, Dispatch, SetStateAction } from "react";
 import { CSREntry } from "@/types";
-import { Button, MainTable, Panel, EmptyState, ContextualMenu, ConfirmationModal } from "@canonical/react-components";
-import { RequiredCSRParams, deleteCSR, rejectCSR, revokeCertificate } from "@/queries"
-import { useCookies } from "react-cookie";
+import { Button, MainTable, Panel, EmptyState, ContextualMenu } from "@canonical/react-components";
+import { deleteCSR, rejectCSR, revokeCertificate, signCSR } from "@/queries"
 import { extractCSR, extractCert, splitBundle } from "@/utils";
-import { UseMutationResult, useMutation, useQueryClient } from "@tanstack/react-query"
 import { SubmitCertificateModal, SuccessNotification } from "./components"
-
+import { NotaryConfirmationModal, NotaryConfirmationModalData } from "@/components/NotaryConfirmationModal";
+import { useAuth } from "@/hooks/useAuth";
 
 type TableProps = {
-    csrs: CSREntry[];
-    setAsideOpen: Dispatch<SetStateAction<boolean>>
+  csrs: CSREntry[];
+  setAsideOpen: Dispatch<SetStateAction<boolean>>
 };
 
-export type ConfirmationModalData = {
-    onMouseDownFunc: () => void
-    warningText: string
-} | null
+export function CertificateRequestsTable({ csrs: rows, setAsideOpen }: TableProps) {
+  const auth = useAuth()
+  const [certificateFormOpen, setCertificateFormOpen] = useState<boolean>(false);
+  const [confirmationModalData, setConfirmationModalData] = useState<NotaryConfirmationModalData | null>(null);
+  const [selectedCSR, setSelectedCSR] = useState<CSREntry | null>(null);
+  const [showCSRContent, setShowCSRContent] = useState<number | null>(null);
+  const [showCertContent, setShowCertContent] = useState<number | null>(null);
+  const [successNotificationId, setSuccessNotificationId] = useState<number | null>(null);
 
-
-export function CertificateRequestsTable({ csrs: rows , setAsideOpen}: TableProps) {
-    const [cookies] = useCookies(['user_token']);
-    const queryClient = useQueryClient();
-    const [certificateFormOpen, setCertificateFormOpen] = useState<boolean>(false);
-    const [confirmationModalData, setConfirmationModalData] = useState<ConfirmationModalData | null>(null);
-    const [selectedCSR, setSelectedCSR] = useState<CSREntry | null>(null);
-    const [showCSRContent, setShowCSRContent] = useState<number | null>(null);
-    const [showCertContent, setShowCertContent] = useState<number | null>(null);
-    const [successNotificationId, setSuccessNotificationId] = useState<number | null>(null);
-
-    const deleteMutation = useMutation({
-        mutationFn: deleteCSR,
-        onSuccess: () => queryClient.invalidateQueries({ queryKey: ['csrs'] }),
+  const handleCopy = (csr: string, id: number) => {
+    navigator.clipboard.writeText(csr).then(() => {
+      setSuccessNotificationId(id);
+      setTimeout(() => setSuccessNotificationId(null), 2500);
     });
+  };
 
-    const rejectMutation = useMutation({
-        mutationFn: rejectCSR,
-        onSuccess: () => queryClient.invalidateQueries({ queryKey: ['csrs'] }),
+  const handleDownload = (csr: string, id: number, csrObj: any) => {
+    const blob = new Blob([csr], { type: 'text/plain' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = `csr-${csrObj.commonName || id}.pem`;
+    link.click();
+    URL.revokeObjectURL(link.href);
+  };
+
+  const handleSign = (id: number) => {
+    if (!auth.activeCA) {
+      return;
+    }
+    const certs = splitBundle(auth.activeCA.certificate);
+    const clientCertificate = certs?.at(0);
+    const certObj = clientCertificate ? extractCert(clientCertificate) : null;
+    setConfirmationModalData({
+      queryFn: signCSR,
+      queryParams: { id: id.toString(), authToken: auth.user?.authToken, certificate_authority_id: auth.activeCA.id },
+      closeFn: () => setConfirmationModalData(null),
+      queryKey: 'csrs',
+      warningText: `Signing a Certificate Request means the CSR will be signed and a certificate will be generated. This CSR will be signed by "${certObj?.commonName}". This action cannot be undone.`,
+      buttonConfirmText: "Sign"
+    })
+  }
+
+  const handleReject = (id: number) => {
+    setConfirmationModalData({
+      queryFn: rejectCSR,
+      queryParams: { id: id.toString(), authToken: auth.user?.authToken },
+      closeFn: () => setConfirmationModalData(null),
+      queryKey: 'csrs',
+      warningText: "Rejecting a Certificate Request means the CSR will remain in this application, but its status will be moved to rejected and the associated certificate will be deleted if there is any. This action cannot be undone.",
+      buttonConfirmText: "Reject",
     });
+  };
 
-    const revokeMutation = useMutation({
-        mutationFn: revokeCertificate,
-        onSuccess: () => queryClient.invalidateQueries({ queryKey: ['csrs'] }),
+  const handleDelete = (id: number) => {
+    setConfirmationModalData({
+      queryFn: deleteCSR,
+      queryParams: { id: id.toString(), authToken: auth.user?.authToken },
+      closeFn: () => setConfirmationModalData(null),
+      queryKey: 'csrs',
+      warningText: "Deleting a Certificate Request means this row will be completely removed from the application. This action cannot be undone.",
+      buttonConfirmText: "Delete",
     });
+  };
 
-    const mutationFunc = (mutation: UseMutationResult<any, unknown, RequiredCSRParams, unknown>, params: RequiredCSRParams) => {
-        mutation.mutate(params);
-        setConfirmationModalData(null);
-    };
+  const handleRevoke = (id: number) => {
+    setConfirmationModalData({
+      queryFn: revokeCertificate,
+      queryParams: { id: id.toString(), authToken: auth.user?.authToken },
+      closeFn: () => setConfirmationModalData(null),
+      queryKey: 'csrs',
+      warningText: "Revoking a Certificate will delete it from the table. This action cannot be undone.",
+      buttonConfirmText: "Revoke",
+    });
+  };
 
-    const handleCopy = (csr: string, id: number) => {
-        navigator.clipboard.writeText(csr).then(() => {
-            setSuccessNotificationId(id);
-            setTimeout(() => setSuccessNotificationId(null), 2500);
-        });
-    };
+  const handleExpand = (id: number, type: 'CSR' | 'Cert') => {
+    if (type === 'CSR') {
+      setShowCSRContent(id === showCSRContent ? null : id);
+      setShowCertContent(null);
+    } else {
+      setShowCertContent(id === showCertContent ? null : id);
+      setShowCSRContent(null);
+    }
+  };
 
-    const handleDownload = (csr: string, id: number, csrObj: any) => {
-        const blob = new Blob([csr], { type: 'text/plain' });
-        const link = document.createElement('a');
-        link.href = URL.createObjectURL(blob);
-        link.download = `csr-${csrObj.commonName || id}.pem`;
-        link.click();
-        URL.revokeObjectURL(link.href);
-    };
+  const getExpiryColor = (notAfter?: string): string => {
+    if (!notAfter) return 'inherit';
+    const expiryDate = new Date(notAfter);
+    const now = new Date();
+    const timeDifference = expiryDate.getTime() - now.getTime();
+    if (timeDifference < 0) return "rgba(199, 22, 43, 1)";
+    if (timeDifference < 24 * 60 * 60 * 1000) return "rgba(249, 155, 17, 0.45)";
+    return "rgba(14, 132, 32, 0.35)";
+  };
 
-    const handleReject = (id: number) => {
-        setConfirmationModalData({
-            onMouseDownFunc: () => mutationFunc(rejectMutation, { id: id.toString(), authToken: cookies.user_token }),
-            warningText: "Rejecting a Certificate Request means the CSR will remain in this application, but its status will be moved to rejected and the associated certificate will be deleted if there is any. This action cannot be undone.",
-        });
-    };
+  const getFieldDisplay = (label: string, field: string | undefined, compareField?: string | undefined) => {
+    const isMismatched = compareField !== undefined && compareField !== field;
+    return field ? (
+      <p style={{ marginBottom: "4px" }}>
+        <b>{label}:</b>{" "}
+        <span style={{ color: isMismatched ? "rgba(199, 22, 43, 1)" : "inherit" }}>
+          {field}
+        </span>
+      </p>
+    ) : null;
+  };
+  const csrrows = rows.map((csrEntry) => {
+    const { id, csr, certificate_chain, status: csr_status } = csrEntry;
+    const csrObj = extractCSR(csr);
+    const certs = splitBundle(certificate_chain);
+    const clientCertificate = certs?.at(0);
+    const certObj = clientCertificate ? extractCert(clientCertificate) : null;
 
-    const handleDelete = (id: number) => {
-        setConfirmationModalData({
-            onMouseDownFunc: () => mutationFunc(deleteMutation, { id: id.toString(), authToken: cookies.user_token }),
-            warningText: "Deleting a Certificate Request means this row will be completely removed from the application. This action cannot be undone.",
-        });
-    };
+    const isCSRContentVisible = showCSRContent === id;
+    const isCertContentVisible = showCertContent === id;
 
-    const handleRevoke = (id: number) => {
-        setConfirmationModalData({
-            onMouseDownFunc: () => mutationFunc(revokeMutation, { id: id.toString(), authToken: cookies.user_token }),
-            warningText: "Revoking a Certificate will delete it from the table. This action cannot be undone.",
-        });
-    };
-
-    const handleExpand = (id: number, type: 'CSR' | 'Cert') => {
-        if (type === 'CSR') {
-            setShowCSRContent(id === showCSRContent ? null : id);
-            setShowCertContent(null);
-        } else {
-            setShowCertContent(id === showCertContent ? null : id);
-            setShowCSRContent(null);
-        }
-    };
-
-    const getExpiryColor = (notAfter?: string): string => {
-        if (!notAfter) return 'inherit';
-        const expiryDate = new Date(notAfter);
-        const now = new Date();
-        const timeDifference = expiryDate.getTime() - now.getTime();
-        if (timeDifference < 0) return "rgba(199, 22, 43, 1)";
-        if (timeDifference < 24 * 60 * 60 * 1000) return "rgba(249, 155, 17, 0.45)";
-        return "rgba(14, 132, 32, 0.35)";
-    };
-
-    const getFieldDisplay = (label: string, field: string | undefined, compareField?: string | undefined) => {
-        const isMismatched = compareField !== undefined && compareField !== field;
-        return field ? (
-            <p style={{ marginBottom: "4px" }}>
-                <b>{label}:</b>{" "}
-                <span style={{ color: isMismatched ? "rgba(199, 22, 43, 1)" : "inherit" }}>
-                    {field}
+    return {
+      sortData: {
+        id,
+        common_name: csrObj.commonName,
+        csr_status: csr_status,
+        cert_expiry_date: certObj?.notAfter || "",
+      },
+      columns: [
+        { content: id.toString() },
+        { content: csrObj.commonName || "N/A" },
+        { content: csr_status },
+        {
+          content: certObj?.notAfter || "",
+          style: { backgroundColor: getExpiryColor(certObj?.notAfter) },
+        },
+        {
+          content: (
+            <>
+              {successNotificationId === id && <SuccessNotification successMessage="CSR copied to clipboard" />}
+              <ContextualMenu
+                hasToggleIcon
+                position="right"
+              >
+                <span className="p-contextual-menu__group">
+                  <Button
+                    className="p-contextual-menu__link"
+                    onMouseDown={() => handleExpand(id, 'CSR')}>
+                    {isCSRContentVisible ? "Hide CSR Content" : "Show CSR Content"}
+                  </Button>
+                  <Button
+                    className="p-contextual-menu__link"
+                    onMouseDown={() => handleCopy(csr, id)}>
+                    Copy CSR to Clipboard
+                  </Button>
+                  <Button
+                    className="p-contextual-menu__link"
+                    onMouseDown={() => handleDownload(csr, id, csrObj)}>
+                    Download CSR
+                  </Button>
                 </span>
-            </p>
-        ) : null;
+                <span className="p-contextual-menu__group">
+                  <Button
+                    className="p-contextual-menu__link"
+                    disabled={csr_status != "Active"}
+                    onMouseDown={() => handleExpand(id, 'Cert')}>
+                    {isCertContentVisible ? "Hide Certificate Content" : "Show Certificate Content"}
+                  </Button>
+                  <Button
+                    className="p-contextual-menu__link"
+                    disabled={!auth.activeCA}
+                    onMouseDown={() => handleSign(id)}>
+                    Sign CSR
+                  </Button>
+                  <Button
+                    className="p-contextual-menu__link"
+                    onMouseDown={() => {
+                      setCertificateFormOpen(true);
+                      setSelectedCSR(csrEntry);
+                    }}>
+                    Upload New Certificate
+                  </Button>
+                  <Button
+                    className="p-contextual-menu__link"
+                    disabled={csr_status != "Active"}
+                    onMouseDown={() => handleRevoke(id)}>
+                    Revoke Certificate
+                  </Button>
+                </span>
+                <span className="p-contextual-menu__group">
+                  <Button
+                    className="p-contextual-menu__link"
+                    disabled={csr_status == "Rejected"}
+                    onMouseDown={() => handleReject(id)}>
+                    Reject Certificate Request
+                  </Button>
+                  <Button
+                    className="p-contextual-menu__link"
+                    onMouseDown={() => handleDelete(id)}>
+                    Delete Certificate Request
+                  </Button>
+                </span>
+              </ContextualMenu>
+            </>
+          ),
+          className: "u-align--right has-overflow",
+          style: { height: "58px", overflow: "hidden" },
+        },
+      ],
+      expanded: isCSRContentVisible || isCertContentVisible,
+      expandedContent: (
+        <div >
+          {isCSRContentVisible && (
+            <div >
+              <h4>Certificate Request Content</h4>
+              {getFieldDisplay("Common Name", csrObj.commonName)}
+              {getFieldDisplay("Subject Alternative Name DNS", csrObj.sansDns?.join(', '))}
+              {getFieldDisplay("Subject Alternative Name IP addresses", csrObj.sansIp?.join(', '))}
+              {getFieldDisplay("Country", csrObj.country)}
+              {getFieldDisplay("State or Province", csrObj.stateOrProvince)}
+              {getFieldDisplay("Locality", csrObj.locality)}
+              {getFieldDisplay("Organization", csrObj.organization)}
+              {getFieldDisplay("Organizational Unit", csrObj.OrganizationalUnitName)}
+              {getFieldDisplay("Email Address", csrObj.emailAddress)}
+              <p><b>Certificate request for a certificate authority</b>: {csrObj.is_ca ? "Yes" : "No"}</p>
+            </div>
+          )}
+          {isCertContentVisible && certObj && (
+            <div >
+              <h4>Certificate Content</h4>
+              {getFieldDisplay("Common Name", certObj.commonName)}
+              {getFieldDisplay("Subject Alternative Name DNS", certObj.sansDns?.join(', '))}
+              {getFieldDisplay("Subject Alternative Name IP addresses", certObj.sansIp?.join(', '))}
+              {getFieldDisplay("Country", certObj.country)}
+              {getFieldDisplay("State or Province", certObj.stateOrProvince)}
+              {getFieldDisplay("Locality", certObj.locality)}
+              {getFieldDisplay("Organization", certObj.organization)}
+              {getFieldDisplay("Organizational Unit", certObj.OrganizationalUnitName)}
+              {getFieldDisplay("Email Address", certObj.emailAddress)}
+              {getFieldDisplay("Start of validity", certObj.notBefore)}
+              {getFieldDisplay("Expiry Time", certObj.notAfter)}
+              {getFieldDisplay("Issuer Common Name", certObj.issuerCommonName)}
+              <p><b>Certificate for a certificate authority</b>: {certObj.is_ca ? "Yes" : "No"}</p>
+            </div>
+          )}
+        </div>
+      ),
     };
-
-    const csrrows = rows.map((csrEntry) => {
-        const { id, csr, certificate_chain, status: csr_status } = csrEntry;
-        const csrObj = extractCSR(csr);
-        const certs = splitBundle(certificate_chain);
-        const clientCertificate = certs?.at(0);
-        const certObj = clientCertificate ? extractCert(clientCertificate) : null;
-
-        const isCSRContentVisible = showCSRContent === id;
-        const isCertContentVisible = showCertContent === id;
-
-        return {
-            sortData: {
-                id,
-                common_name: csrObj.commonName,
-                csr_status: csr_status,
-                cert_expiry_date: certObj?.notAfter || "",
-            },
-            columns: [
-                { content: id.toString() },
-                { content: csrObj.commonName || "N/A" },
-                { content: csr_status },
-                {
-                    content: certObj?.notAfter || "",
-                    style: { backgroundColor: getExpiryColor(certObj?.notAfter) },
-                },
-                {
-                    content: (
-                        <>
-                            {successNotificationId === id && <SuccessNotification successMessage="CSR copied to clipboard" />}
-                            <ContextualMenu
-                                hasToggleIcon
-                                position="right"
-                            >
-                                <span className="p-contextual-menu__group">
-                                    <Button
-                                        className="p-contextual-menu__link"
-                                        onMouseDown={() => handleCopy(csr, id)}>
-                                        Copy Certificate Request to Clipboard
-                                    </Button>
-                                    <Button
-                                        className="p-contextual-menu__link"
-                                        onMouseDown={() => handleDownload(csr, id, csrObj)}>
-                                        Download Certificate Request
-                                    </Button>
-                                    <Button
-                                        className="p-contextual-menu__link"
-                                        onMouseDown={() => handleExpand(id, 'CSR')}>
-                                        {isCSRContentVisible ? "Hide Certificate Request Content" : "Show Certificate Request Content"}
-                                    </Button>
-                                    <Button
-                                        className="p-contextual-menu__link"
-                                        disabled={csr_status == "Rejected"}
-                                        onMouseDown={() => csr_status == "Active" ? handleRevoke(id) : handleReject(id)}>
-                                        {csr_status == "Active" ? "Revoke Certificate Request" : "Reject Certificate Request"}
-                                    </Button>
-                                    <Button
-                                        className="p-contextual-menu__link"
-                                        onMouseDown={() => handleDelete(id)}>
-                                        Delete Certificate Request
-                                    </Button>
-                                </span>
-                                <span className="p-contextual-menu__group">
-                                    <Button
-                                        className="p-contextual-menu__link"
-                                        onMouseDown={() => {
-                                            setCertificateFormOpen(true);
-                                            setSelectedCSR(csrEntry);
-                                        }}>
-                                        Upload Certificate
-                                    </Button>
-                                    <Button
-                                        className="p-contextual-menu__link"
-                                        disabled={csr_status != "Active"}
-                                        onMouseDown={() => handleExpand(id, 'Cert')}>
-                                        {isCertContentVisible ? "Hide Certificate Content" : "Show Certificate Content"}
-                                    </Button>
-                                    <Button
-                                        className="p-contextual-menu__link"
-                                        disabled={csr_status != "Active"}
-                                        onMouseDown={() => handleRevoke(id)}>
-                                        Revoke Certificate
-                                    </Button>
-                                </span>
-                            </ContextualMenu>
-                        </>
-                    ),
-                    className: "u-align--right has-overflow",
-                    style: { height: "58px", overflow: "hidden" },
-                },
-            ],
-            expanded: isCSRContentVisible || isCertContentVisible,
-            expandedContent: (
-                <div >
-                    {isCSRContentVisible && (
-                        <div >
-                            <h4>Certificate Request Content</h4>
-                            {getFieldDisplay("Common Name", csrObj.commonName)}
-                            {getFieldDisplay("Subject Alternative Name DNS", csrObj.sansDns?.join(', '))}
-                            {getFieldDisplay("Subject Alternative Name IP addresses", csrObj.sansIp?.join(', '))}
-                            {getFieldDisplay("Country", csrObj.country)}
-                            {getFieldDisplay("State or Province", csrObj.stateOrProvince)}
-                            {getFieldDisplay("Locality", csrObj.locality)}
-                            {getFieldDisplay("Organization", csrObj.organization)}
-                            {getFieldDisplay("Organizational Unit", csrObj.OrganizationalUnitName)}
-                            {getFieldDisplay("Email Address", csrObj.emailAddress)}
-                            <p><b>Certificate request for a certificate authority</b>: {csrObj.is_ca ? "Yes" : "No"}</p>
-                        </div>
-                    )}
-                    {isCertContentVisible && certObj && (
-                        <div >
-                            <h4>Certificate Content</h4>
-                            {getFieldDisplay("Common Name", certObj.commonName)}
-                            {getFieldDisplay("Subject Alternative Name DNS", certObj.sansDns?.join(', '))}
-                            {getFieldDisplay("Subject Alternative Name IP addresses", certObj.sansIp?.join(', '))}
-                            {getFieldDisplay("Country", certObj.country)}
-                            {getFieldDisplay("State or Province", certObj.stateOrProvince)}
-                            {getFieldDisplay("Locality", certObj.locality)}
-                            {getFieldDisplay("Organization", certObj.organization)}
-                            {getFieldDisplay("Organizational Unit", certObj.OrganizationalUnitName)}
-                            {getFieldDisplay("Email Address", certObj.emailAddress)}
-                            {getFieldDisplay("Start of validity", certObj.notBefore)}
-                            {getFieldDisplay("Expiry Time", certObj.notAfter)}
-                            {getFieldDisplay("Issuer Common Name", certObj.issuerCommonName)}
-                            <p><b>Certificate for a certificate authority</b>: {certObj.is_ca ? "Yes" : "No"}</p>
-                        </div>
-                    )}
-                </div>
-            ),
-        };
-    });
-    return (
-        <Panel
-            stickyHeader
-            title="Certificate Requests"
-            className="u-fixed-width"
-            controls={rows.length > 0 && (
-                <Button appearance="positive" onClick={() => setAsideOpen(true)}>
-                    Add New CSR
-                </Button>
-            )}
-        >
-            <MainTable
-                emptyStateMsg={<CSREmptyState setAsideOpen={setAsideOpen} />}
-                expanding
-                sortable
-                headers={[
-                    {
-                        content: "ID",
-                        sortKey: "id",
-                    },
-                    {
-                        content: "Common Name",
-                        sortKey: "common_name",
-                    },
-                    {
-                        content: "CSR Status",
-                        sortKey: "csr_status",
-                    },
-                    {
-                        content: "Certificate Expiry Date",
-                        sortKey: "cert_expiry_date",
-                    },
-                    {
-                        content: "Actions",
-                        className: "u-align--right has-overflow"
-                    }
-                ]}
-                rows={csrrows}
-            />
-            {confirmationModalData && (
-                <ConfirmationModal
-                    title="Confirm Action"
-                    confirmButtonLabel="Confirm"
-                    onConfirm={confirmationModalData.onMouseDownFunc}
-                    close={() => setConfirmationModalData(null)}
-                >
-                    <p>{confirmationModalData.warningText}</p>
-                </ConfirmationModal>
-            )}
-            {certificateFormOpen && selectedCSR && (
-                <SubmitCertificateModal
-                    id={selectedCSR.id.toString()}
-                    csr={selectedCSR.csr}
-                    cert={selectedCSR.certificate_chain}
-                    setFormOpen={setCertificateFormOpen}
-                />
-            )}
-        </Panel>
-    );
+  });
+  return (
+    <Panel
+      stickyHeader
+      title="Certificate Requests"
+      className="u-fixed-width"
+      controls={rows.length > 0 && (
+        <Button appearance="positive" onClick={() => setAsideOpen(true)}>
+          Add New Certificate Request
+        </Button>
+      )}
+    >
+      <MainTable
+        emptyStateMsg={<CSREmptyState setAsideOpen={setAsideOpen} />}
+        expanding
+        sortable
+        headers={[
+          {
+            content: "ID",
+            sortKey: "id",
+          },
+          {
+            content: "Common Name",
+            sortKey: "common_name",
+          },
+          {
+            content: "CSR Status",
+            sortKey: "csr_status",
+          },
+          {
+            content: "Certificate Expiry Date",
+            sortKey: "cert_expiry_date",
+          },
+          {
+            content: "Actions",
+            className: "u-align--right has-overflow"
+          }
+        ]}
+        rows={csrrows}
+      />
+      {confirmationModalData && <NotaryConfirmationModal {...confirmationModalData} />}
+      {certificateFormOpen && selectedCSR && (
+        <SubmitCertificateModal
+          id={selectedCSR.id.toString()}
+          csr={selectedCSR.csr}
+          cert={selectedCSR.certificate_chain}
+          setFormOpen={setCertificateFormOpen}
+        />
+      )}
+    </Panel>
+  );
 }
 
 function CSREmptyState({ setAsideOpen }: { setAsideOpen: Dispatch<SetStateAction<boolean>> }) {
-    return (
-        <EmptyState
-            image={""}
-            title="No CSRs available yet."
-        >
-            <p>
-                There are no Certificate Requests in Notary. Request your first certificate!
-            </p>
-            <Button
-                appearance="positive"
-                aria-label="add-csr-button"
-                onClick={() => setAsideOpen(true)}>
-                Add New CSR
-            </Button>
-        </EmptyState>
-    );
+  return (
+    <EmptyState
+      image={""}
+      title="No CSRs available yet."
+    >
+      <p>
+        There are no Certificate Requests in Notary. Request your first certificate!
+      </p>
+      <Button
+        appearance="positive"
+        aria-label="add-csr-button"
+        onClick={() => setAsideOpen(true)}>
+        Add New CSR
+      </Button>
+    </EmptyState>
+  );
 }

--- a/ui/src/components/NotaryAppNavigationBars.tsx
+++ b/ui/src/components/NotaryAppNavigationBars.tsx
@@ -46,6 +46,16 @@ export function SideBar({ sidebarVisible, setSidebarVisible, setChangePasswordMo
                   </li>
                   {auth.user?.permissions == 1 &&
                     <li className="p-side-navigation__item">
+                      <a className="p-side-navigation__link" href="/certificate_authorities" aria-current={path.startsWith("/certificate_authorities") ? "page" : "false"} style={{ cursor: "pointer" }}>
+                        <i className="p-icon--copy-to-clipboard is-light p-side-navigation__icon"></i>
+                        <span className="p-side-navigation__label">
+                          <span className="p-side-navigation__label">Certificate Authorities</span>
+                        </span>
+                      </a>
+                    </li>
+                  }
+                  {auth.user?.permissions == 1 &&
+                    <li className="p-side-navigation__item">
                       <a className="p-side-navigation__link" href="/users" aria-current={path.startsWith("/users") ? "page" : "false"} style={{ cursor: "pointer" }}>
                         <i className="p-icon--user is-light p-side-navigation__icon"></i>
                         <span className="p-side-navigation__label">

--- a/ui/src/components/NotaryConfirmationModal.tsx
+++ b/ui/src/components/NotaryConfirmationModal.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { ConfirmationModal, Notification } from "@canonical/react-components";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+export type NotaryConfirmationModalData = {
+  queryFn: (params: any) => Promise<any>
+  queryParams: any
+  closeFn: () => void
+  queryKey: string
+  warningText: string
+  buttonConfirmText: string
+}
+
+export function NotaryConfirmationModal(data: NotaryConfirmationModalData) {
+  const [errorText, setErrorText] = useState<string>("");
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: data.queryFn,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [data.queryKey] });
+      setErrorText("");
+      data.closeFn();
+    },
+    onError: (e: Error) => {
+      setErrorText(e.message);
+    }
+  });
+  return (
+    < ConfirmationModal
+      title="Confirm Action"
+      confirmButtonLabel="Confirm"
+      onConfirm={() => mutation.mutate(data.queryParams)}
+      close={() => data.closeFn()}
+    >
+      <p>{data.warningText}</p>
+      {errorText !== "" &&
+        <Notification severity="negative" title="Error">
+          {errorText}
+        </Notification>
+      }
+    </ConfirmationModal >
+  )
+}

--- a/ui/src/globals.scss
+++ b/ui/src/globals.scss
@@ -6,6 +6,7 @@
 
 // Include Vanilla Framework icons
 @include vf-p-icon-security;
+@include vf-p-icon-copy-to-clipboard;
 
 // Override visibility settings
 #csr-table {

--- a/ui/src/hooks/useAuth.tsx
+++ b/ui/src/hooks/useAuth.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { createContext, useContext, useState, useEffect, Dispatch, SetStateAction } from 'react';
-import { User } from '../types';
+import { createContext, useContext, useState, useEffect, Dispatch, SetStateAction, useCallback } from 'react';
+import { User, CertificateAuthorityEntry } from '../types';
 import { useCookies } from 'react-cookie';
 import { jwtDecode } from 'jwt-decode';
 import { useRouter } from 'next/navigation';
@@ -10,17 +10,28 @@ type AuthContextType = {
     user: User | null
     firstUserCreated: boolean
     setFirstUserCreated: Dispatch<SetStateAction<boolean>>
+    activeCA: CertificateAuthorityEntry | null
+    setActiveCA: (value: CertificateAuthorityEntry | null) => void
 }
 
-const AuthContext = createContext<AuthContextType>({ user: null, firstUserCreated: false, setFirstUserCreated: () => { } });
+const AuthContext = createContext<AuthContextType>({ user: null, firstUserCreated: false, setFirstUserCreated: () => { }, activeCA: null, setActiveCA: () => { } });
 
 export const AuthProvider = ({ children }: Readonly<{ children: React.ReactNode }>) => {
     const [cookies, setCookie, removeCookie] = useCookies(['user_token']);
     const [user, setUser] = useState<User | null>(null);
     const [firstUserCreated, setFirstUserCreated] = useState<boolean>(false)
+    const [activeCAState, setActiveCAState] = useState<CertificateAuthorityEntry | null>(null);
     const router = useRouter();
 
+    const setActiveCA = useCallback((value: CertificateAuthorityEntry | null) => {
+        setActiveCAState(value)
+        localStorage.setItem("activeCA", JSON.stringify(value))
+    }, [])
+
     useEffect(() => {
+        let storedActiveCA = localStorage.getItem("activeCA")
+        setActiveCAState(storedActiveCA ? JSON.parse(storedActiveCA) : null)
+
         const token = cookies.user_token;
         if (token) {
             let userObject = jwtDecode(cookies.user_token) as User
@@ -34,9 +45,9 @@ export const AuthProvider = ({ children }: Readonly<{ children: React.ReactNode 
     }, [cookies.user_token, router]);
 
     return (
-        <AuthContext.Provider value={{ user, firstUserCreated, setFirstUserCreated }}>
+        <AuthContext.Provider value={{ user, firstUserCreated, setFirstUserCreated, activeCA: activeCAState, setActiveCA }}>
             {children}
-        </AuthContext.Provider>
+        </AuthContext.Provider >
     );
 };
 

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -5,12 +5,22 @@ export type CSREntry = {
     status: "Outstanding" | "Active" | "Rejected" | "Revoked"
 }
 
+export type CertificateAuthorityEntry = {
+    id: number,
+    status: "active" | "expired" | "pending" | "legacy"
+    certificate: string
+    csr: string
+    crl: string
+}
+
 export type User = {
     exp: number
     id: number
     permissions: number
     username: string
     authToken: string
+
+    activeCA: number
 }
 
 export type UserEntry = {

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -40,7 +40,14 @@ export const oidToName = (oid: string) => {
         "1.2.840.113549.1.9.14": "Extension Request",
         // OID for basicConstraint
         "2.5.29.19": "Basic Constraint",
-        "2.5.29.17": "Subject Alternative Name"
+        "2.5.29.17": "Subject Alternative Name",
+        //
+        "2.5.29.15": "keyUsage",
+        "2.5.29.37": "extKeyUsage",
+        "2.5.29.14": "subjectKeyIdentifier",
+        "2.5.29.35": "authorityKeyIdentifier",
+        "2.5.29.31": "cRLDistributionPoints",
+
     }
     if (!(oid in map)) {
         throw new Error("oid not recognized: " + oid)
@@ -171,7 +178,7 @@ export const extractCert = (certPemString: string) => {
         type: oidToName(typeAndValue.type),
         value: typeAndValue.value.valueBlock.value
     }));
-    const issuerInfo = cert.subject.typesAndValues.map(typeAndValue => ({
+    const issuerInfo = cert.issuer.typesAndValues.map(typeAndValue => ({
         type: oidToName(typeAndValue.type),
         value: typeAndValue.value.valueBlock.value
     }));

--- a/ui/src/validators.ts
+++ b/ui/src/validators.ts
@@ -1,0 +1,71 @@
+// This file contains the validation functions for forms in Notary
+// A validator function takes in at least the value to be validated, and returns an error string if the value is invalid, or an empty string if the value is valid
+
+import { V } from "vitest/dist/chunks/reporters.d.CqBhtcTq.js";
+
+export type validationResult = {
+    error: string
+    caution: string
+    success: string
+}
+
+export function validateCommonName(value: string): validationResult {
+    let vr: validationResult = { error: "", caution: "", success: "" };
+    if (value.length < 1 || value.length > 64) {
+        vr.error = "must be between 1 and 64 characters"
+    }
+    return vr
+}
+
+export function validateOrganizationName(value: string): validationResult {
+    let vr: validationResult = { error: "", caution: "", success: "" };
+    if (value.length < 1 || value.length > 64) {
+        vr.error = "must be between 1 and 64 characters"
+    }
+    return vr
+}
+
+export function validateOrganizationalUnit(value: string): validationResult {
+    let vr: validationResult = { error: "", caution: "", success: "" };
+    if (value.length < 1 || value.length > 64) {
+        vr.error = "must be between 1 and 64 characters"
+    }
+    return vr
+}
+
+export function validateCountryName(value: string): validationResult {
+    let vr: validationResult = { error: "", caution: "", success: "" };
+    if (value.length !== 2) {
+        vr.error = "must be exactly 2 characters"
+    }
+    if (!/^[A-Z]{2}$/.test(value)) {
+        vr.error = "must be uppercase letters"
+    }
+    return vr
+}
+
+export function validateStateOrProvinceName(value: string): validationResult {
+    let vr: validationResult = { error: "", caution: "", success: "" };
+    if (value.length < 1 || value.length > 64) {
+        vr.error = "must be between 1 and 64 characters"
+    }
+    return vr
+}
+
+export function validateLocalityName(value: string): validationResult {
+    let vr: validationResult = { error: "", caution: "", success: "" };
+    if (value.length < 1 || value.length > 64) {
+        vr.error = "must be between 1 and 64 characters"
+    }
+    return vr
+}
+
+export function validateNotAfter(value: string): validationResult {
+    let vr: validationResult = { error: "", caution: "", success: "" };
+    const date = new Date(value);
+    const now = new Date();
+    if (date < now) {
+        vr.caution = "This date is in the past";
+    }
+    return vr
+}

--- a/ui/src/validators.ts
+++ b/ui/src/validators.ts
@@ -1,7 +1,11 @@
 // This file contains the validation functions for forms in Notary
-// A validator function takes in at least the value to be validated, and returns an error string if the value is invalid, or an empty string if the value is valid
-
-import { V } from "vitest/dist/chunks/reporters.d.CqBhtcTq.js";
+// A validator function takes in at least the value to be validated, and returns a 
+// validationResult object. The validationResult object contains three properties:
+// error, caution, and success. Each of these properties is a string that contains
+// the validation message. The error property is used to indicate that the value is
+// invalid, the caution property is used to indicate that the value is valid but
+// may contain mistakes, and the success property is used to indicate that the value is
+// valid.
 
 export type validationResult = {
     error: string
@@ -11,6 +15,9 @@ export type validationResult = {
 
 export function validateCommonName(value: string): validationResult {
     let vr: validationResult = { error: "", caution: "", success: "" };
+    if (value.length == 0) {
+        return vr
+    }
     if (value.length < 1 || value.length > 64) {
         vr.error = "must be between 1 and 64 characters"
     }
@@ -19,26 +26,35 @@ export function validateCommonName(value: string): validationResult {
 
 export function validateOrganizationName(value: string): validationResult {
     let vr: validationResult = { error: "", caution: "", success: "" };
+    if (value.length == 0) {
+        return vr
+    }
     if (value.length < 1 || value.length > 64) {
-        vr.error = "must be between 1 and 64 characters"
+        vr.caution = "must be between 1 and 64 characters"
     }
     return vr
 }
 
 export function validateOrganizationalUnit(value: string): validationResult {
     let vr: validationResult = { error: "", caution: "", success: "" };
+    if (value.length == 0) {
+        return vr
+    }
     if (value.length < 1 || value.length > 64) {
-        vr.error = "must be between 1 and 64 characters"
+        vr.caution = "must be between 1 and 64 characters"
     }
     return vr
 }
 
 export function validateCountryName(value: string): validationResult {
     let vr: validationResult = { error: "", caution: "", success: "" };
+    if (value.length == 0) {
+        return vr
+    }
     if (value.length !== 2) {
         vr.error = "must be exactly 2 characters"
     }
-    if (!/^[A-Z]{2}$/.test(value)) {
+    if (value !== value.toUpperCase()) {
         vr.error = "must be uppercase letters"
     }
     return vr
@@ -46,6 +62,9 @@ export function validateCountryName(value: string): validationResult {
 
 export function validateStateOrProvinceName(value: string): validationResult {
     let vr: validationResult = { error: "", caution: "", success: "" };
+    if (value.length == 0) {
+        return vr
+    }
     if (value.length < 1 || value.length > 64) {
         vr.error = "must be between 1 and 64 characters"
     }
@@ -54,6 +73,9 @@ export function validateStateOrProvinceName(value: string): validationResult {
 
 export function validateLocalityName(value: string): validationResult {
     let vr: validationResult = { error: "", caution: "", success: "" };
+    if (value.length == 0) {
+        return vr
+    }
     if (value.length < 1 || value.length > 64) {
         vr.error = "must be between 1 and 64 characters"
     }


### PR DESCRIPTION
# Description

This PR introduces a new page to the frontend where the new CA API changes can be used. It includes all of the required features for CA management and signing except for revoking all sub-certificates.
 
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/075008cb-e81d-46b2-bc49-6e893623a62b" />

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/0e59dcbd-225c-4dbd-ae65-72d0d8786eef" />

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/53041a3c-6cac-47f1-963c-0219d814fd00" />

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/d91a2856-efa3-43e5-a686-9ad4e717cba7" />


# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
