### PR TITLE
fix: inform users when backend rejected request [ui]

### DIFF
--- a/ui/src/app/(notary)/certificate_requests/asideForm.tsx
+++ b/ui/src/app/(notary)/certificate_requests/asideForm.tsx
@@ -107,6 +107,7 @@ export default function CertificateRequestsAsidePanel({
         </div>
         <div className="p-form__group row">
           <Button
+            type="button"
             appearance="positive"
             name="submit"
             disabled={!csrIsValid(CSRPEMString)}


### PR DESCRIPTION
# Description

Given an existing CSR in Notary, when users made an identical request using the UI, Notary wouldn't show them why the request failed. The error message from the backend never made its way to the user. Here we address this issue using `type="button`, which prevents the <Button> inside a <form> from triggering a native form submission.

Fixes #231 

## Screenshot

![image](https://github.com/user-attachments/assets/65e7f60e-d2ea-4b39-b517-92123faeb09b)


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
