### PR TITLE
feat: add certificate requester and readonly roles

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -35,3 +35,4 @@ config
 RBAC
 GCM
 HashiCorp
+Requestor

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -41,4 +41,5 @@ Notary implements token-based authentication for its API and web interface. User
 
 ## Authorization
 
-Notary uses role-based access control (RBAC) to manage user permissions. Each user is assigned a role that defines their permissions within the system.
+Notary uses role-based access control (RBAC) to manage user permissions. Each user is assigned a role that defines their permissions within the system. Roles are assigned to accounts when they are created, either via the API (see the [API account reference](../reference/api/accounts.md#create-an-account)) or the web interface. To view the role definitions, see the [Roles reference](../reference/roles.md).
+

--- a/docs/reference/api/accounts.md
+++ b/docs/reference/api/accounts.md
@@ -43,6 +43,10 @@ This path creates a new account. The first account can be created without authen
 - `role_id` (integer): The role ID of the account. Valid values are:
   - `0`: Admin
   - `1`: Certificate Manager
+  - `2`: Certificate Requestor
+  - `3`: Read Only
+
+To view the role definitions, see the [Roles reference](../roles.md).
 
 ### Sample Response
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -8,4 +8,5 @@ This section provides detailed reference material for Notary, from APIs to confi
 api/index.md
 config_file.md
 metrics.md
+roles.md
 ```

--- a/docs/reference/roles.md
+++ b/docs/reference/roles.md
@@ -7,4 +7,4 @@ Notary uses a role-based access control (RBAC) system to manage permissions for 
 - **Certificate Requestor**: Can create and read Certificate Requests.
 - **Read Only**: Can read everything.
 
-Roles are assigned to accounts when they are created, either via the API (see the [API account reference](api/accounts.md)) or the web interface.
+Roles are assigned to accounts when they are created, either via the API (see the [API account reference](api/accounts.md#create-an-account)) or the web interface.

--- a/docs/reference/roles.md
+++ b/docs/reference/roles.md
@@ -3,8 +3,8 @@
 Notary uses a role-based access control (RBAC) system to manage permissions for users. Each role is defined with a set of permissions that determine what actions users can perform within Notary.
 
 - **Admin**: Full access to all Notary features.
-- **Certificate Manager**: Can manage Certificate Authorities, read Certificate Requests, and issue and revoke certificates.
-- **Certificate Requestor**: Can create and read Certificate Requests.
-- **Read Only**: Can read everything.
+- **Certificate Manager**: Can manage Certificate Authorities, Certificate Requests, issue and revoke certificates.
+- **Certificate Requestor**: Can create Certificate Requests and view their own requests.
+- **Read Only**: Can read everything except accounts.
 
 Roles are assigned to accounts when they are created, either via the API (see the [API account reference](api/accounts.md#create-an-account)) or the web interface.

--- a/docs/reference/roles.md
+++ b/docs/reference/roles.md
@@ -6,3 +6,5 @@ Notary uses a role-based access control (RBAC) system to manage permissions for 
 - **Certificate Manager**: Can manage Certificate Authorities, read Certificate Requests, and issue and revoke certificates.
 - **Certificate Requestor**: Can create and read Certificate Requests.
 - **Read Only**: Can read everything.
+
+Roles are assigned to accounts when they are created, either via the API (see the [API account reference](api/accounts.md)) or the web interface.

--- a/docs/reference/roles.md
+++ b/docs/reference/roles.md
@@ -1,0 +1,8 @@
+# Roles
+
+Notary uses a role-based access control (RBAC) system to manage permissions for users. Each role is defined with a set of permissions that determine what actions users can perform within Notary.
+
+- **Admin**: Full access to all Notary features.
+- **Certificate Manager**: Can manage Certificate Authorities, read Certificate Requests, and issue and revoke certificates.
+- **Certificate Requestor**: Can create and read Certificate Requests.
+- **Read Only**: Can read everything.

--- a/internal/db/db_csrs.go
+++ b/internal/db/db_csrs.go
@@ -16,13 +16,10 @@ func (db *Database) ListCertificateRequestWithCertificates() ([]CertificateReque
 }
 
 // ListCertificateRequestWithCertificatesWithoutCAS gets every CertificateRequest entry in the table.
-func (db *Database) ListCertificateRequestWithCertificatesWithoutCAS() ([]CertificateRequestWithChain, error) {
-	return ListEntities[CertificateRequestWithChain](db, db.stmts.ListCertificateRequestsWithoutChain)
-}
-
-// ListCertificateRequestWithCertificatesWithoutCASByUserID gets every CertificateRequest entry in the table for a given user ID.
-func (db *Database) ListCertificateRequestWithCertificatesWithoutCASByUserID(userID int64) ([]CertificateRequestWithChain, error) {
-	filter := CSRFilter{UserID: &userID}
+func (db *Database) ListCertificateRequestWithCertificatesWithoutCAS(filter *CSRFilter) ([]CertificateRequestWithChain, error) {
+	if filter == nil || filter.UserID == nil {
+		return ListEntities[CertificateRequestWithChain](db, db.stmts.ListCertificateRequestsWithoutChain)
+	}
 	csrRow := filter.AsCertificateRequestWithChain()
 	return ListEntities[CertificateRequestWithChain](db, db.stmts.ListCertificateRequestsWithoutChainByUserID, *csrRow)
 }

--- a/internal/db/db_csrs.go
+++ b/internal/db/db_csrs.go
@@ -20,6 +20,13 @@ func (db *Database) ListCertificateRequestWithCertificatesWithoutCAS() ([]Certif
 	return ListEntities[CertificateRequestWithChain](db, db.stmts.ListCertificateRequestsWithoutChain)
 }
 
+// ListCertificateRequestWithCertificatesWithoutCASByUserID gets every CertificateRequest entry in the table for a given user ID.
+func (db *Database) ListCertificateRequestWithCertificatesWithoutCASByUserID(userID int64) ([]CertificateRequestWithChain, error) {
+	filter := CSRFilter{UserID: &userID}
+	csrRow := filter.AsCertificateRequestWithChain()
+	return ListEntities[CertificateRequestWithChain](db, db.stmts.ListCertificateRequestsWithoutChainByUserID, *csrRow)
+}
+
 // GetCertificateRequestByID gets a CSR row from the repository from a given ID.
 func (db *Database) GetCertificateRequest(filter CSRFilter) (*CertificateRequest, error) {
 	csrRow := filter.AsCertificateRequest()

--- a/internal/db/db_csrs_test.go
+++ b/internal/db/db_csrs_test.go
@@ -303,7 +303,8 @@ func TestCASNotShowingUpInCSRsTable(t *testing.T) {
 	if csrs[0].Status != "Outstanding" {
 		t.Fatalf("Expected CSR to be in pending state, was %s", csrs[0].Status)
 	}
-	csrswithchain, err := database.ListCertificateRequestWithCertificatesWithoutCAS()
+	filter := &db.CSRFilter{}
+	csrswithchain, err := database.ListCertificateRequestWithCertificatesWithoutCAS(filter)
 	if err != nil {
 		t.Fatalf("err: %s", err.Error())
 	}

--- a/internal/db/db_users_test.go
+++ b/internal/db/db_users_test.go
@@ -136,7 +136,7 @@ func TestCreateUserFails(t *testing.T) {
 	if num != 1 {
 		t.Fatalf("The number of users should be 1.")
 	}
-	_, err = database.CreateUser("newUser", "pw456", 2)
+	_, err = database.CreateUser("newUser", "pw456", 32)
 	if err == nil {
 		t.Fatalf("An error should have been returned when creating a user with an invalid role ID.")
 	}

--- a/internal/db/filter.go
+++ b/internal/db/filter.go
@@ -30,8 +30,9 @@ func (filter *CertificateFilter) AsCertificate() *Certificate {
 }
 
 type CSRFilter struct {
-	ID  *int64
-	PEM *string
+	UserID *int64
+	ID     *int64
+	PEM    *string
 }
 
 func ByCSRID(id int64) CSRFilter {
@@ -50,8 +51,10 @@ func (filter *CSRFilter) AsCertificateRequest() *CertificateRequest {
 		csrRow = CertificateRequest{CSR_ID: *filter.ID}
 	case filter.PEM != nil:
 		csrRow = CertificateRequest{CSR: *filter.PEM}
+	case filter.UserID != nil:
+		csrRow = CertificateRequest{UserID: *filter.UserID}
 	default:
-		panic(fmt.Errorf("%w: only CSR ID or PEM is supported but none was provided", ErrInvalidFilter))
+		panic(fmt.Errorf("%w: only CSR ID, PEM, and UserID are supported", ErrInvalidFilter))
 	}
 	return &csrRow
 }
@@ -64,8 +67,10 @@ func (filter *CSRFilter) AsCertificateRequestWithChain() *CertificateRequestWith
 		csrRow = CertificateRequestWithChain{CSR_ID: *filter.ID}
 	case filter.PEM != nil:
 		csrRow = CertificateRequestWithChain{CSR: *filter.PEM}
+	case filter.UserID != nil:
+		csrRow = CertificateRequestWithChain{UserID: *filter.UserID}
 	default:
-		panic(fmt.Errorf("%w: only CSR ID or PEM is supported but none was provided", ErrInvalidFilter))
+		panic(fmt.Errorf("%w: only CSR ID, PEM and UserID are supported", ErrInvalidFilter))
 	}
 	return &csrRow
 }

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -74,8 +74,10 @@ type PrivateKey struct {
 type RoleID int
 
 const (
-	RoleAdmin              RoleID = 0
-	RoleCertificateManager RoleID = 1
+	RoleAdmin                RoleID = 0
+	RoleCertificateManager   RoleID = 1
+	RoleCertificateRequestor RoleID = 2
+	RoleReadOnly             RoleID = 3
 )
 
 // User contains information about a user of notary in the database.

--- a/internal/db/validation.go
+++ b/internal/db/validation.go
@@ -123,8 +123,8 @@ func ValidateUser(username string, roleID RoleID) error {
 	if username == "" {
 		return fmt.Errorf("%w: invalid username or password", ErrInvalidUser)
 	}
-	if roleID != RoleAdmin && roleID != RoleCertificateManager {
-		return fmt.Errorf("%w: invalid role", ErrInvalidUser)
+	if roleID < 0 || roleID > 3 {
+		return fmt.Errorf("%w: invalid role ID: %d", ErrInvalidUser, roleID)
 	}
 	return nil
 }

--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -16,7 +16,7 @@ const (
 
 	// Certificate request permissions
 	PermListCertificateRequests             = "certificate_request:list"
-	PermCreateCertificateRequests           = "certificate_request:create"
+	PermCreateCertificateRequest            = "certificate_request:create"
 	PermReadCertificateRequest              = "certificate_request:read"
 	PermDeleteCertificateRequest            = "certificate_request:delete"
 	PermRejectCertificateRequest            = "certificate_request:reject"
@@ -62,7 +62,7 @@ var PermissionsByRole = map[RoleID][]string{
 		PermReadConfig,
 		PermUpdateMyPassword,
 		PermListCertificateRequests,
-		PermCreateCertificateRequests,
+		PermCreateCertificateRequest,
 		PermReadCertificateRequest,
 		PermDeleteCertificateRequest,
 		PermRejectCertificateRequest,
@@ -83,7 +83,7 @@ var PermissionsByRole = map[RoleID][]string{
 	RoleCertificateRequestor: {
 		PermReadMyUser,
 		PermUpdateMyPassword,
-		PermCreateCertificateRequests,
+		PermCreateCertificateRequest,
 		PermReadCertificateRequest,
 		PermReadCertificateRequest,
 	},

--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -84,6 +84,8 @@ var PermissionsByRole = map[RoleID][]string{
 		PermReadMyUser,
 		PermUpdateMyPassword,
 		PermCreateCertificateRequests,
+		PermReadCertificateRequest,
+		PermReadCertificateRequest,
 	},
 
 	RoleReadOnly: {

--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -39,13 +39,15 @@ const (
 type RoleID int
 
 const (
-	RoleAdmin              RoleID = 0
-	RoleCertificateManager RoleID = 1
+	RoleAdmin                RoleID = 0
+	RoleCertificateManager   RoleID = 1
+	RoleCertificateRequestor RoleID = 2
+	RoleReadOnly             RoleID = 3
 )
 
 func (r RoleID) IsValid() bool {
 	switch r {
-	case RoleAdmin, RoleCertificateManager:
+	case RoleAdmin, RoleCertificateManager, RoleCertificateRequestor, RoleReadOnly:
 		return true
 	default:
 		return false
@@ -76,5 +78,21 @@ var PermissionsByRole = map[RoleID][]string{
 		PermSignCertificateAuthorityCertificate,
 		PermCreateCertificateAuthorityCertificate,
 		PermRevokeCertificateAuthorityCertificate,
+	},
+
+	RoleCertificateRequestor: {
+		PermReadMyUser,
+		PermUpdateMyPassword,
+		PermCreateCertificateRequests,
+	},
+
+	RoleReadOnly: {
+		PermReadMyUser,
+		PermUpdateMyPassword,
+		PermListCertificateRequests,
+		PermReadCertificateRequest,
+		PermListCertificateAuthorities,
+		PermReadCertificateAuthority,
+		PermReadConfig,
 	},
 }

--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -85,7 +85,7 @@ var PermissionsByRole = map[RoleID][]string{
 		PermUpdateMyPassword,
 		PermCreateCertificateRequest,
 		PermReadCertificateRequest,
-		PermReadCertificateRequest,
+		PermListCertificateRequests,
 	},
 
 	RoleReadOnly: {

--- a/internal/server/authorization_test.go
+++ b/internal/server/authorization_test.go
@@ -47,8 +47,8 @@ func TestAuthorizationNoAuth(t *testing.T) {
 
 func TestAuthorizationNonAdminAuthorized(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
-	nonAdminToken := tu.MustPrepareNonAdminAccount(t, ts, adminToken)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
+	nonAdminToken := tu.MustPrepareAccount(t, ts, "testuser", 1, adminToken)
 	client := ts.Client()
 
 	testCases := []struct {
@@ -93,8 +93,8 @@ func TestAuthorizationNonAdminAuthorized(t *testing.T) {
 
 func TestAuthorizationNonAdminUnauthorized(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
-	nonAdminToken := tu.MustPrepareNonAdminAccount(t, ts, adminToken)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
+	nonAdminToken := tu.MustPrepareAccount(t, ts, "whatever", 1, adminToken)
 	client := ts.Client()
 
 	testCases := []struct {
@@ -146,8 +146,8 @@ func TestAuthorizationNonAdminUnauthorized(t *testing.T) {
 
 func TestAuthorizationAdminAuthorized(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
-	tu.MustPrepareNonAdminAccount(t, ts, adminToken)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
+	tu.MustPrepareAccount(t, ts, "whatever", 1, adminToken)
 	client := ts.Client()
 
 	testCases := []struct {
@@ -190,8 +190,8 @@ func TestAuthorizationAdminAuthorized(t *testing.T) {
 
 func TestAuthorizationAdminUnAuthorized(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
-	nonAdminToken := tu.MustPrepareNonAdminAccount(t, ts, adminToken)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
+	nonAdminToken := tu.MustPrepareAccount(t, ts, "whatever", 1, adminToken)
 	client := ts.Client()
 
 	req, err := http.NewRequest("DELETE", ts.URL+"/api/v1/accounts/1", nil)

--- a/internal/server/authorization_test.go
+++ b/internal/server/authorization_test.go
@@ -341,6 +341,10 @@ func TestAuthorizationCertificateRequestorUnauthorized(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if statusCode != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d", http.StatusCreated, statusCode)
+	}
+
 	testCases := []struct {
 		desc   string
 		method string

--- a/internal/server/authorization_test.go
+++ b/internal/server/authorization_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/canonical/notary/internal/testutils"
 	tu "github.com/canonical/notary/internal/testutils"
 )
 
@@ -47,8 +48,8 @@ func TestAuthorizationNoAuth(t *testing.T) {
 
 func TestAuthorizationNonAdminAuthorized(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
-	nonAdminToken := tu.MustPrepareAccount(t, ts, "testuser", 1, adminToken)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
+	nonAdminToken := tu.MustPrepareAccount(t, ts, "testuser", testutils.RoleCertificateManager, adminToken)
 	client := ts.Client()
 
 	testCases := []struct {
@@ -93,8 +94,8 @@ func TestAuthorizationNonAdminAuthorized(t *testing.T) {
 
 func TestAuthorizationNonAdminUnauthorized(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
-	nonAdminToken := tu.MustPrepareAccount(t, ts, "whatever", 1, adminToken)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
+	nonAdminToken := tu.MustPrepareAccount(t, ts, "whatever", testutils.RoleCertificateManager, adminToken)
 	client := ts.Client()
 
 	testCases := []struct {
@@ -146,8 +147,8 @@ func TestAuthorizationNonAdminUnauthorized(t *testing.T) {
 
 func TestAuthorizationAdminAuthorized(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
-	tu.MustPrepareAccount(t, ts, "whatever", 1, adminToken)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
+	tu.MustPrepareAccount(t, ts, "whatever", testutils.RoleCertificateManager, adminToken)
 	client := ts.Client()
 
 	testCases := []struct {
@@ -190,8 +191,8 @@ func TestAuthorizationAdminAuthorized(t *testing.T) {
 
 func TestAuthorizationAdminUnAuthorized(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
-	nonAdminToken := tu.MustPrepareAccount(t, ts, "whatever", 1, adminToken)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
+	nonAdminToken := tu.MustPrepareAccount(t, ts, "whatever", testutils.RoleCertificateManager, adminToken)
 	client := ts.Client()
 
 	req, err := http.NewRequest("DELETE", ts.URL+"/api/v1/accounts/1", nil)

--- a/internal/server/authorization_test.go
+++ b/internal/server/authorization_test.go
@@ -284,7 +284,13 @@ func TestAuthorizationCertificateRequestorAuthorized(t *testing.T) {
 			status: http.StatusCreated,
 		},
 		{
-			desc:   "certificate manager can read a certificate request",
+			desc:   "certificate requestor can list certificate requests",
+			method: "GET",
+			path:   "/api/v1/certificate_requests",
+			status: http.StatusOK,
+		},
+		{
+			desc:   "certificate requestor can read a certificate request it created",
 			method: "GET",
 			path:   "/api/v1/certificate_requests/2",
 			status: http.StatusOK,
@@ -325,6 +331,14 @@ func TestAuthorizationCertificateRequestorUnauthorized(t *testing.T) {
 
 	if statusCode != http.StatusCreated {
 		t.Fatalf("expected status %d, got %d", http.StatusCreated, statusCode)
+	}
+
+	csrParams := tu.CreateCertificateRequestParams{
+		CSR: tu.ExampleCSR,
+	}
+	statusCode, _, err = tu.CreateCertificateRequest(ts.URL, client, adminToken, csrParams)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	testCases := []struct {
@@ -390,6 +404,12 @@ func TestAuthorizationCertificateRequestorUnauthorized(t *testing.T) {
 			method: "POST",
 			path:   "/api/v1/certificate_requests/2/sign",
 			data:   `{"certificate_authority_id":"1"}`,
+			status: http.StatusForbidden,
+		},
+		{
+			desc:   "certificate requestor can't read a certificate request it didn't create",
+			method: "GET",
+			path:   "/api/v1/certificate_requests/1",
 			status: http.StatusForbidden,
 		},
 	}

--- a/internal/server/authorization_test.go
+++ b/internal/server/authorization_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/canonical/notary/internal/testutils"
 	tu "github.com/canonical/notary/internal/testutils"
 )
 
@@ -46,10 +45,10 @@ func TestAuthorizationNoAuth(t *testing.T) {
 	}
 }
 
-func TestAuthorizationNonAdminAuthorized(t *testing.T) {
+func TestAuthorizationCertificateManagerAuthorized(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
-	nonAdminToken := tu.MustPrepareAccount(t, ts, "testuser", testutils.RoleCertificateManager, adminToken)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", tu.RoleAdmin, "")
+	certManagerToken := tu.MustPrepareAccount(t, ts, "testuser", tu.RoleCertificateManager, adminToken)
 	client := ts.Client()
 
 	testCases := []struct {
@@ -60,14 +59,14 @@ func TestAuthorizationNonAdminAuthorized(t *testing.T) {
 		status int
 	}{
 		{
-			desc:   "user can change self password with /me",
+			desc:   "certificate manager can change self password with /me",
 			method: "POST",
 			path:   "/api/v1/accounts/me/change_password",
 			data:   `{"password":"BetterPW1!"}`,
 			status: http.StatusCreated,
 		},
 		{
-			desc:   "user can login with new password",
+			desc:   "certificate manager can login with new password",
 			method: "POST",
 			path:   "/login",
 			data:   `{"username":"testuser","password":"BetterPW1!"}`,
@@ -80,7 +79,7 @@ func TestAuthorizationNonAdminAuthorized(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			req.Header.Add("Authorization", "Bearer "+nonAdminToken)
+			req.Header.Add("Authorization", "Bearer "+certManagerToken)
 			res, err := client.Do(req)
 			if err != nil {
 				t.Fatal(err)
@@ -92,10 +91,10 @@ func TestAuthorizationNonAdminAuthorized(t *testing.T) {
 	}
 }
 
-func TestAuthorizationNonAdminUnauthorized(t *testing.T) {
+func TestAuthorizationCertificateManagerUnauthorized(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
-	nonAdminToken := tu.MustPrepareAccount(t, ts, "whatever", testutils.RoleCertificateManager, adminToken)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", tu.RoleAdmin, "")
+	certManagerToken := tu.MustPrepareAccount(t, ts, "whatever", tu.RoleCertificateManager, adminToken)
 	client := ts.Client()
 
 	testCases := []struct {
@@ -133,7 +132,7 @@ func TestAuthorizationNonAdminUnauthorized(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			req.Header.Add("Authorization", "Bearer "+nonAdminToken)
+			req.Header.Add("Authorization", "Bearer "+certManagerToken)
 			res, err := client.Do(req)
 			if err != nil {
 				t.Fatal(err)
@@ -147,8 +146,8 @@ func TestAuthorizationNonAdminUnauthorized(t *testing.T) {
 
 func TestAuthorizationAdminAuthorized(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
-	tu.MustPrepareAccount(t, ts, "whatever", testutils.RoleCertificateManager, adminToken)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", tu.RoleAdmin, "")
+	tu.MustPrepareAccount(t, ts, "whatever", tu.RoleCertificateManager, adminToken)
 	client := ts.Client()
 
 	testCases := []struct {
@@ -191,8 +190,8 @@ func TestAuthorizationAdminAuthorized(t *testing.T) {
 
 func TestAuthorizationAdminUnAuthorized(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
-	nonAdminToken := tu.MustPrepareAccount(t, ts, "whatever", testutils.RoleCertificateManager, adminToken)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", tu.RoleAdmin, "")
+	nonAdminToken := tu.MustPrepareAccount(t, ts, "whatever", tu.RoleCertificateManager, adminToken)
 	client := ts.Client()
 
 	req, err := http.NewRequest("DELETE", ts.URL+"/api/v1/accounts/1", nil)

--- a/internal/server/handlers_accounts_test.go
+++ b/internal/server/handlers_accounts_test.go
@@ -13,8 +13,8 @@ import (
 func TestAccountsEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
 	client := ts.Client()
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
-	nonAdminToken := tu.MustPrepareNonAdminAccount(t, ts, adminToken)
+	adminToken := tu.MustPrepareAccount(t, ts, "testadmin", 0, "")
+	nonAdminToken := tu.MustPrepareAccount(t, ts, "whatever", 1, adminToken)
 
 	t.Run("1. Get admin account - admin token", func(t *testing.T) {
 		statusCode, response, err := tu.GetAccount(ts.URL, client, adminToken, 1)
@@ -188,7 +188,7 @@ func TestAccountsEndToEnd(t *testing.T) {
 func TestCreateAccountInvalidInputs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
 	client := ts.Client()
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
 
 	tests := []struct {
 		testName string
@@ -258,7 +258,7 @@ func TestCreateAccountInvalidInputs(t *testing.T) {
 func TestChangeAccountPasswordInvalidInputs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
 	client := ts.Client()
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
 
 	tests := []struct {
 		testName string

--- a/internal/server/handlers_accounts_test.go
+++ b/internal/server/handlers_accounts_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/canonical/notary/internal/testutils"
 	tu "github.com/canonical/notary/internal/testutils"
 )
 
@@ -13,8 +14,8 @@ import (
 func TestAccountsEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
 	client := ts.Client()
-	adminToken := tu.MustPrepareAccount(t, ts, "testadmin", 0, "")
-	nonAdminToken := tu.MustPrepareAccount(t, ts, "whatever", 1, adminToken)
+	adminToken := tu.MustPrepareAccount(t, ts, "testadmin", testutils.RoleAdmin, "")
+	nonAdminToken := tu.MustPrepareAccount(t, ts, "whatever", testutils.RoleCertificateManager, adminToken)
 
 	t.Run("1. Get admin account - admin token", func(t *testing.T) {
 		statusCode, response, err := tu.GetAccount(ts.URL, client, adminToken, 1)
@@ -55,7 +56,7 @@ func TestAccountsEndToEnd(t *testing.T) {
 		createAccountParams := &tu.CreateAccountParams{
 			Username: "nopass",
 			Password: "myPassword123!",
-			RoleID:   1,
+			RoleID:   testutils.RoleCertificateManager,
 		}
 		statusCode, response, err := tu.CreateAccount(ts.URL, client, adminToken, createAccountParams)
 		if err != nil {
@@ -188,34 +189,34 @@ func TestAccountsEndToEnd(t *testing.T) {
 func TestCreateAccountInvalidInputs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
 	client := ts.Client()
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
 
 	tests := []struct {
 		testName string
 		username string
 		password string
-		roleID   int
+		roleID   testutils.RoleID
 		error    string
 	}{
 		{
 			testName: "No username",
 			username: "",
 			password: "password",
-			roleID:   1,
+			roleID:   testutils.RoleCertificateManager,
 			error:    "Invalid request: username is required",
 		},
 		{
 			testName: "No password",
 			username: "username",
 			password: "",
-			roleID:   1,
+			roleID:   testutils.RoleCertificateManager,
 			error:    "Invalid request: password is required",
 		},
 		{
 			testName: "bad password",
 			username: "username",
 			password: "123",
-			roleID:   1,
+			roleID:   testutils.RoleCertificateManager,
 			error:    "Invalid request: Password must have 8 or more characters, must include at least one capital letter, one lowercase letter, and either a number or a symbol.",
 		},
 		{
@@ -258,7 +259,7 @@ func TestCreateAccountInvalidInputs(t *testing.T) {
 func TestChangeAccountPasswordInvalidInputs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
 	client := ts.Client()
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
 
 	tests := []struct {
 		testName string

--- a/internal/server/handlers_accounts_test.go
+++ b/internal/server/handlers_accounts_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/canonical/notary/internal/testutils"
 	tu "github.com/canonical/notary/internal/testutils"
 )
 
@@ -14,8 +13,8 @@ import (
 func TestAccountsEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
 	client := ts.Client()
-	adminToken := tu.MustPrepareAccount(t, ts, "testadmin", testutils.RoleAdmin, "")
-	nonAdminToken := tu.MustPrepareAccount(t, ts, "whatever", testutils.RoleCertificateManager, adminToken)
+	adminToken := tu.MustPrepareAccount(t, ts, "testadmin", tu.RoleAdmin, "")
+	nonAdminToken := tu.MustPrepareAccount(t, ts, "whatever", tu.RoleCertificateManager, adminToken)
 
 	t.Run("1. Get admin account - admin token", func(t *testing.T) {
 		statusCode, response, err := tu.GetAccount(ts.URL, client, adminToken, 1)
@@ -56,7 +55,7 @@ func TestAccountsEndToEnd(t *testing.T) {
 		createAccountParams := &tu.CreateAccountParams{
 			Username: "nopass",
 			Password: "myPassword123!",
-			RoleID:   testutils.RoleCertificateManager,
+			RoleID:   tu.RoleCertificateManager,
 		}
 		statusCode, response, err := tu.CreateAccount(ts.URL, client, adminToken, createAccountParams)
 		if err != nil {
@@ -189,34 +188,34 @@ func TestAccountsEndToEnd(t *testing.T) {
 func TestCreateAccountInvalidInputs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
 	client := ts.Client()
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", tu.RoleAdmin, "")
 
 	tests := []struct {
 		testName string
 		username string
 		password string
-		roleID   testutils.RoleID
+		roleID   tu.RoleID
 		error    string
 	}{
 		{
 			testName: "No username",
 			username: "",
 			password: "password",
-			roleID:   testutils.RoleCertificateManager,
+			roleID:   tu.RoleCertificateManager,
 			error:    "Invalid request: username is required",
 		},
 		{
 			testName: "No password",
 			username: "username",
 			password: "",
-			roleID:   testutils.RoleCertificateManager,
+			roleID:   tu.RoleCertificateManager,
 			error:    "Invalid request: password is required",
 		},
 		{
 			testName: "bad password",
 			username: "username",
 			password: "123",
-			roleID:   testutils.RoleCertificateManager,
+			roleID:   tu.RoleCertificateManager,
 			error:    "Invalid request: Password must have 8 or more characters, must include at least one capital letter, one lowercase letter, and either a number or a symbol.",
 		},
 		{
@@ -259,7 +258,7 @@ func TestCreateAccountInvalidInputs(t *testing.T) {
 func TestChangeAccountPasswordInvalidInputs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
 	client := ts.Client()
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", tu.RoleAdmin, "")
 
 	tests := []struct {
 		testName string

--- a/internal/server/handlers_certificate_authorities_test.go
+++ b/internal/server/handlers_certificate_authorities_test.go
@@ -10,14 +10,13 @@ import (
 
 	"github.com/canonical/notary/internal/db"
 	"github.com/canonical/notary/internal/server"
-	"github.com/canonical/notary/internal/testutils"
 	tu "github.com/canonical/notary/internal/testutils"
 )
 
 // The order of the tests is important, as some tests depend on the state of the server after previous tests.
 func TestSelfSignedCertificateAuthorityEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", tu.RoleAdmin, "")
 	client := ts.Client()
 
 	t.Run("1. List certificate authorities", func(t *testing.T) {
@@ -254,7 +253,7 @@ func TestSelfSignedCertificateAuthorityEndToEnd(t *testing.T) {
 
 func TestCreateCertificateAuthorityInvalidInputs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", tu.RoleAdmin, "")
 	client := ts.Client()
 
 	tests := []struct {
@@ -343,7 +342,7 @@ func TestCreateCertificateAuthorityInvalidInputs(t *testing.T) {
 
 func TestUploadCertificateToCertificateAuthorityInvalidInputs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", tu.RoleAdmin, "")
 	client := ts.Client()
 
 	createCAParams := tu.CreateCertificateAuthorityParams{
@@ -417,7 +416,7 @@ invalid
 
 func TestSignCertificatesEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", tu.RoleAdmin, "")
 	client := ts.Client()
 
 	t.Run("1. List certificate authorities", func(t *testing.T) {
@@ -690,7 +689,7 @@ func TestSignCertificatesEndToEnd(t *testing.T) {
 
 func TestUnsuccessfulRequestsMadeToCACSRs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", tu.RoleAdmin, "")
 	client := ts.Client()
 
 	t.Run("1. Create self signed certificate authority", func(t *testing.T) {
@@ -821,7 +820,7 @@ func TestUnsuccessfulRequestsMadeToCACSRs(t *testing.T) {
 
 func TestCertificateRevocationListsEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", tu.RoleAdmin, "")
 	client := ts.Client()
 
 	t.Run("1. Create self signed certificate authority", func(t *testing.T) {

--- a/internal/server/handlers_certificate_authorities_test.go
+++ b/internal/server/handlers_certificate_authorities_test.go
@@ -16,7 +16,7 @@ import (
 // The order of the tests is important, as some tests depend on the state of the server after previous tests.
 func TestSelfSignedCertificateAuthorityEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
 	client := ts.Client()
 
 	t.Run("1. List certificate authorities", func(t *testing.T) {
@@ -253,7 +253,7 @@ func TestSelfSignedCertificateAuthorityEndToEnd(t *testing.T) {
 
 func TestCreateCertificateAuthorityInvalidInputs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
 	client := ts.Client()
 
 	tests := []struct {
@@ -342,7 +342,7 @@ func TestCreateCertificateAuthorityInvalidInputs(t *testing.T) {
 
 func TestUploadCertificateToCertificateAuthorityInvalidInputs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
 	client := ts.Client()
 
 	createCAParams := tu.CreateCertificateAuthorityParams{
@@ -416,7 +416,7 @@ invalid
 
 func TestSignCertificatesEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
 	client := ts.Client()
 
 	t.Run("1. List certificate authorities", func(t *testing.T) {
@@ -689,7 +689,7 @@ func TestSignCertificatesEndToEnd(t *testing.T) {
 
 func TestUnsuccessfulRequestsMadeToCACSRs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
 	client := ts.Client()
 
 	t.Run("1. Create self signed certificate authority", func(t *testing.T) {
@@ -820,7 +820,7 @@ func TestUnsuccessfulRequestsMadeToCACSRs(t *testing.T) {
 
 func TestCertificateRevocationListsEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
 	client := ts.Client()
 
 	t.Run("1. Create self signed certificate authority", func(t *testing.T) {

--- a/internal/server/handlers_certificate_authorities_test.go
+++ b/internal/server/handlers_certificate_authorities_test.go
@@ -10,13 +10,14 @@ import (
 
 	"github.com/canonical/notary/internal/db"
 	"github.com/canonical/notary/internal/server"
+	"github.com/canonical/notary/internal/testutils"
 	tu "github.com/canonical/notary/internal/testutils"
 )
 
 // The order of the tests is important, as some tests depend on the state of the server after previous tests.
 func TestSelfSignedCertificateAuthorityEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
 	client := ts.Client()
 
 	t.Run("1. List certificate authorities", func(t *testing.T) {
@@ -253,7 +254,7 @@ func TestSelfSignedCertificateAuthorityEndToEnd(t *testing.T) {
 
 func TestCreateCertificateAuthorityInvalidInputs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
 	client := ts.Client()
 
 	tests := []struct {
@@ -342,7 +343,7 @@ func TestCreateCertificateAuthorityInvalidInputs(t *testing.T) {
 
 func TestUploadCertificateToCertificateAuthorityInvalidInputs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
 	client := ts.Client()
 
 	createCAParams := tu.CreateCertificateAuthorityParams{
@@ -416,7 +417,7 @@ invalid
 
 func TestSignCertificatesEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
 	client := ts.Client()
 
 	t.Run("1. List certificate authorities", func(t *testing.T) {
@@ -689,7 +690,7 @@ func TestSignCertificatesEndToEnd(t *testing.T) {
 
 func TestUnsuccessfulRequestsMadeToCACSRs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
 	client := ts.Client()
 
 	t.Run("1. Create self signed certificate authority", func(t *testing.T) {
@@ -820,7 +821,7 @@ func TestUnsuccessfulRequestsMadeToCACSRs(t *testing.T) {
 
 func TestCertificateRevocationListsEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
 	client := ts.Client()
 
 	t.Run("1. Create self signed certificate authority", func(t *testing.T) {

--- a/internal/server/handlers_certificate_requests.go
+++ b/internal/server/handlers_certificate_requests.go
@@ -79,13 +79,12 @@ func ListCertificateRequests(env *HandlerConfig) http.HandlerFunc {
 		var csrs []db.CertificateRequestWithChain
 		var err error
 
-		switch claims.RoleID {
-		case RoleCertificateRequestor:
-			csrs, err = env.DB.ListCertificateRequestWithCertificatesWithoutCASByUserID(claims.ID)
-		default:
-			csrs, err = env.DB.ListCertificateRequestWithCertificatesWithoutCAS()
+		filter := &db.CSRFilter{}
+		if claims.RoleID == RoleCertificateRequestor {
+			filter.UserID = &claims.ID
 		}
 
+		csrs, err = env.DB.ListCertificateRequestWithCertificatesWithoutCAS(filter)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "Internal Error", err, env.Logger)
 			return

--- a/internal/server/handlers_certificate_requests_test.go
+++ b/internal/server/handlers_certificate_requests_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/canonical/notary/internal/testutils"
 	tu "github.com/canonical/notary/internal/testutils"
 )
 
@@ -13,7 +14,7 @@ import (
 // state of the server after previous tests.
 func TestCertificateRequestsEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "testadmin", 0, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "testadmin", testutils.RoleAdmin, "")
 	client := ts.Client()
 
 	t.Run("1. List certificate requests - no requests yet", func(t *testing.T) {
@@ -227,7 +228,7 @@ func TestCertificateRequestsEndToEnd(t *testing.T) {
 // state of the server after previous tests.
 func TestCertificatesEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
 	client := ts.Client()
 
 	t.Run("1. Create certificate request", func(t *testing.T) {
@@ -331,7 +332,7 @@ func TestCertificatesEndToEnd(t *testing.T) {
 
 func TestCreateCertificateRequestInvalidInputs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
 	client := ts.Client()
 
 	tests := []struct {
@@ -386,7 +387,7 @@ MIIBVwIBADANBgkqhkiG9w0BAQEFAASCAT8wggE7AgEAAkEAuQ==
 
 func TestCreateCertificateInvalidInputs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
 	client := ts.Client()
 
 	tests := []struct {

--- a/internal/server/handlers_certificate_requests_test.go
+++ b/internal/server/handlers_certificate_requests_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/canonical/notary/internal/testutils"
 	tu "github.com/canonical/notary/internal/testutils"
 )
 
@@ -14,7 +13,7 @@ import (
 // state of the server after previous tests.
 func TestCertificateRequestsEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "testadmin", testutils.RoleAdmin, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "testadmin", tu.RoleAdmin, "")
 	client := ts.Client()
 
 	t.Run("1. List certificate requests - no requests yet", func(t *testing.T) {
@@ -228,7 +227,7 @@ func TestCertificateRequestsEndToEnd(t *testing.T) {
 // state of the server after previous tests.
 func TestCertificatesEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", tu.RoleAdmin, "")
 	client := ts.Client()
 
 	t.Run("1. Create certificate request", func(t *testing.T) {
@@ -332,7 +331,7 @@ func TestCertificatesEndToEnd(t *testing.T) {
 
 func TestCreateCertificateRequestInvalidInputs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", tu.RoleAdmin, "")
 	client := ts.Client()
 
 	tests := []struct {
@@ -387,7 +386,7 @@ MIIBVwIBADANBgkqhkiG9w0BAQEFAASCAT8wggE7AgEAAkEAuQ==
 
 func TestCreateCertificateInvalidInputs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", tu.RoleAdmin, "")
 	client := ts.Client()
 
 	tests := []struct {

--- a/internal/server/handlers_certificate_requests_test.go
+++ b/internal/server/handlers_certificate_requests_test.go
@@ -13,7 +13,7 @@ import (
 // state of the server after previous tests.
 func TestCertificateRequestsEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
+	adminToken := tu.MustPrepareAccount(t, ts, "testadmin", 0, "")
 	client := ts.Client()
 
 	t.Run("1. List certificate requests - no requests yet", func(t *testing.T) {
@@ -227,7 +227,7 @@ func TestCertificateRequestsEndToEnd(t *testing.T) {
 // state of the server after previous tests.
 func TestCertificatesEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
 	client := ts.Client()
 
 	t.Run("1. Create certificate request", func(t *testing.T) {
@@ -331,7 +331,7 @@ func TestCertificatesEndToEnd(t *testing.T) {
 
 func TestCreateCertificateRequestInvalidInputs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
 	client := ts.Client()
 
 	tests := []struct {
@@ -386,7 +386,7 @@ MIIBVwIBADANBgkqhkiG9w0BAQEFAASCAT8wggE7AgEAAkEAuQ==
 
 func TestCreateCertificateInvalidInputs(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
 	client := ts.Client()
 
 	tests := []struct {

--- a/internal/server/handlers_certificate_requests_test.go
+++ b/internal/server/handlers_certificate_requests_test.go
@@ -222,6 +222,73 @@ func TestCertificateRequestsEndToEnd(t *testing.T) {
 	})
 }
 
+// TestListCertificateRequestsRequestorRole tests that a certificate requestor can only view their own requests.
+func TestListCertificateRequestsRequestorRole(t *testing.T) {
+	ts := tu.MustPrepareServer(t)
+	adminToken := tu.MustPrepareAccount(t, ts, "testadmin", tu.RoleAdmin, "")
+	client := ts.Client()
+
+	// Create a certificate request as the admin
+	params1 := tu.CreateCertificateRequestParams{
+		CSR: tu.ExampleCSR,
+	}
+	statusCode, _, err := tu.CreateCertificateRequest(ts.URL, client, adminToken, params1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if statusCode != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d", http.StatusCreated, statusCode)
+	}
+
+	// Create a certificate requestor user
+	requestorToken := tu.MustPrepareAccount(t, ts, "requestor", tu.RoleCertificateRequestor, adminToken)
+
+	// Create a certificate request as the requestor
+	params2 := tu.CreateCertificateRequestParams{
+		CSR: tu.AppleCSR,
+	}
+	statusCode, _, err = tu.CreateCertificateRequest(ts.URL, client, requestorToken, params2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if statusCode != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d", http.StatusCreated, statusCode)
+	}
+
+	// Create a second certificate request as the requestor
+	params3 := tu.CreateCertificateRequestParams{
+		CSR: tu.StrawberryCSR,
+	}
+
+	statusCode, _, err = tu.CreateCertificateRequest(ts.URL, client, requestorToken, params3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if statusCode != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d", http.StatusCreated, statusCode)
+	}
+
+	// List certificate requests as the requestor
+	statusCode, listCertRequestsResponse, err := tu.ListCertificateRequests(ts.URL, client, requestorToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if statusCode != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, statusCode)
+	}
+
+	if listCertRequestsResponse.Error != "" {
+		t.Fatalf("expected no error, got %s", listCertRequestsResponse.Error)
+	}
+
+	if len(listCertRequestsResponse.Result) != 2 {
+		t.Fatalf("expected 2 certificate requests, got %d", len(listCertRequestsResponse.Result))
+	}
+}
+
 // This is an end-to-end test for the certificates endpoint.
 // The order of the tests is important, as some tests depend on the
 // state of the server after previous tests.

--- a/internal/server/handlers_config_test.go
+++ b/internal/server/handlers_config_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/canonical/notary/internal/testutils"
 	tu "github.com/canonical/notary/internal/testutils"
 )
 
@@ -43,8 +44,8 @@ func getConfig(url string, client *http.Client, token string) (int, *GetConfigRe
 
 func TestConfigEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
-	nonAdminToken := tu.MustPrepareAccount(t, ts, "whatever", 1, adminToken)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
+	nonAdminToken := tu.MustPrepareAccount(t, ts, "whatever", testutils.RoleCertificateManager, adminToken)
 	client := ts.Client()
 
 	t.Run("1. Get config - no authentication", func(t *testing.T) {

--- a/internal/server/handlers_config_test.go
+++ b/internal/server/handlers_config_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/canonical/notary/internal/testutils"
 	tu "github.com/canonical/notary/internal/testutils"
 )
 
@@ -44,8 +43,8 @@ func getConfig(url string, client *http.Client, token string) (int, *GetConfigRe
 
 func TestConfigEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
-	nonAdminToken := tu.MustPrepareAccount(t, ts, "whatever", testutils.RoleCertificateManager, adminToken)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", tu.RoleAdmin, "")
+	nonAdminToken := tu.MustPrepareAccount(t, ts, "whatever", tu.RoleCertificateManager, adminToken)
 	client := ts.Client()
 
 	t.Run("1. Get config - no authentication", func(t *testing.T) {

--- a/internal/server/handlers_config_test.go
+++ b/internal/server/handlers_config_test.go
@@ -43,8 +43,8 @@ func getConfig(url string, client *http.Client, token string) (int, *GetConfigRe
 
 func TestConfigEndToEnd(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
-	nonAdminToken := tu.MustPrepareNonAdminAccount(t, ts, adminToken)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
+	nonAdminToken := tu.MustPrepareAccount(t, ts, "whatever", 1, adminToken)
 	client := ts.Client()
 
 	t.Run("1. Get config - no authentication", func(t *testing.T) {

--- a/internal/server/handlers_login_test.go
+++ b/internal/server/handlers_login_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/canonical/notary/internal/testutils"
 	tu "github.com/canonical/notary/internal/testutils"
 	"github.com/golang-jwt/jwt/v5"
 )
@@ -17,7 +16,7 @@ func TestLoginEndToEnd(t *testing.T) {
 		adminUser := &tu.CreateAccountParams{
 			Username: "testadmin",
 			Password: "Admin123",
-			RoleID:   testutils.RoleAdmin,
+			RoleID:   tu.RoleAdmin,
 		}
 		statusCode, _, err := tu.CreateAccount(ts.URL, client, "", adminUser)
 		if err != nil {

--- a/internal/server/handlers_login_test.go
+++ b/internal/server/handlers_login_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/canonical/notary/internal/testutils"
 	tu "github.com/canonical/notary/internal/testutils"
 	"github.com/golang-jwt/jwt/v5"
 )
@@ -16,7 +17,7 @@ func TestLoginEndToEnd(t *testing.T) {
 		adminUser := &tu.CreateAccountParams{
 			Username: "testadmin",
 			Password: "Admin123",
-			RoleID:   0,
+			RoleID:   testutils.RoleAdmin,
 		}
 		statusCode, _, err := tu.CreateAccount(ts.URL, client, "", adminUser)
 		if err != nil {

--- a/internal/server/handlers_status_test.go
+++ b/internal/server/handlers_status_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/canonical/notary/internal/testutils"
 	tu "github.com/canonical/notary/internal/testutils"
 )
 
@@ -35,7 +34,7 @@ func TestStatus(t *testing.T) {
 			t.Fatalf("expected version to be set")
 		}
 	})
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", tu.RoleAdmin, "")
 
 	t.Run("status initialized", func(t *testing.T) {
 		statusCode, statusResponse, err := getStatus(ts.URL, client, adminToken)

--- a/internal/server/handlers_status_test.go
+++ b/internal/server/handlers_status_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/canonical/notary/internal/testutils"
 	tu "github.com/canonical/notary/internal/testutils"
 )
 
@@ -34,7 +35,7 @@ func TestStatus(t *testing.T) {
 			t.Fatalf("expected version to be set")
 		}
 	})
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
 
 	t.Run("status initialized", func(t *testing.T) {
 		statusCode, statusResponse, err := getStatus(ts.URL, client, adminToken)

--- a/internal/server/handlers_status_test.go
+++ b/internal/server/handlers_status_test.go
@@ -34,7 +34,7 @@ func TestStatus(t *testing.T) {
 			t.Fatalf("expected version to be set")
 		}
 	})
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
 
 	t.Run("status initialized", func(t *testing.T) {
 		statusCode, statusResponse, err := getStatus(ts.URL, client, adminToken)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -13,7 +13,7 @@ import (
 func NewHandler(config *HandlerConfig) http.Handler {
 	apiV1Router := http.NewServeMux()
 	apiV1Router.HandleFunc("GET /certificate_requests", requirePermission(PermListCertificateRequests, config.JWTSecret, ListCertificateRequests(config), config.Logger))
-	apiV1Router.HandleFunc("POST /certificate_requests", requirePermission(PermCreateCertificateRequests, config.JWTSecret, CreateCertificateRequest(config), config.Logger))
+	apiV1Router.HandleFunc("POST /certificate_requests", requirePermission(PermCreateCertificateRequest, config.JWTSecret, CreateCertificateRequest(config), config.Logger))
 	apiV1Router.HandleFunc("GET /certificate_requests/{id}", requirePermission(PermReadCertificateRequest, config.JWTSecret, GetCertificateRequest(config), config.Logger))
 	apiV1Router.HandleFunc("DELETE /certificate_requests/{id}", requirePermission(PermDeleteCertificateRequest, config.JWTSecret, DeleteCertificateRequest(config), config.Logger))
 	apiV1Router.HandleFunc("POST /certificate_requests/{id}/reject", requirePermission(PermRejectCertificateRequest, config.JWTSecret, RejectCertificateRequest(config), config.Logger))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -46,7 +46,7 @@ func TestInvalidKeyFailure(t *testing.T) {
 func TestRequestOverload(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
 	client := ts.Client()
-	adminToken := tu.MustPrepareAdminAccount(t, ts)
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
 
 	t.Run("throw a valid size string", func(t *testing.T) {
 		createCertificateRequestRequest := tu.CreateCertificateRequestParams{CSR: generateRandomString(20)}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/canonical/notary/internal/encryption_backend"
 	"github.com/canonical/notary/internal/server"
-	"github.com/canonical/notary/internal/testutils"
 	tu "github.com/canonical/notary/internal/testutils"
 	"go.uber.org/zap"
 )
@@ -47,7 +46,7 @@ func TestInvalidKeyFailure(t *testing.T) {
 func TestRequestOverload(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
 	client := ts.Client()
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", tu.RoleAdmin, "")
 
 	t.Run("throw a valid size string", func(t *testing.T) {
 		createCertificateRequestRequest := tu.CreateCertificateRequestParams{CSR: generateRandomString(20)}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/canonical/notary/internal/encryption_backend"
 	"github.com/canonical/notary/internal/server"
+	"github.com/canonical/notary/internal/testutils"
 	tu "github.com/canonical/notary/internal/testutils"
 	"go.uber.org/zap"
 )
@@ -46,7 +47,7 @@ func TestInvalidKeyFailure(t *testing.T) {
 func TestRequestOverload(t *testing.T) {
 	ts := tu.MustPrepareServer(t)
 	client := ts.Client()
-	adminToken := tu.MustPrepareAccount(t, ts, "admin", 0, "")
+	adminToken := tu.MustPrepareAccount(t, ts, "admin", testutils.RoleAdmin, "")
 
 	t.Run("throw a valid size string", func(t *testing.T) {
 		createCertificateRequestRequest := tu.CreateCertificateRequestParams{CSR: generateRandomString(20)}

--- a/internal/testutils/server_test_utils.go
+++ b/internal/testutils/server_test_utils.go
@@ -46,12 +46,12 @@ func MustPrepareServer(t *testing.T) *httptest.Server {
 func MustPrepareAccount(t *testing.T, ts *httptest.Server, username string, roleID RoleID, token string) string {
 	t.Helper()
 
-	adminAccountParams := &CreateAccountParams{
+	accountParams := &CreateAccountParams{
 		Username: username,
 		Password: "Admin123",
 		RoleID:   roleID,
 	}
-	statusCode, _, err := CreateAccount(ts.URL, ts.Client(), token, adminAccountParams)
+	statusCode, _, err := CreateAccount(ts.URL, ts.Client(), token, accountParams)
 	if err != nil {
 		t.Fatalf("couldn't create admin account: %s", err)
 	}
@@ -59,8 +59,8 @@ func MustPrepareAccount(t *testing.T, ts *httptest.Server, username string, role
 		t.Fatalf("expected status %d, got %d", http.StatusCreated, statusCode)
 	}
 	adminLoginParams := &LoginParams{
-		Username: adminAccountParams.Username,
-		Password: adminAccountParams.Password,
+		Username: accountParams.Username,
+		Password: accountParams.Password,
 	}
 	statusCode, loginResponse, err := Login(ts.URL, ts.Client(), adminLoginParams)
 	if err != nil {

--- a/internal/testutils/server_test_utils.go
+++ b/internal/testutils/server_test_utils.go
@@ -43,7 +43,7 @@ func MustPrepareServer(t *testing.T) *httptest.Server {
 	return testServer
 }
 
-func MustPrepareAccount(t *testing.T, ts *httptest.Server, username string, roleID int, token string) string {
+func MustPrepareAccount(t *testing.T, ts *httptest.Server, username string, roleID RoleID, token string) string {
 	t.Helper()
 
 	adminAccountParams := &CreateAccountParams{
@@ -87,10 +87,19 @@ type GetAccountResponse struct {
 	Error  string                   `json:"error,omitempty"`
 }
 
+type RoleID int
+
+const (
+	RoleAdmin                RoleID = 0
+	RoleCertificateManager   RoleID = 1
+	RoleCertificateRequestor RoleID = 2
+	RoleReadOnly             RoleID = 3
+)
+
 type CreateAccountParams struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
-	RoleID   int    `json:"role_id"`
+	RoleID   RoleID `json:"role_id"`
 }
 
 type CreateAccountResponseResult struct {

--- a/internal/testutils/server_test_utils.go
+++ b/internal/testutils/server_test_utils.go
@@ -43,15 +43,15 @@ func MustPrepareServer(t *testing.T) *httptest.Server {
 	return testServer
 }
 
-func MustPrepareAdminAccount(t *testing.T, ts *httptest.Server) string {
+func MustPrepareAccount(t *testing.T, ts *httptest.Server, username string, roleID int, token string) string {
 	t.Helper()
 
 	adminAccountParams := &CreateAccountParams{
-		Username: "testadmin",
+		Username: username,
 		Password: "Admin123",
-		RoleID:   0,
+		RoleID:   roleID,
 	}
-	statusCode, _, err := CreateAccount(ts.URL, ts.Client(), "", adminAccountParams)
+	statusCode, _, err := CreateAccount(ts.URL, ts.Client(), token, adminAccountParams)
 	if err != nil {
 		t.Fatalf("couldn't create admin account: %s", err)
 	}
@@ -65,35 +65,6 @@ func MustPrepareAdminAccount(t *testing.T, ts *httptest.Server) string {
 	statusCode, loginResponse, err := Login(ts.URL, ts.Client(), adminLoginParams)
 	if err != nil {
 		t.Fatalf("couldn't login admin account: %s", err)
-	}
-	if statusCode != http.StatusOK {
-		t.Fatalf("expected status %d, got %d", http.StatusOK, statusCode)
-	}
-	return loginResponse.Result.Token
-}
-
-func MustPrepareNonAdminAccount(t *testing.T, ts *httptest.Server, adminToken string) string {
-	t.Helper()
-
-	nonAdminAccount := &CreateAccountParams{
-		Username: "testuser",
-		Password: "userPass!",
-		RoleID:   1,
-	}
-	statusCode, _, err := CreateAccount(ts.URL, ts.Client(), adminToken, nonAdminAccount)
-	if err != nil {
-		t.Fatalf("couldn't create non-admin account: %s", err)
-	}
-	if statusCode != http.StatusCreated {
-		t.Fatalf("expected status %d, got %d", http.StatusCreated, statusCode)
-	}
-	nonAdminLoginParams := &LoginParams{
-		Username: nonAdminAccount.Username,
-		Password: nonAdminAccount.Password,
-	}
-	statusCode, loginResponse, err := Login(ts.URL, ts.Client(), nonAdminLoginParams)
-	if err != nil {
-		t.Fatalf("couldn't login non-admin account: %s", err)
 	}
 	if statusCode != http.StatusOK {
 		t.Fatalf("expected status %d, got %d", http.StatusOK, statusCode)

--- a/internal/testutils/server_test_utils.go
+++ b/internal/testutils/server_test_utils.go
@@ -133,12 +133,12 @@ type DeleteAccountResponse struct {
 	Error  string                      `json:"error,omitempty"`
 }
 
-func GetAccount(url string, client *http.Client, adminToken string, id int) (int, *GetAccountResponse, error) {
+func GetAccount(url string, client *http.Client, token string, id int) (int, *GetAccountResponse, error) {
 	req, err := http.NewRequest("GET", url+"/api/v1/accounts/"+strconv.Itoa(id), nil)
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	res, err := client.Do(req)
 	if err != nil {
 		return 0, nil, err
@@ -151,12 +151,12 @@ func GetAccount(url string, client *http.Client, adminToken string, id int) (int
 	return res.StatusCode, &accountResponse, nil
 }
 
-func GetMyAccount(url string, client *http.Client, adminToken string) (int, *GetAccountResponse, error) {
+func GetMyAccount(url string, client *http.Client, token string) (int, *GetAccountResponse, error) {
 	req, err := http.NewRequest("GET", url+"/api/v1/accounts/me", nil)
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	res, err := client.Do(req)
 	if err != nil {
 		return 0, nil, err
@@ -169,7 +169,7 @@ func GetMyAccount(url string, client *http.Client, adminToken string) (int, *Get
 	return res.StatusCode, &accountResponse, nil
 }
 
-func CreateAccount(url string, client *http.Client, adminToken string, data *CreateAccountParams) (int, *CreateAccountResponse, error) {
+func CreateAccount(url string, client *http.Client, token string, data *CreateAccountParams) (int, *CreateAccountResponse, error) {
 	body, err := json.Marshal(data)
 	if err != nil {
 		return 0, nil, err
@@ -178,7 +178,7 @@ func CreateAccount(url string, client *http.Client, adminToken string, data *Cre
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	res, err := client.Do(req)
 	if err != nil {
 		return 0, nil, err
@@ -191,7 +191,7 @@ func CreateAccount(url string, client *http.Client, adminToken string, data *Cre
 	return res.StatusCode, &createResponse, nil
 }
 
-func ChangeAccountPassword(url string, client *http.Client, adminToken string, id int, data *ChangeAccountPasswordParams) (int, *ChangeAccountPasswordResponse, error) {
+func ChangeAccountPassword(url string, client *http.Client, token string, id int, data *ChangeAccountPasswordParams) (int, *ChangeAccountPasswordResponse, error) {
 	body, err := json.Marshal(data)
 	if err != nil {
 		return 0, nil, err
@@ -200,7 +200,7 @@ func ChangeAccountPassword(url string, client *http.Client, adminToken string, i
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	res, err := client.Do(req)
 	if err != nil {
 		return 0, nil, err
@@ -213,12 +213,12 @@ func ChangeAccountPassword(url string, client *http.Client, adminToken string, i
 	return res.StatusCode, &changeResponse, nil
 }
 
-func DeleteAccount(url string, client *http.Client, adminToken string, id int) (int, *DeleteAccountResponse, error) {
+func DeleteAccount(url string, client *http.Client, token string, id int) (int, *DeleteAccountResponse, error) {
 	req, err := http.NewRequest("DELETE", url+"/api/v1/accounts/"+strconv.Itoa(id), nil)
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	res, err := client.Do(req)
 	if err != nil {
 		return 0, nil, err
@@ -241,12 +241,12 @@ type GetStatusResponse struct {
 	Result GetStatusResponseResult `json:"result"`
 }
 
-func GetStatus(url string, client *http.Client, adminToken string) (int, *GetStatusResponse, error) {
+func GetStatus(url string, client *http.Client, token string) (int, *GetStatusResponse, error) {
 	req, err := http.NewRequest("GET", url+"/status", nil)
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	res, err := client.Do(req)
 	if err != nil {
 		return 0, nil, err
@@ -331,12 +331,12 @@ type CreateCertificateResponse struct {
 	Error string `json:"error,omitempty"`
 }
 
-func ListCertificateRequests(url string, client *http.Client, adminToken string) (int, *ListCertificateRequestsResponse, error) {
+func ListCertificateRequests(url string, client *http.Client, token string) (int, *ListCertificateRequestsResponse, error) {
 	req, err := http.NewRequest("GET", url+"/api/v1/certificate_requests", nil)
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	res, err := client.Do(req)
 	if err != nil {
 		return 0, nil, err
@@ -348,12 +348,12 @@ func ListCertificateRequests(url string, client *http.Client, adminToken string)
 	return res.StatusCode, &certificateRequestsResponse, nil
 }
 
-func GetCertificateRequest(url string, client *http.Client, adminToken string, id int) (int, *GetCertificateRequestResponse, error) {
+func GetCertificateRequest(url string, client *http.Client, token string, id int) (int, *GetCertificateRequestResponse, error) {
 	req, err := http.NewRequest("GET", url+"/api/v1/certificate_requests/"+strconv.Itoa(id), nil)
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	res, err := client.Do(req)
 	if err != nil {
 		return 0, nil, err
@@ -365,7 +365,7 @@ func GetCertificateRequest(url string, client *http.Client, adminToken string, i
 	return res.StatusCode, &getCertificateRequestResponse, nil
 }
 
-func CreateCertificateRequest(url string, client *http.Client, adminToken string, certRequest CreateCertificateRequestParams) (int, *CreateCertificateRequestResponse, error) {
+func CreateCertificateRequest(url string, client *http.Client, token string, certRequest CreateCertificateRequestParams) (int, *CreateCertificateRequestResponse, error) {
 	reqData, err := json.Marshal(certRequest)
 	if err != nil {
 		return 0, nil, err
@@ -374,7 +374,7 @@ func CreateCertificateRequest(url string, client *http.Client, adminToken string
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 	res, err := client.Do(req)
 	if err != nil {
@@ -387,12 +387,12 @@ func CreateCertificateRequest(url string, client *http.Client, adminToken string
 	return res.StatusCode, &createCertificateRequestResponse, nil
 }
 
-func DeleteCertificateRequest(url string, client *http.Client, adminToken string, id int) (int, error) {
+func DeleteCertificateRequest(url string, client *http.Client, token string, id int) (int, error) {
 	req, err := http.NewRequest("DELETE", url+"/api/v1/certificate_requests/"+strconv.Itoa(id), nil)
 	if err != nil {
 		return 0, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	res, err := client.Do(req)
 	if err != nil {
 		return 0, err
@@ -400,7 +400,7 @@ func DeleteCertificateRequest(url string, client *http.Client, adminToken string
 	return res.StatusCode, nil
 }
 
-func CreateCertificate(url string, client *http.Client, adminToken string, cert CreateCertificateParams) (int, *CreateCertificateResponse, error) {
+func CreateCertificate(url string, client *http.Client, token string, cert CreateCertificateParams) (int, *CreateCertificateResponse, error) {
 	reqData, err := json.Marshal(cert)
 	if err != nil {
 		return 0, nil, err
@@ -409,7 +409,7 @@ func CreateCertificate(url string, client *http.Client, adminToken string, cert 
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 	res, err := client.Do(req)
 	if err != nil {
@@ -422,12 +422,12 @@ func CreateCertificate(url string, client *http.Client, adminToken string, cert 
 	return res.StatusCode, &createCertificateResponse, nil
 }
 
-func RejectCertificate(url string, client *http.Client, adminToken string, id int) (int, error) {
+func RejectCertificate(url string, client *http.Client, token string, id int) (int, error) {
 	req, err := http.NewRequest("POST", url+"/api/v1/certificate_requests/"+strconv.Itoa(id)+"/reject", nil)
 	if err != nil {
 		return 0, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	res, err := client.Do(req)
 	if err != nil {
 		return 0, err
@@ -453,7 +453,7 @@ type CreateCertificateAuthorityResponse struct {
 	Error  string          `json:"error,omitempty"`
 }
 
-func CreateCertificateAuthority(url string, client *http.Client, adminToken string, ca CreateCertificateAuthorityParams) (int, *CreateCertificateAuthorityResponse, error) {
+func CreateCertificateAuthority(url string, client *http.Client, token string, ca CreateCertificateAuthorityParams) (int, *CreateCertificateAuthorityResponse, error) {
 	reqData, err := json.Marshal(ca)
 	if err != nil {
 		return 0, nil, err
@@ -462,7 +462,7 @@ func CreateCertificateAuthority(url string, client *http.Client, adminToken stri
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 	res, err := client.Do(req)
 	if err != nil {
@@ -480,12 +480,12 @@ type ListCertificateAuthoritiesResponse struct {
 	Error  string                        `json:"error,omitempty"`
 }
 
-func ListCertificateAuthorities(url string, client *http.Client, adminToken string) (int, *ListCertificateAuthoritiesResponse, error) {
+func ListCertificateAuthorities(url string, client *http.Client, token string) (int, *ListCertificateAuthoritiesResponse, error) {
 	req, err := http.NewRequest("GET", url+"/api/v1/certificate_authorities", nil)
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	res, err := client.Do(req)
 	if err != nil {
 		return 0, nil, err
@@ -502,12 +502,12 @@ type GetCertificateAuthorityResponse struct {
 	Error  string                      `json:"error,omitempty"`
 }
 
-func GetCertificateAuthority(url string, client *http.Client, adminToken string, id int) (int, *GetCertificateAuthorityResponse, error) {
+func GetCertificateAuthority(url string, client *http.Client, token string, id int) (int, *GetCertificateAuthorityResponse, error) {
 	req, err := http.NewRequest("GET", url+"/api/v1/certificate_authorities/"+strconv.Itoa(id), nil)
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	res, err := client.Do(req)
 	if err != nil {
 		return 0, nil, err
@@ -528,7 +528,7 @@ type UpdateCertificateAuthorityResponse struct {
 	Error  string          `json:"error,omitempty"`
 }
 
-func UpdateCertificateAuthority(url string, client *http.Client, adminToken string, id int, status UpdateCertificateAuthorityParams) (int, *UpdateCertificateAuthorityResponse, error) {
+func UpdateCertificateAuthority(url string, client *http.Client, token string, id int, status UpdateCertificateAuthorityParams) (int, *UpdateCertificateAuthorityResponse, error) {
 	reqData, err := json.Marshal(status)
 	if err != nil {
 		return 0, nil, err
@@ -537,7 +537,7 @@ func UpdateCertificateAuthority(url string, client *http.Client, adminToken stri
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 	res, err := client.Do(req)
 	if err != nil {
@@ -550,12 +550,12 @@ func UpdateCertificateAuthority(url string, client *http.Client, adminToken stri
 	return res.StatusCode, &updateCertificateAuthorityResponse, nil
 }
 
-func DeleteCertificateAuthority(url string, client *http.Client, adminToken string, id int) (int, error) {
+func DeleteCertificateAuthority(url string, client *http.Client, token string, id int) (int, error) {
 	req, err := http.NewRequest("DELETE", url+"/api/v1/certificate_authorities/"+strconv.Itoa(id), nil)
 	if err != nil {
 		return 0, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	res, err := client.Do(req)
 	if err != nil {
 		return 0, err
@@ -568,7 +568,7 @@ type UploadCertificateToCertificateAuthorityResponse struct {
 	Error  string          `json:"error,omitempty"`
 }
 
-func UploadCertificateToCertificateAuthority(url string, client *http.Client, adminToken string, id int, cert server.UploadCertificateToCertificateAuthorityParams) (int, *UploadCertificateToCertificateAuthorityResponse, error) {
+func UploadCertificateToCertificateAuthority(url string, client *http.Client, token string, id int, cert server.UploadCertificateToCertificateAuthorityParams) (int, *UploadCertificateToCertificateAuthorityResponse, error) {
 	reqData, err := json.Marshal(cert)
 	if err != nil {
 		return 0, nil, err
@@ -577,7 +577,7 @@ func UploadCertificateToCertificateAuthority(url string, client *http.Client, ad
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 	res, err := client.Do(req)
 	if err != nil {
@@ -595,7 +595,7 @@ type SignCertificateRequestResponse struct {
 	Error  string          `json:"error,omitempty"`
 }
 
-func SignCertificateRequest(url string, client *http.Client, adminToken string, id int, cert server.SignCertificateRequestParams) (int, *SignCertificateRequestResponse, error) {
+func SignCertificateRequest(url string, client *http.Client, token string, id int, cert server.SignCertificateRequestParams) (int, *SignCertificateRequestResponse, error) {
 	reqData, err := json.Marshal(cert)
 	if err != nil {
 		return 0, nil, err
@@ -604,7 +604,7 @@ func SignCertificateRequest(url string, client *http.Client, adminToken string, 
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 	res, err := client.Do(req)
 	if err != nil {
@@ -622,7 +622,7 @@ type SignCertificateAuthorityResponse struct {
 	Error  string          `json:"error,omitempty"`
 }
 
-func SignCertificateAuthority(url string, client *http.Client, adminToken string, id int, cert server.SignCertificateAuthorityParams) (int, *SignCertificateAuthorityResponse, error) {
+func SignCertificateAuthority(url string, client *http.Client, token string, id int, cert server.SignCertificateAuthorityParams) (int, *SignCertificateAuthorityResponse, error) {
 	reqData, err := json.Marshal(cert)
 	if err != nil {
 		return 0, nil, err
@@ -631,7 +631,7 @@ func SignCertificateAuthority(url string, client *http.Client, adminToken string
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 	res, err := client.Do(req)
 	if err != nil {
@@ -649,12 +649,12 @@ type RevokeCertificateAuthorityCertificateResponse struct {
 	Error  string          `json:"error,omitempty"`
 }
 
-func RevokeCertificateAuthority(url string, client *http.Client, adminToken string, id int) (int, *RevokeCertificateAuthorityCertificateResponse, error) {
+func RevokeCertificateAuthority(url string, client *http.Client, token string, id int) (int, *RevokeCertificateAuthorityCertificateResponse, error) {
 	req, err := http.NewRequest("POST", url+"/api/v1/certificate_authorities/"+strconv.Itoa(id)+"/revoke", nil)
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	res, err := client.Do(req)
 	if err != nil {
 		return 0, nil, err
@@ -671,12 +671,12 @@ type RevokeCertificateRequestResponse struct {
 	Error  string          `json:"error,omitempty"`
 }
 
-func RevokeCertificateRequest(url string, client *http.Client, adminToken string, id int) (int, *RevokeCertificateRequestResponse, error) {
+func RevokeCertificateRequest(url string, client *http.Client, token string, id int) (int, *RevokeCertificateRequestResponse, error) {
 	req, err := http.NewRequest("POST", url+"/api/v1/certificate_requests/"+strconv.Itoa(id)+"/certificate/revoke", nil)
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	res, err := client.Do(req)
 	if err != nil {
 		return 0, nil, err
@@ -693,12 +693,12 @@ type GetCRLResponse struct {
 	Error  string     `json:"error,omitempty"`
 }
 
-func GetCertificateAuthorityCRLRequest(url string, client *http.Client, adminToken string, id int) (int, *GetCRLResponse, error) {
+func GetCertificateAuthorityCRLRequest(url string, client *http.Client, token string, id int) (int, *GetCRLResponse, error) {
 	req, err := http.NewRequest("GET", url+"/api/v1/certificate_authorities/"+strconv.Itoa(id)+"/crl", nil)
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	res, err := client.Do(req)
 	if err != nil {
 		return 0, nil, err
@@ -744,7 +744,7 @@ func SignCSR(csr string) string {
 	return certPEM.String()
 }
 
-func CreateRequestBombWithCustomHeader(url string, client *http.Client, adminToken string, certRequest CreateCertificateRequestParams, contentLengthHeaderData string) (int, error) {
+func CreateRequestBombWithCustomHeader(url string, client *http.Client, token string, certRequest CreateCertificateRequestParams, contentLengthHeaderData string) (int, error) {
 	reqData, err := json.Marshal(certRequest)
 	if err != nil {
 		return 0, err
@@ -753,7 +753,7 @@ func CreateRequestBombWithCustomHeader(url string, client *http.Client, adminTok
 	if err != nil {
 		return 0, err
 	}
-	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Content-Length", contentLengthHeaderData)
 	res, err := client.Do(req)

--- a/ui/src/app/(notary)/certificate_authorities/table.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/table.tsx
@@ -43,7 +43,7 @@ export function CertificateAuthoritiesTable({
   >(null);
 
   const canManageCAs = [RoleID.Admin, RoleID.CertificateManager].includes(
-    auth.user?.role_id as RoleID
+    auth.user?.role_id as RoleID,
   );
 
   const handleCopy = (csr: string, id: number) => {
@@ -386,7 +386,8 @@ export function CertificateAuthoritiesTable({
       title="Certificate Authorities"
       className="u-fixed-width"
       controls={
-        rows.length > 0 && canManageCAs && (
+        rows.length > 0 &&
+        canManageCAs && (
           <Button appearance="positive" onClick={() => setAsideOpen(true)}>
             Add New CA
           </Button>
@@ -447,7 +448,7 @@ function CAEmptyState({
 }) {
   const auth = useAuth();
   const canManageCAs = [RoleID.Admin, RoleID.CertificateManager].includes(
-    auth.user?.role_id as RoleID
+    auth.user?.role_id as RoleID,
   );
 
   return (

--- a/ui/src/app/(notary)/certificate_authorities/table.tsx
+++ b/ui/src/app/(notary)/certificate_authorities/table.tsx
@@ -15,6 +15,7 @@ import {
   NotaryConfirmationModalData,
   NotaryConfirmationModal,
 } from "@/components/NotaryConfirmationModal";
+import { RoleID } from "@/types";
 
 type TableProps = {
   cas: CertificateAuthorityEntry[];
@@ -40,6 +41,10 @@ export function CertificateAuthoritiesTable({
   const [successNotificationId, setSuccessNotificationId] = useState<
     number | null
   >(null);
+
+  const canManageCAs = [RoleID.Admin, RoleID.CertificateManager].includes(
+    auth.user?.role_id as RoleID
+  );
 
   const handleCopy = (csr: string, id: number) => {
     void navigator.clipboard.writeText(csr).then(() => {
@@ -233,7 +238,7 @@ export function CertificateAuthoritiesTable({
                       ? "Hide Certificate Content"
                       : "Show Certificate Content"}
                   </Button>
-                  {!isSelfSigned && (
+                  {canManageCAs && !isSelfSigned && (
                     <Button
                       className="p-contextual-menu__link"
                       disabled={auth.activeCA == null}
@@ -242,7 +247,7 @@ export function CertificateAuthoritiesTable({
                       {caEntry.enabled === true ? "Re-sign CSR" : "Sign CSR"}
                     </Button>
                   )}
-                  {isSelfSigned && (
+                  {canManageCAs && isSelfSigned && (
                     <Button
                       className="p-contextual-menu__link"
                       onClick={() => handleSign(caEntry.id, caEntry.id)}
@@ -250,7 +255,7 @@ export function CertificateAuthoritiesTable({
                       Renew Certificate
                     </Button>
                   )}
-                  {!isSelfSigned && (
+                  {canManageCAs && !isSelfSigned && (
                     <Button
                       className="p-contextual-menu__link"
                       onClick={() => {
@@ -261,7 +266,8 @@ export function CertificateAuthoritiesTable({
                       Upload New Certificate
                     </Button>
                   )}
-                  {!isSelfSigned && (
+
+                  {canManageCAs && !isSelfSigned && (
                     <Button
                       className="p-contextual-menu__link"
                       disabled={caEntry.enabled == false}
@@ -286,7 +292,7 @@ export function CertificateAuthoritiesTable({
                       Set as default for signing CSRs
                     </Button>
                   )}
-                  {caEntry.enabled === true && (
+                  {canManageCAs && caEntry.enabled === true && (
                     <Button
                       className="p-contextual-menu__link"
                       onClick={() => handleDisableCA(caEntry.id)}
@@ -294,12 +300,14 @@ export function CertificateAuthoritiesTable({
                       Disable CA
                     </Button>
                   )}
-                  <Button
-                    className="p-contextual-menu__link"
-                    onClick={() => handleDelete(caEntry.id)}
-                  >
-                    Delete Certificate Authority
-                  </Button>
+                  {canManageCAs && (
+                    <Button
+                      className="p-contextual-menu__link"
+                      onClick={() => handleDelete(caEntry.id)}
+                    >
+                      Delete Certificate Authority
+                    </Button>
+                  )}
                 </span>
               </ContextualMenu>
             </>
@@ -378,7 +386,7 @@ export function CertificateAuthoritiesTable({
       title="Certificate Authorities"
       className="u-fixed-width"
       controls={
-        rows.length > 0 && (
+        rows.length > 0 && canManageCAs && (
           <Button appearance="positive" onClick={() => setAsideOpen(true)}>
             Add New CA
           </Button>
@@ -437,19 +445,26 @@ function CAEmptyState({
 }: {
   setAsideOpen: Dispatch<SetStateAction<boolean>>;
 }) {
+  const auth = useAuth();
+  const canManageCAs = [RoleID.Admin, RoleID.CertificateManager].includes(
+    auth.user?.role_id as RoleID
+  );
+
   return (
     <EmptyState image={""} title="No Certificate Authorities available yet.">
       <p>
         There are no Certificate Authorities in Notary. Create your first one to
         start signing certificates!
       </p>
-      <Button
-        appearance="positive"
-        aria-label="add-ca-button"
-        onClick={() => setAsideOpen(true)}
-      >
-        Add New Certificate Authority
-      </Button>
+      {canManageCAs && (
+        <Button
+          appearance="positive"
+          aria-label="add-ca-button"
+          onClick={() => setAsideOpen(true)}
+        >
+          Add New Certificate Authority
+        </Button>
+      )}
     </EmptyState>
   );
 }

--- a/ui/src/app/(notary)/certificate_requests/table.tsx
+++ b/ui/src/app/(notary)/certificate_requests/table.tsx
@@ -15,6 +15,7 @@ import {
   NotaryConfirmationModalData,
 } from "@/components/NotaryConfirmationModal";
 import { useAuth } from "@/hooks/useAuth";
+import { RoleID } from "@/types";
 
 type TableProps = {
   csrs: CSREntry[];
@@ -37,6 +38,15 @@ export function CertificateRequestsTable({
   const [successNotificationId, setSuccessNotificationId] = useState<
     number | null
   >(null);
+
+  const canManageCSRs = [RoleID.Admin, RoleID.CertificateManager, RoleID.CertificateRequestor].includes(
+    auth.user?.role_id as RoleID
+  );
+
+
+  const canManageCertificates = [RoleID.Admin, RoleID.CertificateManager].includes(
+    auth.user?.role_id as RoleID
+  );
 
   const handleCopy = (csr: string, id: number) => {
     void navigator.clipboard.writeText(csr).then(() => {
@@ -210,6 +220,23 @@ export function CertificateRequestsTable({
                     Download CSR
                   </Button>
                 </span>
+                {canManageCertificates && (
+                  <span className="p-contextual-menu__group">
+                    <Button
+                      className="p-contextual-menu__link"
+                      disabled={csr_status == "Rejected"}
+                      onClick={() => handleReject(id)}
+                    >
+                      Reject Certificate Request
+                    </Button>
+                    <Button
+                      className="p-contextual-menu__link"
+                      onClick={() => handleDelete(id)}
+                    >
+                      Delete Certificate Request
+                    </Button>
+                  </span>
+                )}
                 <span className="p-contextual-menu__group">
                   <Button
                     className="p-contextual-menu__link"
@@ -220,45 +247,38 @@ export function CertificateRequestsTable({
                       ? "Hide Certificate Content"
                       : "Show Certificate Content"}
                   </Button>
-                  <Button
-                    className="p-contextual-menu__link"
-                    disabled={!auth.activeCA}
-                    onClick={() => handleSign(id)}
-                  >
-                    Sign CSR
-                  </Button>
-                  <Button
-                    className="p-contextual-menu__link"
-                    onClick={() => {
-                      setCertificateFormOpen(true);
-                      setSelectedCSR(csrEntry);
-                    }}
-                  >
-                    Upload New Certificate
-                  </Button>
-                  <Button
-                    className="p-contextual-menu__link"
-                    disabled={csr_status != "Active"}
-                    onClick={() => handleRevoke(id)}
-                  >
-                    Revoke Certificate
-                  </Button>
+                  {canManageCertificates && (
+                    <>
+                      <Button
+                        className="p-contextual-menu__link"
+                        disabled={!auth.activeCA}
+                        onClick={() => handleSign(id)}
+                      >
+                        Sign CSR
+                      </Button>
+                      <Button
+                        className="p-contextual-menu__link"
+                        disabled={csr_status != "Active"}
+                        onClick={() => handleRevoke(id)}
+                      >
+                        Revoke Certificate
+                      </Button>
+                    </>
+                  )}
+                  {canManageCertificates && (
+                    <Button
+                      className="p-contextual-menu__link"
+                      onClick={() => {
+                        setCertificateFormOpen(true);
+                        setSelectedCSR(csrEntry);
+                      }}
+                    >
+                      Upload New Certificate
+                    </Button>
+
+                  )}
                 </span>
-                <span className="p-contextual-menu__group">
-                  <Button
-                    className="p-contextual-menu__link"
-                    disabled={csr_status == "Rejected"}
-                    onClick={() => handleReject(id)}
-                  >
-                    Reject Certificate Request
-                  </Button>
-                  <Button
-                    className="p-contextual-menu__link"
-                    onClick={() => handleDelete(id)}
-                  >
-                    Delete Certificate Request
-                  </Button>
-                </span>
+
               </ContextualMenu>
             </>
           ),
@@ -336,7 +356,7 @@ export function CertificateRequestsTable({
       title="Certificate Requests"
       className="u-fixed-width"
       controls={
-        rows.length > 0 && (
+        rows.length > 0 && canManageCSRs && (
           <Button appearance="positive" onClick={() => setAsideOpen(true)}>
             Add New Certificate Request
           </Button>
@@ -395,19 +415,27 @@ function CSREmptyState({
 }: {
   setAsideOpen: Dispatch<SetStateAction<boolean>>;
 }) {
+  const auth = useAuth();
+
+  const canManageCSRs = [RoleID.Admin, RoleID.CertificateManager, RoleID.CertificateRequestor].includes(
+    auth.user?.role_id as RoleID
+  );
+
   return (
     <EmptyState image={""} title="No CSRs available yet.">
       <p>
         There are no Certificate Requests in Notary. Request your first
         certificate!
       </p>
-      <Button
-        appearance="positive"
-        aria-label="add-csr-button"
-        onClick={() => setAsideOpen(true)}
-      >
-        Add New CSR
-      </Button>
+      {canManageCSRs && (
+        <Button
+          appearance="positive"
+          aria-label="add-csr-button"
+          onClick={() => setAsideOpen(true)}
+        >
+          Add New CSR
+        </Button>
+      )}
     </EmptyState>
   );
 }

--- a/ui/src/app/(notary)/certificate_requests/table.tsx
+++ b/ui/src/app/(notary)/certificate_requests/table.tsx
@@ -39,14 +39,16 @@ export function CertificateRequestsTable({
     number | null
   >(null);
 
-  const canManageCSRs = [RoleID.Admin, RoleID.CertificateManager, RoleID.CertificateRequestor].includes(
-    auth.user?.role_id as RoleID
-  );
+  const canManageCSRs = [
+    RoleID.Admin,
+    RoleID.CertificateManager,
+    RoleID.CertificateRequestor,
+  ].includes(auth.user?.role_id as RoleID);
 
-
-  const canManageCertificates = [RoleID.Admin, RoleID.CertificateManager].includes(
-    auth.user?.role_id as RoleID
-  );
+  const canManageCertificates = [
+    RoleID.Admin,
+    RoleID.CertificateManager,
+  ].includes(auth.user?.role_id as RoleID);
 
   const handleCopy = (csr: string, id: number) => {
     void navigator.clipboard.writeText(csr).then(() => {
@@ -275,10 +277,8 @@ export function CertificateRequestsTable({
                     >
                       Upload New Certificate
                     </Button>
-
                   )}
                 </span>
-
               </ContextualMenu>
             </>
           ),
@@ -356,7 +356,8 @@ export function CertificateRequestsTable({
       title="Certificate Requests"
       className="u-fixed-width"
       controls={
-        rows.length > 0 && canManageCSRs && (
+        rows.length > 0 &&
+        canManageCSRs && (
           <Button appearance="positive" onClick={() => setAsideOpen(true)}>
             Add New Certificate Request
           </Button>
@@ -417,9 +418,11 @@ function CSREmptyState({
 }) {
   const auth = useAuth();
 
-  const canManageCSRs = [RoleID.Admin, RoleID.CertificateManager, RoleID.CertificateRequestor].includes(
-    auth.user?.role_id as RoleID
-  );
+  const canManageCSRs = [
+    RoleID.Admin,
+    RoleID.CertificateManager,
+    RoleID.CertificateRequestor,
+  ].includes(auth.user?.role_id as RoleID);
 
   return (
     <EmptyState image={""} title="No CSRs available yet.">

--- a/ui/src/app/(notary)/users/asideForm.tsx
+++ b/ui/src/app/(notary)/users/asideForm.tsx
@@ -104,6 +104,14 @@ function AddNewUserForm(asideProps: AsideProps) {
               label: "Certificate Manager",
               value: RoleID.CertificateManager,
             },
+            {
+              label: "Certificate Requestor",
+              value: RoleID.CertificateRequestor,
+            },
+            {
+              label: "Read Only",
+              value: RoleID.ReadOnly,
+            },
           ]}
         />
         <PasswordToggle

--- a/ui/src/app/(notary)/users/table.tsx
+++ b/ui/src/app/(notary)/users/table.tsx
@@ -22,6 +22,13 @@ type TableProps = {
   setFormData: Dispatch<SetStateAction<AsideFormData>>;
 };
 
+const roleLabels: Record<RoleID, string> = {
+  [RoleID.Admin]: "Admin",
+  [RoleID.CertificateManager]: "Certificate Manager",
+  [RoleID.CertificateRequestor]: "Certificate Requestor",
+  [RoleID.ReadOnly]: "Read Only",
+};
+
 export function UsersTable({ users, setAsideOpen, setFormData }: TableProps) {
   const auth = useAuth();
   const [confirmationModalData, setConfirmationModalData] =
@@ -91,10 +98,7 @@ export function UsersTable({ users, setAsideOpen, setFormData }: TableProps) {
                 content: user.username,
               },
               {
-                content:
-                  user.role_id === RoleID.Admin
-                    ? "Admin"
-                    : "Certificate Manager",
+                content: roleLabels[user.role_id],
               },
               {
                 content: (

--- a/ui/src/components/NotaryAppNavigationBars.tsx
+++ b/ui/src/components/NotaryAppNavigationBars.tsx
@@ -76,27 +76,24 @@ export function SideBar({
                       </span>
                     </a>
                   </li>
-                  {auth.user?.role_id == RoleID.Admin && (
-                    <li className="p-side-navigation__item">
-                      <a
-                        className="p-side-navigation__link"
-                        href="/certificate_authorities"
-                        aria-current={
-                          path.startsWith("/certificate_authorities")
-                            ? "page"
-                            : "false"
-                        }
-                        style={{ cursor: "pointer" }}
-                      >
-                        <i className="p-icon--copy-to-clipboard is-light p-side-navigation__icon"></i>
-                        <span className="p-side-navigation__label">
+                  {auth.user?.role_id !== undefined &&
+                    [RoleID.Admin, RoleID.CertificateManager, RoleID.ReadOnly].includes(auth.user.role_id) && (
+                      <li className="p-side-navigation__item">
+                        <a
+                          className="p-side-navigation__link"
+                          href="/certificate_authorities"
+                          aria-current={
+                            path.startsWith("/certificate_authorities") ? "page" : "false"
+                          }
+                          style={{ cursor: "pointer" }}
+                        >
+                          <i className="p-icon--copy-to-clipboard is-light p-side-navigation__icon"></i>
                           <span className="p-side-navigation__label">
-                            Certificate Authorities
+                            <span className="p-side-navigation__label">Certificate Authorities</span>
                           </span>
-                        </span>
-                      </a>
-                    </li>
-                  )}
+                        </a>
+                      </li>
+                    )}
                   {auth.user?.role_id == RoleID.Admin && (
                     <li className="p-side-navigation__item">
                       <a

--- a/ui/src/components/NotaryAppNavigationBars.tsx
+++ b/ui/src/components/NotaryAppNavigationBars.tsx
@@ -77,19 +77,27 @@ export function SideBar({
                     </a>
                   </li>
                   {auth.user?.role_id !== undefined &&
-                    [RoleID.Admin, RoleID.CertificateManager, RoleID.ReadOnly].includes(auth.user.role_id) && (
+                    [
+                      RoleID.Admin,
+                      RoleID.CertificateManager,
+                      RoleID.ReadOnly,
+                    ].includes(auth.user.role_id) && (
                       <li className="p-side-navigation__item">
                         <a
                           className="p-side-navigation__link"
                           href="/certificate_authorities"
                           aria-current={
-                            path.startsWith("/certificate_authorities") ? "page" : "false"
+                            path.startsWith("/certificate_authorities")
+                              ? "page"
+                              : "false"
                           }
                           style={{ cursor: "pointer" }}
                         >
                           <i className="p-icon--copy-to-clipboard is-light p-side-navigation__icon"></i>
                           <span className="p-side-navigation__label">
-                            <span className="p-side-navigation__label">Certificate Authorities</span>
+                            <span className="p-side-navigation__label">
+                              Certificate Authorities
+                            </span>
                           </span>
                         </a>
                       </li>

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -30,6 +30,8 @@ export type CertificateAuthorityEntry = {
 export enum RoleID {
   Admin = 0,
   CertificateManager = 1,
+  CertificateRequestor = 2,
+  ReadOnly = 3,
 }
 
 export type User = {


### PR DESCRIPTION
# Description

In #257 and #261, we added the necessary structure to support roles and permissions in Notary, we added the ability to choose and view user roles. 

In this PR here, we add the remaining roles needed for Notary to be useful in an enterprise. We now support the following roles:

- **Admin**: Full access to all Notary features.
- **Certificate Manager**: Can manage Certificate Authorities, Certificate Requests, issue and revoke certificates.
- **Certificate Requestor (new)**: Can create Certificate Requests and view their own requests.
- **Read Only (new)**: Can read everything except accounts.

This task is an implementation of the [TE197 - Role-based access in Notary](https://docs.google.com/document/d/1j3Jq9K4W_Jpouw5wNGqoXUOcHafjBu9H6PTgUqQcsIQ/edit?tab=t.0) specification.

## API Changes

Add new roles when POST to `api/v1/accounts`

- `username` (string): The username of the account. 
- `password` (string): The password of the account.
- `role_id` (integer): The role ID of the account. Valid values are:
  - `0`: Admin
  - `1`: Certificate Manager
  - `2`: Certificate Requestor (new)
  - `3`: Read Only (new)

## UI Changes

We selectively display content based on the user role. For instance, an admin user will see the "Add Certificate Request" button, but not a readonly user.

### Screenshots

#### Certificate Requests

##### Admin users

<img width="1715" height="604" alt="image" src="https://github.com/user-attachments/assets/99f2a3d5-bccd-4e0d-8e77-1ad21253182d" />

##### ReadOnly users

<img width="1709" height="372" alt="image" src="https://github.com/user-attachments/assets/7581cb91-f013-49f2-b767-a4cdef103649" />

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
