### PR TITLE
docs: remove superfluous notary prefix in config api reference

### DIFF
--- a/docs/reference/api/config.md
+++ b/docs/reference/api/config.md
@@ -1,5 +1,4 @@
-# Notary's Config
-
+# Config
 
 This section describes the RESTful API for getting the current config of Notary.
 
@@ -9,9 +8,9 @@ This section describes the RESTful API for getting the current config of Notary.
 This path returns the current configuration of Notary excluding sensitive fields.
 
 
-| Method | Path     |
-| :----- | :------- |
-| `GET` | `/api/v1/config` |
+| Method | Path             |
+| :----- | :--------------- |
+| `GET`  | `/api/v1/config` |
 
 
 ### Sample Response


### PR DESCRIPTION
# Description

This is a bit of a nitpick, but we don't have nor need "Notary" as a prefix to all the API endpoints reference documents. Here we remove it from the config doc. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
