### PR TITLE
ci: add tics dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,7 @@ on:
       - main
 
 jobs: 
-  tics:
-    uses: ./.github/workflows/tics.yaml
-    secrets: inherit
+
   frontend-unit-test:
     uses: ./.github/workflows/frontend-unittest.yaml
   frontend-build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ on:
       - main
 
 jobs: 
+  tics:
+    uses: ./.github/workflows/tics.yaml
+    secrets: inherit
   frontend-unit-test:
     uses: ./.github/workflows/frontend-unittest.yaml
   frontend-build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,6 @@ on:
       - main
 
 jobs: 
-
   frontend-unit-test:
     uses: ./.github/workflows/frontend-unittest.yaml
   frontend-build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,6 @@ on:
       - main
 
 jobs: 
-  tics:
-    uses: ./.github/workflows/tics.yaml
-    secrets: inherit
   frontend-unit-test:
     uses: ./.github/workflows/frontend-unittest.yaml
   frontend-build:

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -3,7 +3,7 @@ name: TiCS Static Analysis
 on:
   schedule:
     - cron: "0 3 * * 0" # Every Sunday at 3 am
-  workflow_dispatch:
+  workflow_call:
 
 
 jobs:

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -3,6 +3,7 @@ name: TiCS Static Analysis
 on:
   schedule:
     - cron: "0 3 * * 0" # Every Sunday at 3 am
+  workflow_call:
 
 
 jobs:

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: generate coverage
         run: |
           go install github.com/t-yuki/gocover-cobertura@latest
-          go install honnef.co/go/tools/cmd/staticcheck@v0.4.7
+          go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
           go test -v ./... -coverprofile=coverage.out
           gocover-cobertura < coverage.out > coverage.xml
       - name: move results to necessary folder for TICS

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -16,6 +16,7 @@ jobs:
       - name: generate coverage
         run: |
           go install github.com/t-yuki/gocover-cobertura@latest
+          go install honnef.co/go/tools/cmd/staticcheck@v0.4.7
           go test -v ./... -coverprofile=coverage.out
           gocover-cobertura < coverage.out > coverage.xml
       - name: move results to necessary folder for TICS

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -3,7 +3,7 @@ name: TiCS Static Analysis
 on:
   schedule:
     - cron: "0 3 * * 0" # Every Sunday at 3 am
-  workflow_call:
+  workflow_dispatch:
 
 
 jobs:


### PR DESCRIPTION
# Description

I thought tics installed its own dependencies. but it doesn't. it also doesn't error out if it's missing, it just tanks the score of the repo instead.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
