### PR TITLE
feat: map certificate requests to users

### DIFF
--- a/docs/reference/api/certificate_requests.md
+++ b/docs/reference/api/certificate_requests.md
@@ -21,7 +21,8 @@ None
             "id": 1,
             "csr": "-----BEGIN CERTIFICATE REQUEST-----\nMIICrjCCAZYCAQAwaTELMAkGA1UEBhMCVFIxDjAMBgNVBAgMBUl6bWlyMRIwEAYD\nVQQHDAlOYXJsaWRlcmUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0\nZDETMBEGA1UEAwwKYmFuYW5hLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC\nAQoCggEBAK+vJMxO1GTty09/E4M/RbTCPABleCuYc/uzj72KWaIvoDaanuJ4NBWM\n2aUiepxWdMNTR6oe31gLq4agLYT309tXwCeBLQnOxvBFWONmBG1qo0fQkvT5kSoq\nAO29D7hkQ0gVwg7EF3qOd0JgbDm/yvexKpYLVvWMQAngHwZRnd5vHGk6M3P7G4oG\nmIj/CL2bF6va7GWODYHb+a7jI1nkcsrk+vapc+doVszcoJ+2ryoK6JndOSGjt9SD\nuxulWZHQO32XC0btyub63pom4QxRtRXmb1mjM37XEwXJSsQO1HOnmc6ycqUK53p0\njF8Qbs0m8y/p2NHFGTUfiyNYA3EdkjUCAwEAAaAAMA0GCSqGSIb3DQEBCwUAA4IB\nAQA+hq8kS2Y1Y6D8qH97Mnnc6Ojm61Q5YJ4MghaTD+XXbueTCx4DfK7ujYzK3IEF\npH1AnSeJCsQeBdjT7p6nv5GcwqWXWztNKn9zibXiASK/yYKwqvQpjSjSeqGEh+Sa\n9C9SHeaPhZrJRj0i3NkqmN8moWasF9onW6MNKBX0B+pvBB+igGPcjCIFIFGUUaky\nupMXY9IG3LlWvlt+HTfuMZV+zSOZgD9oyqkh5K9XRKNq/mnNz/1llUCBZRmfeRBY\n+sJ4M6MJRztiyX4/Fjb8UHQviH931rkiEGtG826IvWIyiRSnAeE8B/VzL0GlT9Zq\nge6lFRxB1FlDuU4Blef8FnOI\n-----END CERTIFICATE REQUEST-----",
             "certificate_chain": "",
-            "status": "Outstanding"
+            "status": "Outstanding",
+            "username": "johndoe"
         }
     ]
 }
@@ -70,7 +71,8 @@ None
         "id": 2,
         "csr": "-----BEGIN CERTIFICATE REQUEST-----\nMIICrjCCAZYCAQAwaTELMAkGA1UEBhMCVFIxDjAMBgNVBAgMBUl6bWlyMRIwEAYD\nVQQHDAlOYXJsaWRlcmUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0\nZDETMBEGA1UEAwwKYmFuYW5hLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC\nAQoCggEBAK+vJMxO1GTty09/E4M/RbTCPABleCuYc/uzj72KWaIvoDaanuJ4NBWM\n2aUiepxWdMNTR6oe31gLq4agLYT309tXwCeBLQnOxvBFWONmBG1qo0fQkvT5kSoq\nAO29D7hkQ0gVwg7EF3qOd0JgbDm/yvexKpYLVvWMQAngHwZRnd5vHGk6M3P7G4oG\nmIj/CL2bF6va7GWODYHb+a7jI1nkcsrk+vapc+doVszcoJ+2ryoK6JndOSGjt9SD\nuxulWZHQO32XC0btyub63pom4QxRtRXmb1mjM37XEwXJSsQO1HOnmc6ycqUK53p0\njF8Qbs0m8y/p2NHFGTUfiyNYA3EdkjUCAwEAAaAAMA0GCSqGSIb3DQEBCwUAA4IB\nAQA+hq8kS2Y1Y6D8qH97Mnnc6Ojm61Q5YJ4MghaTD+XXbueTCx4DfK7ujYzK3IEF\npH1AnSeJCsQeBdjT7p6nv5GcwqWXWztNKn9zibXiASK/yYKwqvQpjSjSeqGEh+Sa\n9C9SHeaPhZrJRj0i3NkqmN8moWasF9onW6MNKBX0B+pvBB+igGPcjCIFIFGUUaky\nupMXY9IG3LlWvlt+HTfuMZV+zSOZgD9oyqkh5K9XRKNq/mnNz/1llUCBZRmfeRBY\n+sJ4M6MJRztiyX4/Fjb8UHQviH931rkiEGtG826IvWIyiRSnAeE8B/VzL0GlT9Zq\nge6lFRxB1FlDuU4Blef8FnOI\n-----END CERTIFICATE REQUEST-----",
         "certificate_chain": "",
