### PR TITLE
feat: add ability to choose user role ID

### DIFF
--- a/docs/reference/api/accounts.md
+++ b/docs/reference/api/accounts.md
@@ -40,6 +40,9 @@ This path creates a new account. The first account can be created without authen
 
 - `username` (string): The username of the account. 
 - `password` (string): The password of the account.
+- `role_id` (integer): The role ID of the account. Valid values are:
+  - `0`: Admin
+  - `1`: Certificate Manager
 
 ### Sample Response
 

--- a/internal/server/handlers_accounts_test.go
+++ b/internal/server/handlers_accounts_test.go
@@ -55,6 +55,7 @@ func TestAccountsEndToEnd(t *testing.T) {
 		createAccountParams := &tu.CreateAccountParams{
 			Username: "nopass",
 			Password: "myPassword123!",
+			RoleID:   1,
 		}
 		statusCode, response, err := tu.CreateAccount(ts.URL, client, adminToken, createAccountParams)
 		if err != nil {
@@ -193,25 +194,43 @@ func TestCreateAccountInvalidInputs(t *testing.T) {
 		testName string
 		username string
 		password string
+		roleID   int
 		error    string
 	}{
 		{
 			testName: "No username",
 			username: "",
 			password: "password",
+			roleID:   1,
 			error:    "Invalid request: username is required",
 		},
 		{
 			testName: "No password",
 			username: "username",
 			password: "",
+			roleID:   1,
 			error:    "Invalid request: password is required",
 		},
 		{
 			testName: "bad password",
 			username: "username",
 			password: "123",
+			roleID:   1,
 			error:    "Invalid request: Password must have 8 or more characters, must include at least one capital letter, one lowercase letter, and either a number or a symbol.",
+		},
+		{
+			testName: "invalid role ID (negative)",
+			username: "username",
+			password: "Pizza123!",
+			roleID:   -1,
+			error:    "Invalid request: invalid role ID: -1",
+		},
+		{
+			testName: "invalid role ID (no matching role)",
+			username: "username",
+			password: "Pizza123!",
+			roleID:   999,
+			error:    "Invalid request: invalid role ID: 999",
 		},
 	}
 
@@ -220,6 +239,7 @@ func TestCreateAccountInvalidInputs(t *testing.T) {
 			createAccountParams := &tu.CreateAccountParams{
 				Username: test.username,
 				Password: test.password,
+				RoleID:   test.roleID,
 			}
 			statusCode, createCertResponse, err := tu.CreateAccount(ts.URL, client, adminToken, createAccountParams)
 			if err != nil {

--- a/internal/server/handlers_login_test.go
+++ b/internal/server/handlers_login_test.go
@@ -16,6 +16,7 @@ func TestLoginEndToEnd(t *testing.T) {
 		adminUser := &tu.CreateAccountParams{
 			Username: "testadmin",
 			Password: "Admin123",
+			RoleID:   0,
 		}
 		statusCode, _, err := tu.CreateAccount(ts.URL, client, "", adminUser)
 		if err != nil {

--- a/internal/testutils/server_test_utils.go
+++ b/internal/testutils/server_test_utils.go
@@ -49,6 +49,7 @@ func MustPrepareAdminAccount(t *testing.T, ts *httptest.Server) string {
 	adminAccountParams := &CreateAccountParams{
 		Username: "testadmin",
 		Password: "Admin123",
+		RoleID:   0,
 	}
 	statusCode, _, err := CreateAccount(ts.URL, ts.Client(), "", adminAccountParams)
 	if err != nil {
@@ -77,6 +78,7 @@ func MustPrepareNonAdminAccount(t *testing.T, ts *httptest.Server, adminToken st
 	nonAdminAccount := &CreateAccountParams{
 		Username: "testuser",
 		Password: "userPass!",
+		RoleID:   1,
 	}
 	statusCode, _, err := CreateAccount(ts.URL, ts.Client(), adminToken, nonAdminAccount)
 	if err != nil {
@@ -117,6 +119,7 @@ type GetAccountResponse struct {
 type CreateAccountParams struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
+	RoleID   int    `json:"role_id"`
 }
 
 type CreateAccountResponseResult struct {

--- a/ui/src/app/(auth)/initialize/page.tsx
+++ b/ui/src/app/(auth)/initialize/page.tsx
@@ -14,6 +14,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { useState, ChangeEvent } from "react";
 import { useRouter } from "next/navigation";
 import { useCookies } from "react-cookie";
+import { RoleID } from "@/types";
 
 export default function Initialize() {
   const router = useRouter();
@@ -115,6 +116,7 @@ export default function Initialize() {
                 postUserMutation.mutate({
                   username: username,
                   password: password1,
+                  role_id: RoleID.Admin,
                 });
               }
             }}

--- a/ui/src/app/(notary)/users/asideForm.tsx
+++ b/ui/src/app/(notary)/users/asideForm.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   Input,
   PasswordToggle,
+  Select,
   Form,
 } from "@canonical/react-components";
 import { AsideFormData } from "@/types";
@@ -52,6 +53,7 @@ function AddNewUserForm(asideProps: AsideProps) {
     },
   });
   const [username, setUsername] = useState<string>("");
+  const [role_id, setRoleID] = useState<number>(0);
   const [password1, setPassword1] = useState<string>("");
   const [password2, setPassword2] = useState<string>("");
   const passwordsMatch = password1 === password2;
@@ -63,6 +65,9 @@ function AddNewUserForm(asideProps: AsideProps) {
   const [, setErrorText] = useState<string>("");
   const handleUsernameChange = (event: ChangeEvent<HTMLInputElement>) => {
     setUsername(event.target.value);
+  };
+  const handleRoleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setRoleID(Number(event.target.value));
   };
   const handlePassword1Change = (event: ChangeEvent<HTMLInputElement>) => {
     setPassword1(event.target.value);
@@ -79,6 +84,27 @@ function AddNewUserForm(asideProps: AsideProps) {
           type="text"
           required={true}
           onChange={handleUsernameChange}
+        />
+        <Select
+          id="roleID"
+          label="Role"
+          value={role_id.toString()}
+          onChange={handleRoleChange}
+          options={[
+            {
+              disabled: true,
+              label: "Select an option",
+              value: "",
+            },
+            {
+              label: "Admin",
+              value: "0",
+            },
+            {
+              label: "Certificate Manager",
+              value: "1",
+            },
+          ]}
         />
         <PasswordToggle
           help="Password must have 8 or more characters, must include at least one capital letter, one lowercase letter, and either a number or a symbol."
@@ -104,6 +130,7 @@ function AddNewUserForm(asideProps: AsideProps) {
               authToken: auth.user ? auth.user.authToken : "",
               username: username,
               password: password1,
+              role_id: role_id,
             });
           }}
         >

--- a/ui/src/app/(notary)/users/table.tsx
+++ b/ui/src/app/(notary)/users/table.tsx
@@ -1,5 +1,5 @@
 import { useState, Dispatch, SetStateAction } from "react";
-import { AsideFormData, UserEntry } from "@/types";
+import { AsideFormData, UserEntry, RoleID } from "@/types";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   Button,
@@ -75,6 +75,9 @@ export function UsersTable({ users, setAsideOpen, setFormData }: TableProps) {
               content: "Username",
             },
             {
+              content: "Role",
+            },
+            {
               content: "Actions",
               className: "u-align--right has-overflow",
             },
@@ -86,6 +89,9 @@ export function UsersTable({ users, setAsideOpen, setFormData }: TableProps) {
               },
               {
                 content: user.username,
+              },
+              {
+                content: user.role_id === RoleID.Admin ? "Admin" : "Certificate Manager",
               },
               {
                 content: (

--- a/ui/src/queries.ts
+++ b/ui/src/queries.ts
@@ -286,12 +286,14 @@ export async function deleteUser(params: { authToken: string; id: string }) {
 export async function postFirstUser(userForm: {
   username: string;
   password: string;
+  role_id: number;
 }) {
   const response = await fetch("/api/v1/accounts", {
     method: "POST",
     body: JSON.stringify({
       username: userForm.username,
       password: userForm.password,
+      role_id: userForm.role_id,
     }),
   });
   const respData = await response.json();
@@ -307,12 +309,14 @@ export async function postUser(userForm: {
   authToken: string;
   username: string;
   password: string;
+  role_id: number;
 }) {
   const response = await fetch("/api/v1/accounts", {
     method: "POST",
     body: JSON.stringify({
       username: userForm.username,
       password: userForm.password,
+      role_id: userForm.role_id,
     }),
     headers: {
       Authorization: "Bearer " + userForm.authToken,

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -44,6 +44,7 @@ export type User = {
 export type UserEntry = {
   id: number;
   username: string;
+  role_id: RoleID;
 };
 
 export type AsideFormData = {


### PR DESCRIPTION
# Description

Add ability to choose user role ID when creating new accounts.

## API Changes

When users create new accounts using POST to `/api/v1/accounts`, they can choose the role ID

### Parameters

- `username` (string): The username of the account. 
- `password` (string): The password of the account.
- `role_id` (integer): The role ID of the account. Valid values are:
  - `0`: Admin
  - `1`: Certificate Manager

## UI Changes

We see the user role as part of the users table

<img width="2561" height="519" alt="image" src="https://github.com/user-attachments/assets/68ca391e-b8c4-40a4-a071-916d219bf902" />

When creating new accounts we get a choice of roles from a dropdown menu:

<img width="2567" height="845" alt="image" src="https://github.com/user-attachments/assets/241732d4-386b-4409-95cf-e2fdd27d6b98" />

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
