### PR TITLE
fix: use GoProjects viewer url in TICS workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,5 +44,3 @@ jobs:
     needs: [snap-build]
     uses: ./.github/workflows/snap-publish.yaml
     secrets: inherit
-  tics:
-    uses: ./.github/workflows/tics.yaml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,3 +44,5 @@ jobs:
     needs: [snap-build]
     uses: ./.github/workflows/snap-publish.yaml
     secrets: inherit
+  tics:
+    uses: ./.github/workflows/tics.yaml

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: "0 3 * * 0" # Every Sunday at 3 am
   workflow_dispatch:
-
+  workflow_call:
 
 jobs:
   analyze:
@@ -30,6 +30,6 @@ jobs:
           mode: qserver
           project: notary
           branchdir: ${{ github.workspace }}
-          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=GoProjects
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
           installTics: true

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -5,6 +5,7 @@ on:
     - cron: "0 3 * * 0" # Every Sunday at 3 am
   workflow_dispatch:
 
+
 jobs:
   analyze:
     runs-on: [self-hosted, linux, amd64, tiobe, jammy]

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "0 3 * * 0" # Every Sunday at 3 am
   workflow_dispatch:
-  workflow_call:
 
 jobs:
   analyze:


### PR DESCRIPTION
# Description

Following a TICS upgrade, all workflows using Go have to update the ‘viewerUrl’ to 'https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=GoProjects'. This should fix an issue with our workflow currently not working. 

## Reference
- https://chat.canonical.com/canonical/pl/w76d5zmx4id7bxrwszsx5cxsme

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