-        "status": "Outstanding"
+        "status": "Outstanding",
+        "username": "johndoe"
     }
 }
 ```
@@ -173,8 +175,8 @@ None
 
 This path signs any certificate request with an active root or intermediate certificate authority.
 
-| Method | Path                                               |
-| :----- | :------------------------------------------------- |
+| Method | Path                                     |
+| :----- | :--------------------------------------- |
 | `POST` | `/api/v1/certificate_requests/{id}/sign` |
 
 ### Parameters

--- a/internal/db/db_certificate_authorities.go
+++ b/internal/db/db_certificate_authorities.go
@@ -37,8 +37,8 @@ func (db *Database) GetDenormalizedCertificateAuthority(filter CertificateAuthor
 
 // CreateCertificateAuthority creates a new certificate authority in the database from a given CSR, private key, and certificate chain.
 // The certificate chain is optional and can be empty.
-func (db *Database) CreateCertificateAuthority(csrPEM string, privPEM string, crlPEM string, certChainPEM string) (int64, error) {
-	csrID, err := db.CreateCertificateRequest(csrPEM)
+func (db *Database) CreateCertificateAuthority(csrPEM string, privPEM string, crlPEM string, certChainPEM string, userID int64) (int64, error) {
+	csrID, err := db.CreateCertificateRequest(csrPEM, userID)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/db_certificate_authorities_test.go
+++ b/internal/db/db_certificate_authorities_test.go
@@ -25,7 +25,7 @@ func TestRootCertificateAuthorityEndToEnd(t *testing.T) {
 		t.Fatalf("CA found when no CA's should be available")
 	}
 
-	caID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate)
+	caID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, 0)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
@@ -103,7 +103,7 @@ func TestIntermediateCertificateAuthorityEndToEnd(t *testing.T) {
 		t.Fatalf("CA found when no CA's should be available")
 	}
 
-	caID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "")
+	caID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "", 0)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
@@ -183,39 +183,39 @@ func TestCertificateAuthorityFails(t *testing.T) {
 	}
 	defer database.Close()
 
-	_, err = database.CreateCertificateAuthority("", "", "", "")
+	_, err = database.CreateCertificateAuthority("", "", "", "", 0)
 	if err == nil {
 		t.Fatalf("Should have failed to create certificate authority")
 	}
-	_, err = database.CreateCertificateAuthority(RootCACSR, "", "", "")
+	_, err = database.CreateCertificateAuthority(RootCACSR, "", "", "", 0)
 	if err == nil {
 		t.Fatalf("Should have failed to create certificate authority")
 	}
-	_, err = database.CreateCertificateAuthority(RootCACSR, "nope", "", "")
+	_, err = database.CreateCertificateAuthority(RootCACSR, "nope", "", "", 0)
 	if err == nil {
 		t.Fatalf("Should have failed to create certificate authority")
 	}
-	_, err = database.CreateCertificateAuthority("nope", RootCAPrivateKey, RootCACRL, "")
+	_, err = database.CreateCertificateAuthority("nope", RootCAPrivateKey, RootCACRL, "", 0)
 	if err == nil {
 		t.Fatalf("Should have failed to create certificate authority")
 	}
-	_, err = database.CreateCertificateAuthority("", RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate)
+	_, err = database.CreateCertificateAuthority("", RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, 0)
 	if err == nil {
 		t.Fatalf("Should have failed to create certificate authority")
 	}
-	_, err = database.CreateCertificateAuthority(RootCACSR, "", RootCACRL, RootCACertificate+"\n"+RootCACertificate)
+	_, err = database.CreateCertificateAuthority(RootCACSR, "", RootCACRL, RootCACertificate+"\n"+RootCACertificate, 0)
 	if err == nil {
 		t.Fatalf("Should have failed to create certificate authority")
 	}
-	_, err = database.CreateCertificateAuthority("nope", RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate)
+	_, err = database.CreateCertificateAuthority("nope", RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, 0)
 	if err == nil {
 		t.Fatalf("Should have failed to create certificate authority")
 	}
-	_, err = database.CreateCertificateAuthority(RootCACSR, "nope", RootCACRL, RootCACertificate+"\n"+RootCACertificate)
+	_, err = database.CreateCertificateAuthority(RootCACSR, "nope", RootCACRL, RootCACertificate+"\n"+RootCACertificate, 0)
 	if err == nil {
 		t.Fatalf("Should have failed to create certificate authority")
 	}
-	_, err = database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, "", RootCACertificate+"\n"+RootCACertificate)
+	_, err = database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, "", RootCACertificate+"\n"+RootCACertificate, 0)
 	if err == nil {
 		t.Fatalf("Should have failed to create certificate authority")
 	}
@@ -282,7 +282,7 @@ func TestSelfSignedCertificateList(t *testing.T) {
 	}
 	defer database.Close()
 
-	caID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate)
+	caID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, 0)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
@@ -317,11 +317,11 @@ func TestSigningCSRsFromSelfSignedCertificate(t *testing.T) {
 	}
 	defer database.Close()
 
-	caID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate)
+	caID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, 0)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
-	csrID, err := database.CreateCertificateRequest(AppleCSR)
+	csrID, err := database.CreateCertificateRequest(AppleCSR, 0)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
@@ -348,7 +348,7 @@ func TestSigningCSRsFromIntermediateCertificate(t *testing.T) {
 	}
 	defer database.Close()
 
-	caID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, IntermediateCACRL, IntermediateCACertificate+"\n"+RootCACertificate)
+	caID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, IntermediateCACRL, IntermediateCACertificate+"\n"+RootCACertificate, 0)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
@@ -356,7 +356,7 @@ func TestSigningCSRsFromIntermediateCertificate(t *testing.T) {
 		t.Fatalf("Error creating certificate authority: expected CA id to be 1 but it was %d", caID)
 	}
 
-	csrID, err := database.CreateCertificateRequest(AppleCSR)
+	csrID, err := database.CreateCertificateRequest(AppleCSR, 0)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
@@ -386,7 +386,7 @@ func TestSigningCSRFromUnsignedIntermediateCertificate(t *testing.T) {
 	}
 	defer database.Close()
 
-	caID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "")
+	caID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "", 0)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
@@ -394,7 +394,7 @@ func TestSigningCSRFromUnsignedIntermediateCertificate(t *testing.T) {
 		t.Fatalf("Error creating certificate authority: expected CA id to be 1 but it was %d", caID)
 	}
 
-	csrID, err := database.CreateCertificateRequest(AppleCSR)
+	csrID, err := database.CreateCertificateRequest(AppleCSR, 0)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
@@ -421,12 +421,12 @@ func TestSigningIntermediateCAByRootCA(t *testing.T) {
 	}
 	defer database.Close()
 
-	rootCAID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate)
+	rootCAID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, 0)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
 
-	intermediateCAID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "")
+	intermediateCAID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "", 0)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
@@ -447,7 +447,7 @@ func TestSigningIntermediateCAByRootCA(t *testing.T) {
 		t.Fatalf("Expected intermediate ca certificate chain to be 2 certificates long.")
 	}
 
-	csrID, err := database.CreateCertificateRequest(AppleCSR)
+	csrID, err := database.CreateCertificateRequest(AppleCSR, 0)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
@@ -463,7 +463,7 @@ func TestSigningIntermediateCAByRootCA(t *testing.T) {
 		t.Fatalf("Expected end certificate chain to be 3 certificates long.")
 	}
 
-	csrID, err = database.CreateCertificateRequest(StrawberryCSR)
+	csrID, err = database.CreateCertificateRequest(StrawberryCSR, 0)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
@@ -489,7 +489,7 @@ func TestCertificateRevocationListsEndToEnd(t *testing.T) {
 	defer database.Close()
 
 	// The root CA has a valid CRL with no entries.
-	rootCAID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate)
+	rootCAID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, 0)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
@@ -506,7 +506,7 @@ func TestCertificateRevocationListsEndToEnd(t *testing.T) {
 	}
 
 	// The intermediate CA has no CRL.
-	intermediateCAID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "")
+	intermediateCAID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "", 0)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
@@ -547,7 +547,7 @@ func TestCertificateRevocationListsEndToEnd(t *testing.T) {
 	}
 
 	// The signed CSR has a CRLDistributionPoint extension that points to the Intermediate CA's CRL with the correct hostname.
-	csrID, err := database.CreateCertificateRequest(AppleCSR)
+	csrID, err := database.CreateCertificateRequest(AppleCSR, 0)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
@@ -589,7 +589,7 @@ func TestCertificateRevocationListsEndToEnd(t *testing.T) {
 	}
 
 	// The signed certificate has a CRLDistributionPoint extension that points to the root CA's CRL with the correct hostname.
-	csrID, err = database.CreateCertificateRequest(StrawberryCSR)
+	csrID, err = database.CreateCertificateRequest(StrawberryCSR, 0)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}

--- a/internal/db/db_certificate_authorities_test.go
+++ b/internal/db/db_certificate_authorities_test.go
@@ -17,6 +17,11 @@ func TestRootCertificateAuthorityEndToEnd(t *testing.T) {
 	}
 	defer database.Close()
 
+	userID, err := database.CreateUser("testuser", "whateverpassword", 0)
+	if err != nil {
+		t.Fatalf("Couldn't create user: %s", err)
+	}
+
 	cas, err := database.ListCertificateAuthorities()
 	if err != nil {
 		t.Fatalf("Couldn't list certificate authorities: %s", err)
@@ -25,7 +30,7 @@ func TestRootCertificateAuthorityEndToEnd(t *testing.T) {
 		t.Fatalf("CA found when no CA's should be available")
 	}
 
-	caID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, 0)
+	caID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, userID)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
@@ -95,6 +100,11 @@ func TestIntermediateCertificateAuthorityEndToEnd(t *testing.T) {
 	}
 	defer database.Close()
 
+	userID, err := database.CreateUser("testuser", "whateverpassword", 0)
+	if err != nil {
+		t.Fatalf("Couldn't create user: %s", err)
+	}
+
 	cas, err := database.ListCertificateAuthorities()
 	if err != nil {
 		t.Fatalf("Couldn't list certificate authorities: %s", err)
@@ -103,7 +113,7 @@ func TestIntermediateCertificateAuthorityEndToEnd(t *testing.T) {
 		t.Fatalf("CA found when no CA's should be available")
 	}
 
-	caID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "", 0)
+	caID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "", userID)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
@@ -282,7 +292,12 @@ func TestSelfSignedCertificateList(t *testing.T) {
 	}
 	defer database.Close()
 
-	caID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, 0)
+	userID, err := database.CreateUser("testuser", "whateverpassword", 0)
+	if err != nil {
+		t.Fatalf("Couldn't create user: %s", err)
+	}
+
+	caID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, userID)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
@@ -317,11 +332,16 @@ func TestSigningCSRsFromSelfSignedCertificate(t *testing.T) {
 	}
 	defer database.Close()
 
-	caID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, 0)
+	userID, err := database.CreateUser("testuser", "whateverpassword", 0)
+	if err != nil {
+		t.Fatalf("Couldn't create user: %s", err)
+	}
+
+	caID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, userID)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
-	csrID, err := database.CreateCertificateRequest(AppleCSR, 0)
+	csrID, err := database.CreateCertificateRequest(AppleCSR, userID)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
@@ -348,7 +368,12 @@ func TestSigningCSRsFromIntermediateCertificate(t *testing.T) {
 	}
 	defer database.Close()
 
-	caID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, IntermediateCACRL, IntermediateCACertificate+"\n"+RootCACertificate, 0)
+	userID, err := database.CreateUser("testuser", "whateverpassword", 0)
+	if err != nil {
+		t.Fatalf("Couldn't create user: %s", err)
+	}
+
+	caID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, IntermediateCACRL, IntermediateCACertificate+"\n"+RootCACertificate, userID)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
@@ -356,7 +381,7 @@ func TestSigningCSRsFromIntermediateCertificate(t *testing.T) {
 		t.Fatalf("Error creating certificate authority: expected CA id to be 1 but it was %d", caID)
 	}
 
-	csrID, err := database.CreateCertificateRequest(AppleCSR, 0)
+	csrID, err := database.CreateCertificateRequest(AppleCSR, userID)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
@@ -386,7 +411,12 @@ func TestSigningCSRFromUnsignedIntermediateCertificate(t *testing.T) {
 	}
 	defer database.Close()
 
-	caID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "", 0)
+	userID, err := database.CreateUser("testuser", "whateverpassword", 0)
+	if err != nil {
+		t.Fatalf("Couldn't create user: %s", err)
+	}
+
+	caID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "", userID)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
@@ -394,7 +424,7 @@ func TestSigningCSRFromUnsignedIntermediateCertificate(t *testing.T) {
 		t.Fatalf("Error creating certificate authority: expected CA id to be 1 but it was %d", caID)
 	}
 
-	csrID, err := database.CreateCertificateRequest(AppleCSR, 0)
+	csrID, err := database.CreateCertificateRequest(AppleCSR, userID)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
@@ -421,12 +451,17 @@ func TestSigningIntermediateCAByRootCA(t *testing.T) {
 	}
 	defer database.Close()
 
-	rootCAID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, 0)
+	userID, err := database.CreateUser("testuser", "whateverpassword", 0)
+	if err != nil {
+		t.Fatalf("Couldn't create user: %s", err)
+	}
+
+	rootCAID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, userID)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
 
-	intermediateCAID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "", 0)
+	intermediateCAID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "", userID)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
@@ -447,7 +482,7 @@ func TestSigningIntermediateCAByRootCA(t *testing.T) {
 		t.Fatalf("Expected intermediate ca certificate chain to be 2 certificates long.")
 	}
 
-	csrID, err := database.CreateCertificateRequest(AppleCSR, 0)
+	csrID, err := database.CreateCertificateRequest(AppleCSR, userID)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
@@ -463,7 +498,7 @@ func TestSigningIntermediateCAByRootCA(t *testing.T) {
 		t.Fatalf("Expected end certificate chain to be 3 certificates long.")
 	}
 
-	csrID, err = database.CreateCertificateRequest(StrawberryCSR, 0)
+	csrID, err = database.CreateCertificateRequest(StrawberryCSR, userID)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
@@ -488,8 +523,13 @@ func TestCertificateRevocationListsEndToEnd(t *testing.T) {
 	}
 	defer database.Close()
 
+	userID, err := database.CreateUser("testuser", "whateverpassword", 0)
+	if err != nil {
+		t.Fatalf("Couldn't create user: %s", err)
+	}
+
 	// The root CA has a valid CRL with no entries.
-	rootCAID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, 0)
+	rootCAID, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, userID)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
@@ -506,7 +546,7 @@ func TestCertificateRevocationListsEndToEnd(t *testing.T) {
 	}
 
 	// The intermediate CA has no CRL.
-	intermediateCAID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "", 0)
+	intermediateCAID, err := database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "", userID)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
@@ -547,7 +587,7 @@ func TestCertificateRevocationListsEndToEnd(t *testing.T) {
 	}
 
 	// The signed CSR has a CRLDistributionPoint extension that points to the Intermediate CA's CRL with the correct hostname.
-	csrID, err := database.CreateCertificateRequest(AppleCSR, 0)
+	csrID, err := database.CreateCertificateRequest(AppleCSR, userID)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
@@ -589,7 +629,7 @@ func TestCertificateRevocationListsEndToEnd(t *testing.T) {
 	}
 
 	// The signed certificate has a CRLDistributionPoint extension that points to the root CA's CRL with the correct hostname.
-	csrID, err = database.CreateCertificateRequest(StrawberryCSR, 0)
+	csrID, err = database.CreateCertificateRequest(StrawberryCSR, userID)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}

--- a/internal/db/db_certificates_test.go
+++ b/internal/db/db_certificates_test.go
@@ -17,14 +17,14 @@ func TestCertificatesEndToEnd(t *testing.T) {
 	}
 	defer database.Close()
 
-	csrID, err := database.CreateCertificateRequest(AppleCSR)
+	csrID, err := database.CreateCertificateRequest(AppleCSR, 0)
 	if err != nil {
 		t.Fatalf("Couldn't complete Create: %s", err)
 	}
 	if csrID != 1 {
 		t.Fatalf("Couldn't complete Create: wrong csr id. expected 1, got %d", csrID)
 	}
-	csrID, err = database.CreateCertificateRequest(BananaCSR)
+	csrID, err = database.CreateCertificateRequest(BananaCSR, 0)
 	if err != nil {
 		t.Fatalf("Couldn't complete Create: %s", err)
 	}
@@ -130,7 +130,7 @@ func TestGetCertificateFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	database.CreateCertificateRequest(AppleCSR)                                                                                      //nolint:errcheck
+	database.CreateCertificateRequest(AppleCSR, 0)                                                                                   //nolint:errcheck
 	database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(AppleCSR), AppleCert+IntermediateCert+"some extra string"+RootCert) //nolint:errcheck
 
 	cert, err := database.GetCertificate(db.ByCertificatePEM(AppleCert))
@@ -167,11 +167,11 @@ func TestCertificateAddFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	_, err := database.CreateCertificateRequest(AppleCSR)
+	_, err := database.CreateCertificateRequest(AppleCSR, 0)
 	if err != nil {
 		t.Fatalf("The certificate should have been uploaded successfully")
 	}
-	_, err = database.CreateCertificateRequest(BananaCSR)
+	_, err = database.CreateCertificateRequest(BananaCSR, 0)
 	if err != nil {
 		t.Fatalf("The certificate should have been uploaded successfully")
 	}
@@ -206,11 +206,11 @@ func TestGetCertificateChainFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	_, err := database.CreateCertificateRequest(AppleCSR)
+	_, err := database.CreateCertificateRequest(AppleCSR, 0)
 	if err != nil {
 		t.Fatalf("The certificate should have been uploaded successfully")
 	}
-	_, err = database.CreateCertificateRequest(BananaCSR)
+	_, err = database.CreateCertificateRequest(BananaCSR, 0)
 	if err != nil {
 		t.Fatalf("The certificate should have been uploaded successfully")
 	}

--- a/internal/db/db_certificates_test.go
+++ b/internal/db/db_certificates_test.go
@@ -17,14 +17,19 @@ func TestCertificatesEndToEnd(t *testing.T) {
 	}
 	defer database.Close()
 
-	csrID, err := database.CreateCertificateRequest(AppleCSR, 0)
+	userID, err := database.CreateUser("testuser", "testpassword", 0)
+	if err != nil {
+		t.Fatalf("Couldn't complete CreateUser: %s", err)
+	}
+
+	csrID, err := database.CreateCertificateRequest(AppleCSR, userID)
 	if err != nil {
 		t.Fatalf("Couldn't complete Create: %s", err)
 	}
 	if csrID != 1 {
 		t.Fatalf("Couldn't complete Create: wrong csr id. expected 1, got %d", csrID)
 	}
-	csrID, err = database.CreateCertificateRequest(BananaCSR, 0)
+	csrID, err = database.CreateCertificateRequest(BananaCSR, userID)
 	if err != nil {
 		t.Fatalf("Couldn't complete Create: %s", err)
 	}
@@ -130,7 +135,12 @@ func TestGetCertificateFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	database.CreateCertificateRequest(AppleCSR, 0)                                                                                   //nolint:errcheck
+	userID, err := database.CreateUser("testuser", "testpassword", 0)
+	if err != nil {
+		t.Fatalf("Couldn't complete CreateUser: %s", err)
+	}
+
+	database.CreateCertificateRequest(AppleCSR, userID)                                                                              //nolint:errcheck
 	database.AddCertificateChainToCertificateRequest(db.ByCSRPEM(AppleCSR), AppleCert+IntermediateCert+"some extra string"+RootCert) //nolint:errcheck
 
 	cert, err := database.GetCertificate(db.ByCertificatePEM(AppleCert))
@@ -167,11 +177,16 @@ func TestCertificateAddFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	_, err := database.CreateCertificateRequest(AppleCSR, 0)
+	userID, err := database.CreateUser("testuser", "testpassword", 0)
+	if err != nil {
+		t.Fatalf("Couldn't complete CreateUser: %s", err)
+	}
+
+	_, err = database.CreateCertificateRequest(AppleCSR, userID)
 	if err != nil {
 		t.Fatalf("The certificate should have been uploaded successfully")
 	}
-	_, err = database.CreateCertificateRequest(BananaCSR, 0)
+	_, err = database.CreateCertificateRequest(BananaCSR, userID)
 	if err != nil {
 		t.Fatalf("The certificate should have been uploaded successfully")
 	}
@@ -206,11 +221,16 @@ func TestGetCertificateChainFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	_, err := database.CreateCertificateRequest(AppleCSR, 0)
+	userID, err := database.CreateUser("testuser", "testpassword", 0)
+	if err != nil {
+		t.Fatalf("Couldn't complete CreateUser: %s", err)
+	}
+
+	_, err = database.CreateCertificateRequest(AppleCSR, userID)
 	if err != nil {
 		t.Fatalf("The certificate should have been uploaded successfully")
 	}
-	_, err = database.CreateCertificateRequest(BananaCSR, 0)
+	_, err = database.CreateCertificateRequest(BananaCSR, userID)
 	if err != nil {
 		t.Fatalf("The certificate should have been uploaded successfully")
 	}

--- a/internal/db/db_csrs.go
+++ b/internal/db/db_csrs.go
@@ -33,12 +33,13 @@ func (db *Database) GetCertificateRequestAndChain(filter CSRFilter) (*Certificat
 }
 
 // CreateCertificateRequest creates a new CSR entry in the repository. The string must be a valid CSR and unique.
-func (db *Database) CreateCertificateRequest(csr string) (int64, error) {
+func (db *Database) CreateCertificateRequest(csr string, userID int64) (int64, error) {
 	if err := ValidateCertificateRequest(csr); err != nil {
 		return 0, err
 	}
 	row := CertificateRequest{
-		CSR: csr,
+		CSR:    csr,
+		UserID: userID,
 	}
 	return CreateEntity(db, db.stmts.CreateCertificateRequest, row)
 }

--- a/internal/db/db_csrs_test.go
+++ b/internal/db/db_csrs_test.go
@@ -17,21 +17,21 @@ func TestCSRsEndToEnd(t *testing.T) {
 	}
 	defer database.Close()
 
-	csrID, err := database.CreateCertificateRequest(AppleCSR)
+	csrID, err := database.CreateCertificateRequest(AppleCSR, 0)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
 	if csrID != 1 {
 		t.Fatalf("Couldn't complete Create: expected user id 1, but got %d", csrID)
 	}
-	csrID, err = database.CreateCertificateRequest(BananaCSR)
+	csrID, err = database.CreateCertificateRequest(BananaCSR, 0)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
 	if csrID != 2 {
 		t.Fatalf("Couldn't complete Create: expected user id 2, but got %d", csrID)
 	}
-	csrID, err = database.CreateCertificateRequest(StrawberryCSR)
+	csrID, err = database.CreateCertificateRequest(StrawberryCSR, 0)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
@@ -130,15 +130,15 @@ func TestCreateCertificateRequestFails(t *testing.T) {
 	defer db.Close()
 
 	InvalidCSR := strings.ReplaceAll(AppleCSR, "M", "i")
-	if _, err := db.CreateCertificateRequest(InvalidCSR); err == nil {
+	if _, err := db.CreateCertificateRequest(InvalidCSR, 0); err == nil {
 		t.Fatalf("Expected error due to invalid CSR")
 	}
 
-	_, err := db.CreateCertificateRequest(AppleCSR)
+	_, err := db.CreateCertificateRequest(AppleCSR, 0)
 	if err != nil {
 		t.Fatalf("Failed to create CSR: %s", err)
 	}
-	if _, err := db.CreateCertificateRequest(AppleCSR); err == nil {
+	if _, err := db.CreateCertificateRequest(AppleCSR, 0); err == nil {
 		t.Fatalf("Expected error due to duplicate CSR")
 	}
 }
@@ -147,7 +147,7 @@ func TestGetCertificateRequestFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	_, err := database.CreateCertificateRequest(AppleCSR)
+	_, err := database.CreateCertificateRequest(AppleCSR, 0)
 	if err != nil {
 		t.Fatalf("Failed to create CSR: %s", err)
 	}
@@ -173,7 +173,7 @@ func TestGetCertificateRequestFails(t *testing.T) {
 func TestDeleteCertificateRequest(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
-	_, err := database.CreateCertificateRequest(AppleCSR)
+	_, err := database.CreateCertificateRequest(AppleCSR, 0)
 	if err != nil {
 		t.Fatalf("Failed to create CSR: %s", err)
 	}
@@ -204,7 +204,7 @@ func TestRevokeCertificateRequestFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	_, err := database.CreateCertificateRequest(AppleCSR)
+	_, err := database.CreateCertificateRequest(AppleCSR, 0)
 	if err != nil {
 		t.Fatalf("Failed to create CSR: %s", err)
 	}
@@ -229,7 +229,7 @@ func TestRejectCertificateRequestFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	_, err := database.CreateCertificateRequest(AppleCSR)
+	_, err := database.CreateCertificateRequest(AppleCSR, 0)
 	if err != nil {
 		t.Fatalf("Failed to create CSR: %s", err)
 	}
@@ -259,15 +259,15 @@ func TestCASNotShowingUpInCSRsTable(t *testing.T) {
 		t.Fatalf("Couldn't complete NewDatabase: %s", err)
 	}
 	defer database.Close()
-	_, err = database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate)
+	_, err = database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, 0)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
-	_, err = database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "")
+	_, err = database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "", 0)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
-	_, err = database.CreateCertificateRequest(AppleCSR)
+	_, err = database.CreateCertificateRequest(AppleCSR, 0)
 	if err != nil {
 		t.Fatalf("Failed to create CSR: %s", err)
 	}

--- a/internal/db/db_csrs_test.go
+++ b/internal/db/db_csrs_test.go
@@ -17,21 +17,26 @@ func TestCSRsEndToEnd(t *testing.T) {
 	}
 	defer database.Close()
 
-	csrID, err := database.CreateCertificateRequest(AppleCSR, 0)
+	userID, err := database.CreateUser("testuser", "testpassword", 0)
+	if err != nil {
+		t.Fatalf("Couldn't create user: %s", err)
+	}
+
+	csrID, err := database.CreateCertificateRequest(AppleCSR, userID)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
 	if csrID != 1 {
 		t.Fatalf("Couldn't complete Create: expected user id 1, but got %d", csrID)
 	}
-	csrID, err = database.CreateCertificateRequest(BananaCSR, 0)
+	csrID, err = database.CreateCertificateRequest(BananaCSR, userID)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
 	if csrID != 2 {
 		t.Fatalf("Couldn't complete Create: expected user id 2, but got %d", csrID)
 	}
-	csrID, err = database.CreateCertificateRequest(StrawberryCSR, 0)
+	csrID, err = database.CreateCertificateRequest(StrawberryCSR, userID)
 	if err != nil {
 		t.Fatalf("Couldn't create CSR: %s", err)
 	}
@@ -129,16 +134,21 @@ func TestCreateCertificateRequestFails(t *testing.T) {
 	db, _ := db.NewDatabase(":memory:")
 	defer db.Close()
 
+	userID, err := db.CreateUser("testuser", "testpassword", 0)
+	if err != nil {
+		t.Fatalf("Couldn't create user: %s", err)
+	}
+
 	InvalidCSR := strings.ReplaceAll(AppleCSR, "M", "i")
 	if _, err := db.CreateCertificateRequest(InvalidCSR, 0); err == nil {
 		t.Fatalf("Expected error due to invalid CSR")
 	}
 
-	_, err := db.CreateCertificateRequest(AppleCSR, 0)
+	_, err = db.CreateCertificateRequest(AppleCSR, userID)
 	if err != nil {
 		t.Fatalf("Failed to create CSR: %s", err)
 	}
-	if _, err := db.CreateCertificateRequest(AppleCSR, 0); err == nil {
+	if _, err := db.CreateCertificateRequest(AppleCSR, userID); err == nil {
 		t.Fatalf("Expected error due to duplicate CSR")
 	}
 }
@@ -147,7 +157,12 @@ func TestGetCertificateRequestFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	_, err := database.CreateCertificateRequest(AppleCSR, 0)
+	userID, err := database.CreateUser("testuser", "testpassword", 0)
+	if err != nil {
+		t.Fatalf("Couldn't create user: %s", err)
+	}
+
+	_, err = database.CreateCertificateRequest(AppleCSR, userID)
 	if err != nil {
 		t.Fatalf("Failed to create CSR: %s", err)
 	}
@@ -173,7 +188,13 @@ func TestGetCertificateRequestFails(t *testing.T) {
 func TestDeleteCertificateRequest(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
-	_, err := database.CreateCertificateRequest(AppleCSR, 0)
+
+	userID, err := database.CreateUser("testuser", "testpassword", 0)
+	if err != nil {
+		t.Fatalf("Couldn't create user: %s", err)
+	}
+
+	_, err = database.CreateCertificateRequest(AppleCSR, userID)
 	if err != nil {
 		t.Fatalf("Failed to create CSR: %s", err)
 	}
@@ -204,7 +225,12 @@ func TestRevokeCertificateRequestFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	_, err := database.CreateCertificateRequest(AppleCSR, 0)
+	userID, err := database.CreateUser("testuser", "testpassword", 0)
+	if err != nil {
+		t.Fatalf("Couldn't create user: %s", err)
+	}
+
+	_, err = database.CreateCertificateRequest(AppleCSR, userID)
 	if err != nil {
 		t.Fatalf("Failed to create CSR: %s", err)
 	}
@@ -229,7 +255,12 @@ func TestRejectCertificateRequestFails(t *testing.T) {
 	database, _ := db.NewDatabase(":memory:")
 	defer database.Close()
 
-	_, err := database.CreateCertificateRequest(AppleCSR, 0)
+	userID, err := database.CreateUser("testuser", "testpassword", 0)
+	if err != nil {
+		t.Fatalf("Couldn't create user: %s", err)
+	}
+
+	_, err = database.CreateCertificateRequest(AppleCSR, userID)
 	if err != nil {
 		t.Fatalf("Failed to create CSR: %s", err)
 	}
@@ -259,15 +290,21 @@ func TestCASNotShowingUpInCSRsTable(t *testing.T) {
 		t.Fatalf("Couldn't complete NewDatabase: %s", err)
 	}
 	defer database.Close()
-	_, err = database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, 0)
+
+	userID, err := database.CreateUser("testuser", "testpassword", 0)
+	if err != nil {
+		t.Fatalf("Couldn't create user: %s", err)
+	}
+
+	_, err = database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, userID)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
-	_, err = database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "", 0)
+	_, err = database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "", userID)
 	if err != nil {
 		t.Fatalf("Couldn't create certificate authority: %s", err)
 	}
-	_, err = database.CreateCertificateRequest(AppleCSR, 0)
+	_, err = database.CreateCertificateRequest(AppleCSR, userID)
 	if err != nil {
 		t.Fatalf("Failed to create CSR: %s", err)
 	}

--- a/internal/db/db_init_test.go
+++ b/internal/db/db_init_test.go
@@ -22,7 +22,7 @@ func Example() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	csrID, err := database.CreateCertificateRequest(BananaCSR)
+	csrID, err := database.CreateCertificateRequest(BananaCSR, 0)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/internal/db/sql_stmts.go
+++ b/internal/db/sql_stmts.go
@@ -12,8 +12,10 @@ const (
 
 			csr TEXT NOT NULL UNIQUE,
 			certificate_id INTEGER,
-			user_id INTEGER NOT NULL,
+			user_id INTEGER,
 			status TEXT DEFAULT 'Outstanding',
+
+			FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL,
 
 			CHECK (status IN ('Outstanding', 'Rejected', 'Revoked', 'Active')),
 			CHECK (NOT (certificate_id == NULL AND status == 'Active' )),

--- a/internal/db/sql_stmts.go
+++ b/internal/db/sql_stmts.go
@@ -12,6 +12,7 @@ const (
 
 			csr TEXT NOT NULL UNIQUE,
 			certificate_id INTEGER,
+			user_id INTEGER NOT NULL,
 			status TEXT DEFAULT 'Outstanding',
 
 			CHECK (status IN ('Outstanding', 'Rejected', 'Revoked', 'Active')),
@@ -80,7 +81,7 @@ const (
 	listCertificateRequestsWithoutCASStmt = "SELECT csrs.&CertificateRequest.csr_id, csrs.&CertificateRequest.csr, csrs.&CertificateRequest.status, csrs.&CertificateRequest.certificate_id FROM certificate_requests csrs LEFT JOIN certificate_authorities cas ON csrs.csr_id = cas.csr_id WHERE cas.certificate_authority_id IS NULL"
 	getCertificateRequestStmt             = "SELECT &CertificateRequest.* FROM certificate_requests WHERE csr_id==$CertificateRequest.csr_id or csr==$CertificateRequest.csr"
 	updateCertificateRequestStmt          = "UPDATE certificate_requests SET certificate_id=$CertificateRequest.certificate_id, status=$CertificateRequest.status WHERE csr_id==$CertificateRequest.csr_id or csr==$CertificateRequest.csr"
-	createCertificateRequestStmt          = "INSERT INTO certificate_requests (csr) VALUES ($CertificateRequest.csr)"
+	createCertificateRequestStmt          = "INSERT INTO certificate_requests (csr, user_id) VALUES ($CertificateRequest.csr, $CertificateRequest.user_id)"
 	deleteCertificateRequestStmt          = "DELETE FROM certificate_requests WHERE csr_id=$CertificateRequest.csr_id or csr=$CertificateRequest.csr"
 
 	listCertificateRequestsWithCertificatesStmt = `
