### PR TITLE
feat: display 403 page when user tries to access forbidden page

### DIFF
--- a/ui/src/app/(notary)/users/page.tsx
+++ b/ui/src/app/(notary)/users/page.tsx
@@ -41,6 +41,9 @@ export default function Users() {
     if (query.error.message.includes("401")) {
       removeCookie("user_token");
     }
+    if (query.error.message.includes("403")) {
+      return <Error msg="403 Forbidden: You do not have access to this page." />;
+    }
     return <Error msg={query.error.message} />;
   }
   const users = Array.from(query.data ? query.data : []);

--- a/ui/src/app/(notary)/users/page.tsx
+++ b/ui/src/app/(notary)/users/page.tsx
@@ -42,7 +42,9 @@ export default function Users() {
       removeCookie("user_token");
     }
     if (query.error.message.includes("403")) {
-      return <Error msg="403 Forbidden: You do not have access to this page." />;
+      return (
+        <Error msg="403 Forbidden: You do not have access to this page." />
+      );
     }
     return <Error msg={query.error.message} />;
   }

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -356,5 +356,8 @@ export const retryUnlessUnauthorized = (
   if (error.message.includes("401")) {
     return false;
   }
+  if (error.message.includes("403")) {
+    return false;
+  }
   return true;
 };


### PR DESCRIPTION
# Description

Given a non-admin user, when they try to access a page they are forbidden to access, they are currently seeing a loading component. Here we replace the existing behavior with a clear "forbidden" message making it obvious why the page doesn't load normally.

Fixes #82 

## Screenshot

![image](https://github.com/user-attachments/assets/de89ef40-4c68-4cb9-b336-97d07d2fef92)

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
