### PR TITLE
fix: Fixes CA status setting when revoking certs

### DIFF
--- a/internal/db/db_certificate_authorities.go
+++ b/internal/db/db_certificate_authorities.go
@@ -518,12 +518,11 @@ func (db *Database) SignCertificateRequest(csrFilter CSRFilter, caFilter Certifi
 	return err
 }
 
-// RevokeCertificate revokes a certificate previously signed by a Notary CA by places the serial number of the certificate in its CRL.
+// RevokeCertificate revokes a certificate previously signed by a Notary CA by placing the serial number of the certificate in its issuer's CRL.
 func (db *Database) RevokeCertificate(filter CSRFilter) error {
 	oldRow, err := db.GetCertificateRequestAndChain(filter)
 	if err != nil {
-		log.Println(err)
-		return fmt.Errorf("%w: no certificate request found", ErrNotFound)
+		return err
 	}
 	if oldRow.CertificateChain == "" {
 		return fmt.Errorf("%w: no certificate to revoke with associated CSR", ErrInvalidInput)
@@ -535,13 +534,11 @@ func (db *Database) RevokeCertificate(filter CSRFilter) error {
 	}
 	issuerCert, err := db.GetCertificate(ByCertificatePEM(certChain[1]))
 	if err != nil {
-		log.Println(err)
-		return fmt.Errorf("%w: issuer certificate not found", ErrInternal)
+		return err
 	}
-	revokedCert, err := db.GetCertificate(ByCertificatePEM(certChain[0]))
+	certToRevoke, err := db.GetCertificate(ByCertificatePEM(certChain[0]))
 	if err != nil {
-		log.Println(err)
-		return fmt.Errorf("%w: certificate to be revoked not found", ErrInternal)
+		return err
 	}
 	ca, err := db.GetCertificateAuthority(ByCertificateAuthorityCertificateID(issuerCert.CertificateID))
 	if !rowFound(err) {
@@ -553,29 +550,32 @@ func (db *Database) RevokeCertificate(filter CSRFilter) error {
 	}
 	caWithPK, err := db.GetDenormalizedCertificateAuthority(ByCertificateAuthorityID(ca.CertificateAuthorityID))
 	if err != nil {
-		log.Println(err)
-		return fmt.Errorf("%w: issuer certificate authority not found", ErrInternal)
+		return err
 	}
 	newCRL, err := AddCertificateToCRL(oldRow.CertificateChain, caWithPK.PrivateKeyPEM, ca.CRL)
 	if err != nil {
-		log.Println(err)
 		return fmt.Errorf("%w: couldn't add certificate to certificate authority", ErrInternal)
 	}
-	err = db.DeleteCertificate(ByCertificateID(revokedCert.CertificateID))
+	err = db.DeleteCertificate(ByCertificateID(certToRevoke.CertificateID))
 	if err != nil {
-		log.Println(err)
-		return fmt.Errorf("%w: couldn't delete certificate from notary", ErrInternal)
+		return err
 	}
 	err = db.UpdateCertificateAuthorityCRL(ByCertificateAuthorityID(ca.CertificateAuthorityID), newCRL)
 	if err != nil {
-		log.Println(err)
-		return fmt.Errorf("%w: couldn't add new CRL to certificate authority", ErrInternal)
+		return err
 	}
-	err = db.UpdateCertificateAuthorityStatus(ByCertificateAuthorityID(ca.CertificateAuthorityID), CAPending)
-	if err != nil {
-		log.Println(err)
-		return fmt.Errorf("%w: couldn't update certificate authority status to pending", ErrInternal)
+
+	// Check if the certificate being revoked belongs to a CA, if so, set its status to legacy
+	revokedCA, err := db.GetCertificateAuthority(ByCertificateAuthorityCertificateID(certToRevoke.CertificateID))
+	if rowFound(err) {
+		err = db.UpdateCertificateAuthorityStatus(ByCertificateAuthorityID(revokedCA.CertificateAuthorityID), CALegacy)
+		if err != nil {
+			return err
+		}
+	} else if realError(err) {
+		return err
 	}
+
 	stmt, err := sqlair.Prepare(updateCertificateRequestStmt, CertificateRequest{})
 	if err != nil {
 		return err

--- a/internal/server/handlers_certificate_authorities_test.go
+++ b/internal/server/handlers_certificate_authorities_test.go
@@ -1583,6 +1583,22 @@ func TestCertificateRevocationListsEndToEnd(t *testing.T) {
 				t.Fatalf("expected no certificate, got '%s'", csr.CertificateChain)
 			}
 		}
+		statusCode, cas, err := listCertificateAuthorities(ts.URL, client, adminToken)
+		if err != nil {
+			t.Fatalf("expected no error checking CA status, got: %s", err)
+		}
+		if statusCode != http.StatusOK {
+			t.Fatalf("expected status %d when checking CAs, got %d", http.StatusOK, statusCode)
+		}
+		if len(cas.Result) != 2 {
+			t.Fatalf("expected 2 certificate authorities, got %d", len(cas.Result))
+		}
+		if cas.Result[0].Status != "active" {
+			t.Fatalf("expected root CA to remain active after certificate revocation, got %s", cas.Result[0].Status)
+		}
+		if cas.Result[1].Status != "active" {
+			t.Fatalf("expected intermediate CA to remain active after certificate revocation, got %s", cas.Result[1].Status)
+		}
 	})
 
 	t.Run("9. Get both CA's. Each CA should have 1 certificate in their CRL", func(t *testing.T) {

--- a/internal/server/handlers_certificate_authorities_test.go
+++ b/internal/server/handlers_certificate_authorities_test.go
@@ -1628,8 +1628,8 @@ func TestCertificateRevocationListsEndToEnd(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected no error, got: %s", err)
 		}
-		if cas.Result[1].Status != "pending" {
-			t.Fatalf("expected revoked intermediate CA to have revoked status")
+		if cas.Result[1].Status != "legacy" {
+			t.Fatalf("expected revoked intermediate CA to have legacy status")
 		}
 		if cas.Result[1].CertificatePEM != "" {
 			t.Fatalf("expected revoked intermediate CA to not have a certificate")


### PR DESCRIPTION
# Description

When revoking a leaf cert the status of the the issuer's cert should not be changed, but when a CA is revoked, its state should become "legacy"

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
