### PR TITLE
docs: correct login path

### DIFF
--- a/docs/reference/api/login.md
+++ b/docs/reference/api/login.md
@@ -6,9 +6,9 @@ This section describes the RESTful API for system user authentication.
 
 This path returns a token that can be used to authenticate with Notary.
 
-| Method | Path            |
-| :----- | :-------------- |
-| `POST` | `/api/v1/login` |
+| Method | Path     |
+| :----- | :------- |
+| `POST` | `/login` |
 
 ### Parameters
 


### PR DESCRIPTION
# Description

The `login` api path was incorrectly documented. Here we replace `/api/v1/login` with `/login` in the API reference.

Fixes #244 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