@@ -89,6 +90,7 @@ WITH RECURSIVE certificate_chain AS (
         csr.csr_id,
         csr.csr,
 		csr.status,
+		csr.user_id,
         cert.certificate_id,
         cert.issuer_id,
         cert.certificate,
@@ -104,6 +106,7 @@ WITH RECURSIVE certificate_chain AS (
         cc.csr_id,
         cc.csr,
 		cc.status,
+		cc.user_id,
         cert.certificate_id,
         cert.issuer_id,
         cert.certificate,
@@ -124,7 +127,8 @@ WITH RECURSIVE certificate_chain AS (
     SELECT
         csr.csr_id,
         csr.csr,
-		csr.status,
+        csr.status,
+        csr.user_id,
         cert.certificate_id,
         cert.issuer_id,
         cert.certificate,
@@ -139,7 +143,8 @@ WITH RECURSIVE certificate_chain AS (
     SELECT
         cc.csr_id,
         cc.csr,
-		cc.status,
+        cc.status,
+        cc.user_id,
         cert.certificate_id,
         cert.issuer_id,
         cert.certificate,
@@ -152,6 +157,7 @@ SELECT
 	cc.&CertificateRequestWithChain.csr_id,
 	cc.&CertificateRequestWithChain.csr,
 	cc.&CertificateRequestWithChain.status,
+	cc.&CertificateRequestWithChain.user_id,
 	chain AS &CertificateRequestWithChain.certificate_chain
 FROM certificate_chain cc
 LEFT JOIN certificate_authorities cas ON cc.csr_id = cas.csr_id
@@ -163,6 +169,7 @@ WITH RECURSIVE certificate_chain AS (
         csr.csr_id,
         csr.csr,
 		csr.status,
+		csr.user_id,
         cert.certificate_id,
         cert.issuer_id,
         cert.certificate,
@@ -178,6 +185,7 @@ WITH RECURSIVE certificate_chain AS (
         cc.csr_id,
         cc.csr,
 		cc.status,
+		cc.user_id,
         cert.certificate_id,
         cert.issuer_id,
         cert.certificate,

--- a/internal/db/sql_stmts.go
+++ b/internal/db/sql_stmts.go
@@ -198,6 +198,7 @@ SELECT
 	&CertificateRequestWithChain.csr_id,
 	&CertificateRequestWithChain.csr,
 	&CertificateRequestWithChain.status,
+	&CertificateRequestWithChain.user_id,
 	chain AS &CertificateRequestWithChain.certificate_chain
 FROM certificate_chain
 WHERE (csr_id = $CertificateRequestWithChain.csr_id OR csr = $CertificateRequestWithChain.csr) AND (chain = '' OR issuer_id = 0)`

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -87,6 +87,7 @@ type CertificateRequest struct {
 	CSR           string `db:"csr"`
 	Status        string `db:"status"`
 	CertificateID int64  `db:"certificate_id"`
+	UserID        int64  `db:"user_id"`
 }
 
 // CertificateRequestWithChain contains the same information as the CertificateRequest object,
@@ -98,6 +99,7 @@ type CertificateRequestWithChain struct {
 	CSR              string `db:"csr"`
 	Status           string `db:"status"`
 	CertificateChain string `db:"certificate_chain"`
+	UserID           int64  `db:"user_id"`
 }
 
 // PrivateKey contains the PEM encoded string of a private key. This object is only used in relation

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -241,7 +241,7 @@ func generateCertPair(daysRemaining int) (string, string, string) {
 func initializeTestDBWithCerts(t *testing.T, database *db.Database) {
 	for _, v := range []int{5, 10, 32} {
 		csr, cert, ca := generateCertPair(v)
-		csrID, err := database.CreateCertificateRequest(csr)
+		csrID, err := database.CreateCertificateRequest(csr, 0)
 		if err != nil {
 			t.Fatalf("couldn't create test csr: %s", err)
 		}
@@ -254,12 +254,12 @@ func initializeTestDBWithCerts(t *testing.T, database *db.Database) {
 
 func initializeTestDBWithCaCerts(t *testing.T, database *db.Database) {
 	// create an active ca
-	_, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate)
+	_, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, 0)
 	if err != nil {
 		t.Fatalf("couldn't create self signed ca: %s", err)
 	}
 	// create a pending ca
-	_, err = database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "")
+	_, err = database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "", 0)
 	if err != nil {
 		t.Fatalf("couldn't create pending ca: %s", err)
 	}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -239,9 +239,13 @@ func generateCertPair(daysRemaining int) (string, string, string) {
 }
 
 func initializeTestDBWithCerts(t *testing.T, database *db.Database) {
+	userID, err := database.CreateUser("testuser", "whateverPassword", 0)
+	if err != nil {
+		t.Fatalf("couldn't create test user: %s", err)
+	}
 	for _, v := range []int{5, 10, 32} {
 		csr, cert, ca := generateCertPair(v)
-		csrID, err := database.CreateCertificateRequest(csr, 0)
+		csrID, err := database.CreateCertificateRequest(csr, userID)
 		if err != nil {
 			t.Fatalf("couldn't create test csr: %s", err)
 		}
@@ -253,13 +257,18 @@ func initializeTestDBWithCerts(t *testing.T, database *db.Database) {
 }
 
 func initializeTestDBWithCaCerts(t *testing.T, database *db.Database) {
+	// Create user
+	userID, err := database.CreateUser("testuser", "whateverPassword", 0)
+	if err != nil {
+		t.Fatalf("couldn't create test user: %s", err)
+	}
 	// create an active ca
-	_, err := database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, 0)
+	_, err = database.CreateCertificateAuthority(RootCACSR, RootCAPrivateKey, RootCACRL, RootCACertificate+"\n"+RootCACertificate, userID)
 	if err != nil {
 		t.Fatalf("couldn't create self signed ca: %s", err)
 	}
 	// create a pending ca
-	_, err = database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "", 0)
+	_, err = database.CreateCertificateAuthority(IntermediateCACSR, IntermediateCAPrivateKey, "", "", userID)
 	if err != nil {
 		t.Fatalf("couldn't create pending ca: %s", err)
 	}

--- a/internal/server/handlers_certificate_requests.go
+++ b/internal/server/handlers_certificate_requests.go
@@ -64,6 +64,7 @@ type CertificateRequest struct {
 	CSR              string `json:"csr"`
 	CertificateChain string `json:"certificate_chain"`
 	Status           string `json:"status"`
+	UserID           int64  `json:"user_id"`
 }
 
 // ListCertificateRequests returns all of the Certificate Requests
@@ -81,6 +82,7 @@ func ListCertificateRequests(env *HandlerConfig) http.HandlerFunc {
 				CSR:              csr.CSR,
 				Status:           csr.Status,
 				CertificateChain: csr.CertificateChain,
+				UserID:           csr.UserID,
 			}
 		}
 		err = writeResponse(w, certificateRequestsResponse, http.StatusOK)
@@ -104,7 +106,14 @@ func CreateCertificateRequest(env *HandlerConfig) http.HandlerFunc {
 			writeError(w, http.StatusBadRequest, fmt.Errorf("Invalid request: %s", err).Error(), err, env.Logger)
 			return
 		}
-		newCSRID, err := env.DB.CreateCertificateRequest(createCertificateRequestParams.CSR)
+
+		claims, headerErr := getClaimsFromAuthorizationHeader(r.Header.Get("Authorization"), env.JWTSecret)
+		if headerErr != nil {
+			writeError(w, http.StatusUnauthorized, "Unauthorized", headerErr, env.Logger)
+			return
+		}
+
+		newCSRID, err := env.DB.CreateCertificateRequest(createCertificateRequestParams.CSR, claims.ID)
 		if err != nil {
 			if errors.Is(err, db.ErrAlreadyExists) {
 				writeError(w, http.StatusBadRequest, "given csr already recorded", err, env.Logger)
@@ -159,6 +168,7 @@ func GetCertificateRequest(env *HandlerConfig) http.HandlerFunc {
 			CSR:              csr.CSR,
 			CertificateChain: csr.CertificateChain,
 			Status:           csr.Status,
+			UserID:           csr.UserID,
 		}
 		err = writeResponse(w, certificateRequestResponse, http.StatusOK)
 		if err != nil {

--- a/internal/server/handlers_certificate_requests_test.go
+++ b/internal/server/handlers_certificate_requests_test.go
@@ -225,6 +225,9 @@ func TestCertificateRequestsEndToEnd(t *testing.T) {
 		if listCertRequestsResponse.Result[0].CertificateChain != "" {
 			t.Fatalf("expected empty string for certificate chain, got %s", listCertRequestsResponse.Result[0].CertificateChain)
 		}
+		if listCertRequestsResponse.Result[0].Username != "testadmin" {
+			t.Fatalf("expected username 'testadmin', got %s", listCertRequestsResponse.Result[0].Username)
+		}
 	})
 
 	t.Run("4. Get certificate request", func(t *testing.T) {
@@ -246,6 +249,9 @@ func TestCertificateRequestsEndToEnd(t *testing.T) {
 		}
 		if getCertRequestResponse.Result.CertificateChain != "" {
 			t.Fatalf("expected no certificate, got %s", getCertRequestResponse.Result.CertificateChain)
+		}
+		if getCertRequestResponse.Result.Username != "testadmin" {
+			t.Fatalf("expected username 'testadmin', got %s", getCertRequestResponse.Result.Username)
 		}
 	})
 
@@ -342,6 +348,9 @@ func TestCertificateRequestsEndToEnd(t *testing.T) {
 		}
 		if getCertRequestResponse.Result.CertificateChain != "" {
 			t.Fatalf("expected no certificate, got %s", getCertRequestResponse.Result.CertificateChain)
+		}
+		if getCertRequestResponse.Result.Username != "testadmin" {
+			t.Fatalf("expected username 'testadmin', got %s", getCertRequestResponse.Result.Username)
 		}
 	})
 

--- a/ui/src/app/(notary)/certificate_requests/table.tsx
+++ b/ui/src/app/(notary)/certificate_requests/table.tsx
@@ -168,6 +168,7 @@ export function CertificateRequestsTable({
         common_name: csrObj.commonName,
         csr_status: csr_status,
         cert_expiry_date: certObj?.notAfter || "",
+        username: csrEntry.username,
       },
       columns: [
         { content: id.toString() },
@@ -176,6 +177,9 @@ export function CertificateRequestsTable({
         {
           content: certObj?.notAfter || "",
           style: { backgroundColor: getExpiryColor(certObj?.notAfter) },
+        },
+        {
+          content: csrEntry.username,
         },
         {
           content: (
@@ -359,6 +363,10 @@ export function CertificateRequestsTable({
           {
             content: "Certificate Expiry Date",
             sortKey: "cert_expiry_date",
+          },
+          {
+            content: "Username",
+            sortKey: "username",
           },
           {
             content: "Actions",

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -3,6 +3,7 @@ export type CSREntry = {
   csr: string;
   certificate_chain: string;
   status: "Outstanding" | "Active" | "Rejected" | "Revoked";
+  username: string;
 };
 
 export type CertificateSigningRequest = {


### PR DESCRIPTION
# Description

Here we map certificate requests to users, making it clear to certificate administrators who requested which certificate. This feature is valuable on its own and as part of adding authorization support to Notary. This includes changes at the database, API, and UI levels.

## API

We added `username` as a return attribute when retrieving certificate requests `GET https://127.0.0.1:3001/api/v1/certificate_requests/1`

```
{
    "result": {
        "id": 1,
        "csr": "-----BEGIN CERTIFICATE REQUEST-----\nMIIC6TCCAdECAQAwcjELMAkGA1UEBhMCQ0ExCzAJBgNVBAgMAlFDMRIwEAYDVQQH\nDAlNb250csOpYWwxFzAVBgNVBAoMDkNhbm9uaWNhbCBMdGQuMRcwFQYDVQQLDA5D\nYW5vbmljYWwgTHRkLjEQMA4GA1UEAwwHZGRkLmNvbTCCASIwDQYJKoZIhvcNAQEB\nBQADggEPADCCAQoCggEBALb0EezLypyljI1c+prNLIqyOMGJ8U5M85HutF2vy5vs\nYH9WFWkYbXto7M18BKLRHJ1AA9WFeNFGyYwsu+2RESYTCUrTGh2RFlpqvVoanTMx\n57/iDA0Y7FHZByy1HaMyHAui7GSNVutuNUAmwyoVsFcFAVXMh+VSy/FuCmy6Fco1\nJLpu/GVae5Hfx3VV0suktAdEmaV+eMfuxCgUGawPmYIVHHs4FnayYv7SOFvF67fQ\nG8w+NH0jPnIb3AxDsFSUQeTbmhCfHN9pxeDggnpiY1QOj8lxzvVG9xfzQ93cmtjb\ngCT3frs4WtXNPF2H/Kz5ID7dDwslipfWCgvqTUWlmvcCAwEAAaAyMDAGCSqGSIb3\nDQEJDjEjMCEwHwYDVR0RBBgwFoIHZGRkLmNvbYILd3d3LmRkZC5jb20wDQYJKoZI\nhvcNAQELBQADggEBAFhbU7bayznci/TT5R1lCAbrcqYSKdndx00r+gI+NVI2p/mY\n9sNQD3P7loAP1Qj8Gw1QS4Qy1eHzErc1G+s3ujPdasB6zNlP7QVT8uNfHJpQoxNc\nG+Ga1CWvwEC3O0yF9jfqrIyDQW4CNhRVAXwVeiX4hM3qTwGAwV+o/EjWhMENvcuE\nItoO9PfHxNjJCvg7GzoKJapd61yXKr5mf14FUN2FO3oz71xgkndjVKRszX4EETOl\nNYgiZXAeRRWaqQ2a9DIm8mwRvp21f6cug58MA+vm5bYjeCDqhvE3UfA+T/WmauOh\nLwBjBCi42LNHDrFcUQkaesQQ4Gr3wjCRyjhjOf0=\n-----END CERTIFICATE REQUEST-----",
        "certificate_chain": "",
        "status": "Outstanding",
        "username": "gruyaume"
    }
}
```

## Screenshot

![image](https://github.com/user-attachments/assets/500aa5d9-3ee3-4cde-b329-c4ba37fd65c6)

## Reference
- https://docs.google.com/document/d/1cjOmWbiRkswyzcILrRUt16NMw0INs3ywj7M32i3VlCU/edit?tab=t.0

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
