### PR TITLE
chore: reorganize sql statements

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -10,7 +10,8 @@ import (
 
 // Database is the object used to communicate with the established repository.
 type Database struct {
-	conn *sqlair.DB
+	conn  *sqlair.DB
+	stmts *Statements
 }
 
 // Close closes the connection to the repository cleanly.
@@ -21,6 +22,7 @@ func (db *Database) Close() error {
 	if err := db.conn.PlainDB().Close(); err != nil {
 		return err
 	}
+	db.stmts = nil
 	return nil
 }
 
@@ -49,6 +51,8 @@ func NewDatabase(databasePath string) (*Database, error) {
 		return nil, err
 	}
 	db := new(Database)
+	db.stmts = PrepareStatements(db.conn)
 	db.conn = sqlair.NewDB(sqlConnection)
+
 	return db, nil
 }

--- a/internal/db/db_csrs.go
+++ b/internal/db/db_csrs.go
@@ -24,144 +24,9 @@ type CertificateRequestWithChain struct {
 	CertificateChain string `db:"certificate_chain"`
 }
 
-const queryCreateCertificateRequestsTable = `
-	CREATE TABLE IF NOT EXISTS certificate_requests (
-	    csr_id INTEGER PRIMARY KEY AUTOINCREMENT,
-
-		csr TEXT NOT NULL UNIQUE, 
-		certificate_id INTEGER,
-		status TEXT DEFAULT 'Outstanding', 
-		
-		CHECK (status IN ('Outstanding', 'Rejected', 'Revoked', 'Active')),
-		CHECK (NOT (certificate_id == NULL AND status == 'Active' )),
-		CHECK (NOT (certificate_id != NULL AND status == 'Outstanding'))
-        CHECK (NOT (certificate_id != NULL AND status == 'Rejected'))
-        CHECK (NOT (certificate_id != NULL AND status == 'Revoked'))
-)`
-
-const (
-	listCertificateRequestsStmt           = "SELECT &CertificateRequest.* FROM certificate_requests"
-	listCertificateRequestsWithoutCASStmt = "SELECT csrs.&CertificateRequest.csr_id, csrs.&CertificateRequest.csr, csrs.&CertificateRequest.status, csrs.&CertificateRequest.certificate_id FROM certificate_requests csrs LEFT JOIN certificate_authorities cas ON csrs.csr_id = cas.csr_id WHERE cas.certificate_authority_id IS NULL"
-	getCertificateRequestStmt             = "SELECT &CertificateRequest.* FROM certificate_requests WHERE csr_id==$CertificateRequest.csr_id or csr==$CertificateRequest.csr"
-	updateCertificateRequestStmt          = "UPDATE certificate_requests SET certificate_id=$CertificateRequest.certificate_id, status=$CertificateRequest.status WHERE csr_id==$CertificateRequest.csr_id or csr==$CertificateRequest.csr"
-	createCertificateRequestStmt          = "INSERT INTO certificate_requests (csr) VALUES ($CertificateRequest.csr)"
-	deleteCertificateRequestStmt          = "DELETE FROM certificate_requests WHERE csr_id=$CertificateRequest.csr_id or csr=$CertificateRequest.csr"
-
-	listCertificateRequestsWithCertificatesStmt = `
-WITH RECURSIVE certificate_chain AS (
-    SELECT 
-        csr.csr_id,
-        csr.csr,
-		csr.status,
-        cert.certificate_id,
-        cert.issuer_id,
-        cert.certificate,
-        COALESCE(cert.certificate, '') AS chain
-    FROM certificate_requests csr
-    LEFT JOIN certificates cert 
-      ON csr.certificate_id = cert.certificate_id
-    
-    UNION ALL
-    
-    -- Recursive Query: Find the issuer certificate in the certificates table
-    SELECT 
-        cc.csr_id,
-        cc.csr,
-		cc.status,
-        cert.certificate_id,
-        cert.issuer_id,
-        cert.certificate,
-        cc.chain || CHAR(10) || cert.certificate AS chain
-    FROM certificates cert
-    JOIN certificate_chain cc
-      ON cert.certificate_id = cc.issuer_id
-)
-SELECT 
-	&CertificateRequestWithChain.csr_id,
-	&CertificateRequestWithChain.csr,
-	&CertificateRequestWithChain.status,
-	chain AS &CertificateRequestWithChain.certificate_chain
-FROM certificate_chain
-WHERE chain = '' OR issuer_id = 0`
-	listCertificateRequestsWithCertificatesWithoutCASStmt = `
-WITH RECURSIVE certificate_chain AS (
-    SELECT 
-        csr.csr_id,
-        csr.csr,
-		csr.status,
-        cert.certificate_id,
-        cert.issuer_id,
-        cert.certificate,
-        COALESCE(cert.certificate, '') AS chain
-    FROM certificate_requests csr
-    LEFT JOIN certificates cert 
-      ON csr.certificate_id = cert.certificate_id
-    
-    UNION ALL
-    
-    -- Recursive Query: Find the issuer certificate in the certificates table
-    SELECT 
-        cc.csr_id,
-        cc.csr,
-		cc.status,
-        cert.certificate_id,
-        cert.issuer_id,
-        cert.certificate,
-        cc.chain || CHAR(10) || cert.certificate AS chain
-    FROM certificates cert
-    JOIN certificate_chain cc
-      ON cert.certificate_id = cc.issuer_id
-)
-SELECT 
-	cc.&CertificateRequestWithChain.csr_id,
-	cc.&CertificateRequestWithChain.csr,
-	cc.&CertificateRequestWithChain.status,
-	chain AS &CertificateRequestWithChain.certificate_chain
-FROM certificate_chain cc
-LEFT JOIN certificate_authorities cas ON cc.csr_id = cas.csr_id 
-WHERE cas.certificate_authority_id IS NULL AND (chain = '' OR issuer_id = 0)`
-
-	getCertificateRequestWithCertificateStmt = `
-WITH RECURSIVE certificate_chain AS (
-    SELECT 
-        csr.csr_id,
-        csr.csr,
-		csr.status,
-        cert.certificate_id,
-        cert.issuer_id,
-        cert.certificate,
-        COALESCE(cert.certificate, '') AS chain
-    FROM certificate_requests csr
-    LEFT JOIN certificates cert 
-      ON csr.certificate_id = cert.certificate_id
-    
-    UNION ALL
-    
-    -- Recursive Query: Find the issuer certificate in the certificates table
-    SELECT 
-        cc.csr_id,
-        cc.csr,
-		cc.status,
-        cert.certificate_id,
-        cert.issuer_id,
-        cert.certificate,
-        cc.chain || CHAR(10) || cert.certificate AS chain
-    FROM certificates cert
-    JOIN certificate_chain cc
-      ON cert.certificate_id = cc.issuer_id
-)
-SELECT 
-	&CertificateRequestWithChain.csr_id,
-	&CertificateRequestWithChain.csr,
-	&CertificateRequestWithChain.status,
-	chain AS &CertificateRequestWithChain.certificate_chain
-FROM certificate_chain
-WHERE (csr_id = $CertificateRequestWithChain.csr_id OR csr = $CertificateRequestWithChain.csr) AND (chain = '' OR issuer_id = 0)`
-)
-
 // ListCertificateRequests gets every CertificateRequest entry in the table.
 func (db *Database) ListCertificateRequests() ([]CertificateRequest, error) {
-	csrs, err := ListEntities[CertificateRequest](db, listCertificateRequestsStmt)
+	csrs, err := ListEntities[CertificateRequest](db, db.stmts.ListCertificateRequests)
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to list certificate requests", err)
 	}
