### PR TITLE
fix: remove CSR and private key when removing CA

### DIFF
--- a/internal/db/db_certificate_authorities.go
+++ b/internal/db/db_certificate_authorities.go
@@ -420,6 +420,16 @@ func (db *Database) DeleteCertificateAuthority(filter CertificateAuthorityFilter
 		log.Println(err)
 		return fmt.Errorf("%w: failed to delete certificate authority", ErrInternal)
 	}
+	err = db.DeleteCertificateRequest(ByCSRID(caRow.CSRID))
+	if err != nil {
+		log.Println(err)
+		return fmt.Errorf("%w: failed to delete CA's certificate request", ErrInternal)
+	}
+	err = db.DeletePrivateKey(ByPrivateKeyID(caRow.PrivateKeyID))
+	if err != nil {
+		log.Println(err)
+		return fmt.Errorf("%w: failed to delete CA's private key", ErrInternal)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Remove the CSR and private key when removing a CA

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