@@ -170,7 +35,7 @@ func (db *Database) ListCertificateRequests() ([]CertificateRequest, error) {
 
 // ListCertificateRequestsWithoutCAS gets every CertificateRequest entry in the table.
 func (db *Database) ListCertificateRequestsWithoutCAS() ([]CertificateRequest, error) {
-	csrs, err := ListEntities[CertificateRequest](db, listCertificateRequestsWithoutCASStmt)
+	csrs, err := ListEntities[CertificateRequest](db, db.stmts.ListCertificateRequestsWithoutCAS)
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to list certificate requests", err)
 	}
@@ -179,7 +44,7 @@ func (db *Database) ListCertificateRequestsWithoutCAS() ([]CertificateRequest, e
 
 // ListCertificateRequestWithCertificates gets every CertificateRequest entry in the table.
 func (db *Database) ListCertificateRequestWithCertificates() ([]CertificateRequestWithChain, error) {
-	csrs, err := ListEntities[CertificateRequestWithChain](db, listCertificateRequestsWithCertificatesStmt)
+	csrs, err := ListEntities[CertificateRequestWithChain](db, db.stmts.ListCertificateRequestsWithChain)
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to list certificate requests", err)
 	}
@@ -188,7 +53,7 @@ func (db *Database) ListCertificateRequestWithCertificates() ([]CertificateReque
 
 // ListCertificateRequestWithCertificatesWithoutCAS gets every CertificateRequest entry in the table.
 func (db *Database) ListCertificateRequestWithCertificatesWithoutCAS() ([]CertificateRequestWithChain, error) {
-	csrs, err := ListEntities[CertificateRequestWithChain](db, listCertificateRequestsWithCertificatesWithoutCASStmt)
+	csrs, err := ListEntities[CertificateRequestWithChain](db, db.stmts.ListCertificateRequestsWithoutChain)
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to list certificate requests", err)
 	}
@@ -208,7 +73,7 @@ func (db *Database) GetCertificateRequest(filter CSRFilter) (*CertificateRequest
 		return nil, fmt.Errorf("%w: certificate request - both ID and PEM are nil", ErrInvalidFilter)
 	}
 
-	csr, err := GetOneEntity[CertificateRequest](db, getCertificateRequestStmt, csrRow)
+	csr, err := GetOneEntity[CertificateRequest](db, db.stmts.GetCertificateRequest, csrRow)
 	if err != nil {
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return nil, fmt.Errorf("%w: %s", ErrNotFound, "certificate request")
@@ -231,11 +96,7 @@ func (db *Database) GetCertificateRequestAndChain(filter CSRFilter) (*Certificat
 		return nil, fmt.Errorf("%w: certificate request - both ID and PEM are nil", ErrInvalidFilter)
 	}
 
-	stmt, err := sqlair.Prepare(getCertificateRequestWithCertificateStmt, CertificateRequestWithChain{})
-	if err != nil {
-		return nil, fmt.Errorf("%w: failed to get certificate request due to sql compilation error", ErrInternal)
-	}
-	err = db.conn.Query(context.Background(), stmt, csrRow).Get(&csrRow)
+	err := db.conn.Query(context.Background(), db.stmts.GetCertificateRequestWithChain, csrRow).Get(&csrRow)
 	if err != nil {
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return nil, fmt.Errorf("%w: certificate request not found", ErrNotFound)
@@ -250,15 +111,11 @@ func (db *Database) CreateCertificateRequest(csr string) (int64, error) {
 	if err := ValidateCertificateRequest(csr); err != nil {
 		return 0, fmt.Errorf("%w: %e", ErrInvalidCertificateRequest, err)
 	}
-	stmt, err := sqlair.Prepare(createCertificateRequestStmt, CertificateRequest{})
-	if err != nil {
-		return 0, fmt.Errorf("%w: failed to create certificate request due to sql compilation error", ErrInternal)
-	}
 	row := CertificateRequest{
 		CSR: csr,
 	}
 	var outcome sqlair.Outcome
-	err = db.conn.Query(context.Background(), stmt, row).Get(&outcome)
+	err := db.conn.Query(context.Background(), db.stmts.CreateCertificateRequest, row).Get(&outcome)
 	if err != nil {
 		if IsConstraintError(err, "UNIQUE constraint failed") {
 			return 0, fmt.Errorf("%w: certificate request already exists", ErrAlreadyExists)
@@ -278,17 +135,13 @@ func (db *Database) RejectCertificateRequest(filter CSRFilter) error {
 	if err != nil {
 		return err
 	}
-	stmt, err := sqlair.Prepare(updateCertificateRequestStmt, CertificateRequest{})
-	if err != nil {
-		return err
-	}
 	newRow := CertificateRequest{
 		CSR_ID:        oldRow.CSR_ID,
 		CSR:           oldRow.CSR,
 		CertificateID: 0,
 		Status:        "Rejected",
 	}
-	err = db.conn.Query(context.Background(), stmt, newRow).Run()
+	err = db.conn.Query(context.Background(), db.stmts.UpdateCertificateRequest, newRow).Run()
 	if err != nil {
 		return fmt.Errorf("%w: failed to reject certificate request", ErrInternal)
 	}
@@ -302,11 +155,7 @@ func (db *Database) DeleteCertificateRequest(filter CSRFilter) error {
 		return err
 	}
 
-	stmt, err := sqlair.Prepare(deleteCertificateRequestStmt, CertificateRequest{})
-	if err != nil {
-		return fmt.Errorf("%w: failed to delete certificate request due to sql compilation error", ErrInternal)
-	}
-	err = db.conn.Query(context.Background(), stmt, csrRow).Run()
+	err = db.conn.Query(context.Background(), db.stmts.DeleteCertificateRequest, csrRow).Run()
 	if err != nil {
 		return fmt.Errorf("%w: failed to delete certificate request", ErrInternal)
 	}

--- a/internal/db/filter.go
+++ b/internal/db/filter.go
@@ -92,6 +92,7 @@ func (filter *CertificateAuthorityFilter) AsCertificateAuthority() (*Certificate
 	}
 	return &CARow, nil
 }
+
 func (filter *CertificateAuthorityFilter) AsCertificateAuthorityDenormalized() (*CertificateAuthorityDenormalized, error) {
 	var CADenormalizedRow CertificateAuthorityDenormalized
 

--- a/internal/db/sql_stmts.go
+++ b/internal/db/sql_stmts.go
@@ -1,0 +1,418 @@
+package db
+
+import (
+	"github.com/canonical/sqlair"
+)
+
+const (
+	// Table definition SQL Strings
+	queryCreateCertificateRequestsTable = `
+		CREATE TABLE IF NOT EXISTS certificate_requests (
+		    csr_id INTEGER PRIMARY KEY AUTOINCREMENT,
+
+			csr TEXT NOT NULL UNIQUE,
+			certificate_id INTEGER,
+			status TEXT DEFAULT 'Outstanding',
+
+			CHECK (status IN ('Outstanding', 'Rejected', 'Revoked', 'Active')),
+			CHECK (NOT (certificate_id == NULL AND status == 'Active' )),
+			CHECK (NOT (certificate_id != NULL AND status == 'Outstanding'))
+	        CHECK (NOT (certificate_id != NULL AND status == 'Rejected'))
+	        CHECK (NOT (certificate_id != NULL AND status == 'Revoked'))
+    )`
+	queryCreateCertificatesTable = `
+		CREATE TABLE IF NOT EXISTS certificates (
+		    certificate_id INTEGER PRIMARY KEY AUTOINCREMENT,
+			issuer_id INTEGER,
+
+			certificate TEXT NOT NULL UNIQUE
+	)`
+	queryCreateCertificateAuthoritiesTable = `
+		CREATE TABLE IF NOT EXISTS certificate_authorities (
+		    certificate_authority_id INTEGER PRIMARY KEY AUTOINCREMENT,
+
+			crl TEXT,
+			status TEXT DEFAULT 'Pending',
+
+			private_key_id INTEGER,
+			certificate_id INTEGER,
+			csr_id INTEGER NOT NULL UNIQUE,
+
+			CHECK (status IN ('active', 'expired', 'pending', 'legacy')),
+			CHECK (NOT (certificate_id == NULL AND status == 'active' )),
+			CHECK (NOT (certificate_id != NULL AND status == 'pending'))
+	        CHECK (NOT (certificate_id != NULL AND status == 'expired'))
+	)`
+	queryCreatePrivateKeysTable = `
+		CREATE TABLE IF NOT EXISTS private_keys (
+		    private_key_id INTEGER PRIMARY KEY AUTOINCREMENT,
+
+			private_key TEXT NOT NULL UNIQUE
+	)`
+	queryCreateUsersTable = `
+		CREATE TABLE IF NOT EXISTS users (
+	 		id INTEGER PRIMARY KEY AUTOINCREMENT,
+
+			username TEXT NOT NULL UNIQUE
+			CHECK (trim(username) != ''),
+			hashed_password TEXT NOT NULL
+			CHECK (trim(hashed_password) != ''),
+			permissions INTEGER CHECK (permissions IN (0,1))
+	)`
+)
+
+const (
+	// // // // // // // // // // // // //
+	//  Certificate Request SQL Strings //
+	// // // // // // // // // // // // //
+	listCertificateRequestsStmt           = "SELECT &CertificateRequest.* FROM certificate_requests"
+	listCertificateRequestsWithoutCASStmt = "SELECT csrs.&CertificateRequest.csr_id, csrs.&CertificateRequest.csr, csrs.&CertificateRequest.status, csrs.&CertificateRequest.certificate_id FROM certificate_requests csrs LEFT JOIN certificate_authorities cas ON csrs.csr_id = cas.csr_id WHERE cas.certificate_authority_id IS NULL"
+	getCertificateRequestStmt             = "SELECT &CertificateRequest.* FROM certificate_requests WHERE csr_id==$CertificateRequest.csr_id or csr==$CertificateRequest.csr"
+	updateCertificateRequestStmt          = "UPDATE certificate_requests SET certificate_id=$CertificateRequest.certificate_id, status=$CertificateRequest.status WHERE csr_id==$CertificateRequest.csr_id or csr==$CertificateRequest.csr"
+	createCertificateRequestStmt          = "INSERT INTO certificate_requests (csr) VALUES ($CertificateRequest.csr)"
+	deleteCertificateRequestStmt          = "DELETE FROM certificate_requests WHERE csr_id=$CertificateRequest.csr_id or csr=$CertificateRequest.csr"
+
+	listCertificateRequestsWithCertificatesStmt = `
+WITH RECURSIVE certificate_chain AS (
+    SELECT
+        csr.csr_id,
+        csr.csr,
+		csr.status,
+        cert.certificate_id,
+        cert.issuer_id,
+        cert.certificate,
+        COALESCE(cert.certificate, '') AS chain
+    FROM certificate_requests csr
+    LEFT JOIN certificates cert
+      ON csr.certificate_id = cert.certificate_id
+
+    UNION ALL
+
+    -- Recursive Query: Find the issuer certificate in the certificates table
+    SELECT
+        cc.csr_id,
+        cc.csr,
+		cc.status,
+        cert.certificate_id,
+        cert.issuer_id,
+        cert.certificate,
+        cc.chain || CHAR(10) || cert.certificate AS chain
+    FROM certificates cert
+    JOIN certificate_chain cc
+      ON cert.certificate_id = cc.issuer_id
+)
+SELECT
+	&CertificateRequestWithChain.csr_id,
+	&CertificateRequestWithChain.csr,
+	&CertificateRequestWithChain.status,
+	chain AS &CertificateRequestWithChain.certificate_chain
+FROM certificate_chain
+WHERE chain = '' OR issuer_id = 0`
+	listCertificateRequestsWithCertificatesWithoutCASStmt = `
+WITH RECURSIVE certificate_chain AS (
+    SELECT
+        csr.csr_id,
+        csr.csr,
+		csr.status,
+        cert.certificate_id,
+        cert.issuer_id,
+        cert.certificate,
+        COALESCE(cert.certificate, '') AS chain
+    FROM certificate_requests csr
+    LEFT JOIN certificates cert
+      ON csr.certificate_id = cert.certificate_id
+
+    UNION ALL
+
+    -- Recursive Query: Find the issuer certificate in the certificates table
+    SELECT
+        cc.csr_id,
+        cc.csr,
+		cc.status,
+        cert.certificate_id,
+        cert.issuer_id,
+        cert.certificate,
+        cc.chain || CHAR(10) || cert.certificate AS chain
+    FROM certificates cert
+    JOIN certificate_chain cc
+      ON cert.certificate_id = cc.issuer_id
+)
+SELECT
+	cc.&CertificateRequestWithChain.csr_id,
+	cc.&CertificateRequestWithChain.csr,
+	cc.&CertificateRequestWithChain.status,
+	chain AS &CertificateRequestWithChain.certificate_chain
+FROM certificate_chain cc
+LEFT JOIN certificate_authorities cas ON cc.csr_id = cas.csr_id
+WHERE cas.certificate_authority_id IS NULL AND (chain = '' OR issuer_id = 0)`
+
+	getCertificateRequestWithCertificateStmt = `
+WITH RECURSIVE certificate_chain AS (
+    SELECT
+        csr.csr_id,
+        csr.csr,
+		csr.status,
+        cert.certificate_id,
+        cert.issuer_id,
+        cert.certificate,
+        COALESCE(cert.certificate, '') AS chain
+    FROM certificate_requests csr
+    LEFT JOIN certificates cert
+      ON csr.certificate_id = cert.certificate_id
+
+    UNION ALL
+
+    -- Recursive Query: Find the issuer certificate in the certificates table
+    SELECT
+        cc.csr_id,
+        cc.csr,
+		cc.status,
+        cert.certificate_id,
+        cert.issuer_id,
+        cert.certificate,
+        cc.chain || CHAR(10) || cert.certificate AS chain
+    FROM certificates cert
+    JOIN certificate_chain cc
+      ON cert.certificate_id = cc.issuer_id
+)
+SELECT
+	&CertificateRequestWithChain.csr_id,
+	&CertificateRequestWithChain.csr,
+	&CertificateRequestWithChain.status,
+	chain AS &CertificateRequestWithChain.certificate_chain
+FROM certificate_chain
+WHERE (csr_id = $CertificateRequestWithChain.csr_id OR csr = $CertificateRequestWithChain.csr) AND (chain = '' OR issuer_id = 0)`
+
+	// // // // // // // // // //
+	// Certificate SQL Strings //
+	// // // // // // // // // //
+	createCertificateStmt   = "INSERT INTO certificates (certificate, issuer_id) VALUES ($Certificate.certificate, $Certificate.issuer_id)"
+	addCertificateToCSRStmt = "UPDATE certificates SET certificate_id=$Certificate.certificate_id, status=$CertificateRequest.status WHERE id==$CertificateRequest.id or csr==$CertificateRequest.csr"
+	getCertificateStmt      = "SELECT &Certificate.* FROM certificates WHERE certificate_id==$Certificate.certificate_id or certificate==$Certificate.certificate"
+	updateCertificateStmt   = "UPDATE certificates SET issuer_id=$Certificate.issuer_id WHERE certificate_id==$Certificate.certificate_id or certificate==$Certificate.certificate"
+	listCertificatesStmt    = "SELECT &Certificate.* FROM certificates"
+	deleteCertificateStmt   = "DELETE FROM certificates WHERE certificate_id=$Certificate.certificate_id or certificate=$Certificate.certificate"
+
+	getCertificateChainStmt = `WITH RECURSIVE cert_chain AS (
+    -- Initial query: Start search from the end certificate
+    SELECT certificate_id, certificate, issuer_id
+    FROM certificates
+    WHERE certificate_id = $Certificate.certificate_id or certificate = $Certificate.certificate
+
+    UNION ALL
+
+    -- Recursive Query: Move up the chain until issuer_id is 0 (root)
+    SELECT certs.certificate_id, certs.certificate, certs.issuer_id
+    FROM certificates certs
+    JOIN cert_chain
+      ON certs.certificate_id = cert_chain.issuer_id
+)
+SELECT &Certificate.* FROM cert_chain;`
+
+	// // // // // // // // // // // // // //
+	//  Certificate Authority SQL Strings  //
+	// // // // // // // // // // // // // //
+	createCertificateAuthorityStmt = "INSERT INTO certificate_authorities (crl, status, private_key_id, csr_id, certificate_id) VALUES ($CertificateAuthority.crl, $CertificateAuthority.status, $CertificateAuthority.private_key_id, $CertificateAuthority.csr_id, $CertificateAuthority.certificate_id)"
+	getCertificateAuthorityStmt    = "SELECT &CertificateAuthority.* FROM certificate_authorities WHERE certificate_authority_id==$CertificateAuthority.certificate_authority_id or csr_id==$CertificateAuthority.csr_id or certificate_id==$CertificateAuthority.certificate_id"
+	listCertificateAuthoritiesStmt = "SELECT &CertificateAuthority.* FROM certificate_authorities"
+	updateCertificateAuthorityStmt = "UPDATE certificate_authorities SET crl=$CertificateAuthority.crl, status=$CertificateAuthority.status, certificate_id=$CertificateAuthority.certificate_id WHERE certificate_authority_id==$CertificateAuthority.certificate_authority_id or csr_id==$CertificateAuthority.csr_id"
+	deleteCertificateAuthorityStmt = "DELETE FROM certificate_authorities WHERE certificate_authority_id=$CertificateAuthority.certificate_authority_id or csr_id=$CertificateAuthority.csr_id"
+
+	listDenormalizedCertificateAuthoritiesStmt = `
+WITH RECURSIVE cas_with_chain AS (
+    SELECT
+        cas.certificate_authority_id,
+        cas.private_key_id,
+		cas.csr_id,
+        cas.status,
+        cas.crl,
+        certs.certificate_id,
+        certs.issuer_id,
+        certs.certificate,
+        COALESCE(certs.certificate, '') AS chain
+    FROM certificate_authorities cas
+    LEFT JOIN certificates certs ON cas.certificate_id = certs.certificate_id
+
+    UNION ALL
+
+    SELECT
+        cc.certificate_authority_id,
+		cc.private_key_id,
+		cc.csr_id,
+        cc.status,
+		cc.crl,
+        certs.certificate_id,
+        certs.issuer_id,
+        certs.certificate,
+        cc.chain || CHAR(10) || certs.certificate AS chain
+    FROM cas_with_chain cc
+    JOIN certificates certs ON certs.certificate_id = cc.issuer_id
+)
+	SELECT
+		cc.certificate_authority_id as &CertificateAuthorityDenormalized.certificate_authority_id,
+		cc.crl as &CertificateAuthorityDenormalized.crl,
+		cc.status as &CertificateAuthorityDenormalized.status,
+		pk.private_key AS &CertificateAuthorityDenormalized.private_key,
+		cc.chain AS &CertificateAuthorityDenormalized.certificate_chain,
+		csrs.csr AS &CertificateAuthorityDenormalized.csr
+	FROM cas_with_chain cc
+	LEFT JOIN private_keys pk ON cc.private_key_id = pk.private_key_id
+	LEFT JOIN certificate_requests csrs ON cc.csr_id = csrs.csr_id
+	WHERE cc.chain = '' OR cc.issuer_id = 0
+`
+	getDenormalizedCertificateAuthorityStmt = `
+WITH RECURSIVE cas_with_chain AS (
+    SELECT
+        cas.certificate_authority_id,
+        cas.private_key_id,
+		cas.csr_id,
+        cas.status,
+        cas.crl,
+        certs.certificate_id,
+        certs.issuer_id,
+        certs.certificate,
+        COALESCE(certs.certificate, '') AS chain
+    FROM certificate_authorities cas
+    LEFT JOIN certificates certs ON cas.certificate_id = certs.certificate_id
+
+    UNION ALL
+
+    SELECT
+        cc.certificate_authority_id,
+		cc.private_key_id,
+		cc.csr_id,
+        cc.status,
+		cc.crl,
+        certs.certificate_id,
+        certs.issuer_id,
+        certs.certificate,
+        cc.chain || CHAR(10) || certs.certificate AS chain
+    FROM cas_with_chain cc
+    JOIN certificates certs ON certs.certificate_id = cc.issuer_id
+)
+	SELECT
+		cc.certificate_authority_id as &CertificateAuthorityDenormalized.certificate_authority_id,
+		cc.crl as &CertificateAuthorityDenormalized.crl,
+		cc.status as &CertificateAuthorityDenormalized.status,
+		pk.private_key AS &CertificateAuthorityDenormalized.private_key,
+		cc.chain AS &CertificateAuthorityDenormalized.certificate_chain,
+		csrs.csr AS &CertificateAuthorityDenormalized.csr
+	FROM cas_with_chain cc
+	LEFT JOIN private_keys pk ON cc.private_key_id = pk.private_key_id
+	LEFT JOIN certificate_requests csrs ON cc.csr_id = csrs.csr_id
+	WHERE cc.certificate_authority_id==$CertificateAuthorityDenormalized.certificate_authority_id
+			or csrs.csr==$CertificateAuthorityDenormalized.csr
+			and (issuer_id = 0 OR chain = '')`
+
+	// // // // // // // // // //
+	// Private Key SQL Strings //
+	// // // // // // // // // //
+	listPrivateKeysStmt  = "SELECT &PrivateKey.* FROM private_keys"
+	getPrivateKeyStmt    = "SELECT &PrivateKey.* FROM private_keys WHERE private_key_id==$PrivateKey.private_key_id or private_key==$PrivateKey.private_key"
+	createPrivateKeyStmt = "INSERT INTO private_keys (private_key) VALUES ($PrivateKey.private_key)"
+	deletePrivateKeyStmt = "DELETE FROM private_keys WHERE private_key_id==$PrivateKey.private_key_id or private_key==$PrivateKey.private_key"
+
+	// // // // // // // // // //
+	// Users Table SQL Strings //
+	// // // // // // // // // //
+	listUsersStmt   = "SELECT &User.* from users"
+	getUserStmt     = "SELECT &User.* from users WHERE id==$User.id or username==$User.username"
+	createUserStmt  = "INSERT INTO users (username, hashed_password, permissions) VALUES ($User.username, $User.hashed_password, $User.permissions)"
+	updateUserStmt  = "UPDATE users SET hashed_password=$User.hashed_password WHERE id==$User.id or username==$User.username"
+	deleteUserStmt  = "DELETE FROM users WHERE id==$User.id"
+	getNumUsersStmt = "SELECT COUNT(*) AS &NumUsers.count FROM users"
+)
+
+// Statements contains all prepared SQL statements used by the database
+type Statements struct {
+	// Certificate Request statements
+	CreateCertificateRequest            *sqlair.Statement
+	GetCertificateRequest               *sqlair.Statement
+	GetCertificateRequestWithChain      *sqlair.Statement
+	UpdateCertificateRequest            *sqlair.Statement
+	ListCertificateRequests             *sqlair.Statement
+	ListCertificateRequestsWithoutCAS   *sqlair.Statement
+	ListCertificateRequestsWithChain    *sqlair.Statement
+	ListCertificateRequestsWithoutChain *sqlair.Statement
+	DeleteCertificateRequest            *sqlair.Statement
+
+	// Certificate statements
+	CreateCertificate   *sqlair.Statement
+	GetCertificate      *sqlair.Statement
+	ListCertificates    *sqlair.Statement
+	DeleteCertificate   *sqlair.Statement
+	GetCertificateChain *sqlair.Statement
+
+	// Certificate Authority statements
+	CreateCertificateAuthority             *sqlair.Statement
+	GetCertificateAuthority                *sqlair.Statement
+	GetDenormalizedCertificateAuthority    *sqlair.Statement
+	UpdateCertificateAuthority             *sqlair.Statement
+	ListCertificateAuthorities             *sqlair.Statement
+	ListDenormalizedCertificateAuthorities *sqlair.Statement
+	DeleteCertificateAuthority             *sqlair.Statement
+
+	// Private Key statements
+	CreatePrivateKey *sqlair.Statement
+	GetPrivateKey    *sqlair.Statement
+	ListPrivateKeys  *sqlair.Statement
+	DeletePrivateKey *sqlair.Statement
+
+	// User statements
+	CreateUser  *sqlair.Statement
+	GetUser     *sqlair.Statement
+	UpdateUser  *sqlair.Statement
+	ListUsers   *sqlair.Statement
+	DeleteUser  *sqlair.Statement
+	GetNumUsers *sqlair.Statement
+}
+
+// PrepareStatements prepares all SQL statements used by the database.
+// This function runs once during initialization and prepares all SQL statements.
+// It panics if any of the statements fail to prepare.
+func PrepareStatements(db *sqlair.DB) *Statements {
+	stmts := &Statements{}
+
+	// Certificate Request statements
+	stmts.CreateCertificateRequest = sqlair.MustPrepare(createCertificateRequestStmt, CertificateRequest{})
+	stmts.GetCertificateRequest = sqlair.MustPrepare(getCertificateRequestStmt, CertificateRequest{})
+	stmts.GetCertificateRequestWithChain = sqlair.MustPrepare(getCertificateRequestWithCertificateStmt, CertificateRequestWithChain{})
+	stmts.UpdateCertificateRequest = sqlair.MustPrepare(updateCertificateRequestStmt, CertificateRequest{})
+	stmts.ListCertificateRequests = sqlair.MustPrepare(listCertificateRequestsStmt, CertificateRequest{})
+	stmts.ListCertificateRequestsWithoutCAS = sqlair.MustPrepare(listCertificateRequestsWithoutCASStmt, CertificateRequest{})
+	stmts.ListCertificateRequestsWithChain = sqlair.MustPrepare(listCertificateRequestsWithCertificatesStmt, CertificateRequestWithChain{})
+	stmts.ListCertificateRequestsWithoutChain = sqlair.MustPrepare(listCertificateRequestsWithCertificatesWithoutCASStmt, CertificateRequestWithChain{})
+	stmts.DeleteCertificateRequest = sqlair.MustPrepare(deleteCertificateRequestStmt, CertificateRequest{})
+
+	// Certificate statements
+	stmts.CreateCertificate = sqlair.MustPrepare(createCertificateStmt, Certificate{})
+	stmts.GetCertificate = sqlair.MustPrepare(getCertificateStmt, Certificate{})
+	stmts.ListCertificates = sqlair.MustPrepare(listCertificatesStmt, Certificate{})
+	stmts.DeleteCertificate = sqlair.MustPrepare(deleteCertificateStmt, Certificate{})
+	stmts.GetCertificateChain = sqlair.MustPrepare(getCertificateChainStmt, Certificate{})
+
+	// Certificate Authority statements
+	stmts.CreateCertificateAuthority = sqlair.MustPrepare(createCertificateAuthorityStmt, CertificateAuthority{})
+	stmts.GetCertificateAuthority = sqlair.MustPrepare(getCertificateAuthorityStmt, CertificateAuthority{})
+	stmts.GetDenormalizedCertificateAuthority = sqlair.MustPrepare(getDenormalizedCertificateAuthorityStmt, CertificateAuthorityDenormalized{})
+	stmts.UpdateCertificateAuthority = sqlair.MustPrepare(updateCertificateAuthorityStmt, CertificateAuthority{})
+	stmts.ListCertificateAuthorities = sqlair.MustPrepare(listCertificateAuthoritiesStmt, CertificateAuthority{})
+	stmts.ListDenormalizedCertificateAuthorities = sqlair.MustPrepare(listDenormalizedCertificateAuthoritiesStmt, CertificateAuthorityDenormalized{})
+	stmts.DeleteCertificateAuthority = sqlair.MustPrepare(deleteCertificateAuthorityStmt, CertificateAuthority{})
+
+	// Private Key statements
+	stmts.CreatePrivateKey = sqlair.MustPrepare(createPrivateKeyStmt, PrivateKey{})
+	stmts.GetPrivateKey = sqlair.MustPrepare(getPrivateKeyStmt, PrivateKey{})
+	stmts.ListPrivateKeys = sqlair.MustPrepare(listPrivateKeysStmt, PrivateKey{})
+	stmts.DeletePrivateKey = sqlair.MustPrepare(deletePrivateKeyStmt, PrivateKey{})
+
+	// User statements
+	stmts.CreateUser = sqlair.MustPrepare(createUserStmt, User{})
+	stmts.GetUser = sqlair.MustPrepare(getUserStmt, User{})
+	stmts.UpdateUser = sqlair.MustPrepare(updateUserStmt, User{})
+	stmts.ListUsers = sqlair.MustPrepare(listUsersStmt, User{})
+	stmts.DeleteUser = sqlair.MustPrepare(deleteUserStmt, User{})
+	stmts.GetNumUsers = sqlair.MustPrepare(getNumUsersStmt, NumUsers{})
+
+	return stmts
+}

--- a/internal/db/utils.go
+++ b/internal/db/utils.go
@@ -8,21 +8,15 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/canonical/sqlair"
 )
 
 // ListEntities retrieves all entities of a given type from the database.
-func ListEntities[T any](db *Database, query string) ([]T, error) {
-	stmt, err := sqlair.Prepare(query, *new(T))
-	if err != nil {
-		return nil, fmt.Errorf("%w: error compiling sql query", ErrInternal)
-	}
-
+func ListEntities[T any](db *Database, stmt *sqlair.Statement) ([]T, error) {
 	var entities []T
-	err = db.conn.Query(context.Background(), stmt).GetAll(&entities)
+	err := db.conn.Query(context.Background(), stmt).GetAll(&entities)
 	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 		return nil, ErrInternal
 	}
@@ -31,14 +25,9 @@ func ListEntities[T any](db *Database, query string) ([]T, error) {
 }
 
 // GetOneEntity retrieves a single entity of a given type from the database.
-func GetOneEntity[T any](db *Database, query string, params T) (*T, error) {
-	stmt, err := sqlair.Prepare(query, *new(T))
-	if err != nil {
-		return nil, fmt.Errorf("%w: error compiling sql query", ErrInternal)
-	}
-
+func GetOneEntity[T any](db *Database, stmt *sqlair.Statement, params T) (*T, error) {
 	var result T
-	err = db.conn.Query(context.Background(), stmt, params).Get(&result)
+	err := db.conn.Query(context.Background(), stmt, params).Get(&result)
 	if err != nil {
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return nil, ErrNotFound


### PR DESCRIPTION
# Description

This change moves the constant sql statements into its own file, and prepares all of them during startup instead of on-demand. This removes a lot of the unnecessary error checks that are guaranteed to succeed forever if they are compiled the first time.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
